### PR TITLE
[Bug fix] Fixing the retrieval of the SoC version when registering allocated memory to NPU

### DIFF
--- a/csrc/mem_alloc.cpp
+++ b/csrc/mem_alloc.cpp
@@ -17,8 +17,10 @@ uintptr_t alloc_pinned_ptr(std::size_t size, unsigned int flags) {
         throw std::runtime_error("aclrtMallocHost failed: " + std::to_string(err));
     }
 
-    const char* socVersion = std::getenv("SOC_VERSION");
+    const char* socVersion = aclrtGetSocName();
 
+    // nullptr means that the chip version failed to be obtained. We cannot be sure about the
+    // version of the device. Unless we are sure that we deal with a 310 device, we try to register.
     if (socVersion == nullptr || std::string(socVersion).find("310") == std::string::npos) {
         // not 310p
         auto devPtr = register_ptr(ptr, size);


### PR DESCRIPTION
This PR fixes https://github.com/LMCache/LMCache-Ascend/issues/37. 
The problem was that the env var SOC_VERSION is not always set in the environment. The previous logic of the alloc_pinned_ptr  function is that, unless we are sure that we are dealing the 310p device, we try to register the memory. However, since the SOC_VERSION was not set, many times this resolved to trying to register the memory even on 310p devices. 

The logic of alloc_pinned_ptr  is left unchanged here, and a comment has been added to clarify this. However, now the code relies on ACL APIs to retrieve the SoC version, which is safer. Torch_npu does the same, for reference: https://github.com/Ascend/pytorch/blob/master/torch_npu/csrc/core/npu/NpuVariables.cpp

We could consider always adopting this function across the codebase instead of the env var. 