### PR TITLE
Pos kernels implentment and UT tests

### DIFF
--- a/csrc/pos_kernels.cpp
+++ b/csrc/pos_kernels.cpp
@@ -1,14 +1,188 @@
 #include "pos_kernels.h"
+#include <torch_npu/csrc/framework/OpCommand.h>
+#include <torch_npu/csrc/npu/Module.h>
+#include "tiling/platform/platform_ascendc.h"
+#include <torch_npu/csrc/core/npu/NPUStream.h>
 #include <pybind11/pybind11.h>
-#include <Python.h> 
-
+#include <Python.h>
 namespace py = pybind11;
 
-void rotary_embedding_k_fused(const torch::Tensor& old_positions,
-                              const torch::Tensor& new_positions,
-                              torch::Tensor& key, int64_t head_size,
-                              const torch::Tensor& cos_sin_cache, bool is_neox) {
-    // TODO:
-    PyErr_SetString(PyExc_NotImplementedError, "Please contact LMCache Ascend.");
-    throw py::error_already_set();
+namespace {
+
+constexpr uint32_t new_POSITION_INDEX = 0;
+constexpr uint32_t old_POSITION_INDEX = 1;
+constexpr uint32_t INPUT_KEY_IN_INDEX = 2;
+constexpr uint32_t INPUT_COSSINCACHE_INDEX = 3;
+
+constexpr uint32_t INPUT_KSTRIDE_INDEX = 0;
+constexpr uint32_t INPUT_IS_NEOXSTYLE_INDEX = 1;
+constexpr uint32_t INPUT_NUM_kHEADS_INDEX = 2;
+
+constexpr uint32_t INDEX_KEYOUT_OUTPUT = 0;
+
+static constexpr uint32_t TILING_BF16 = 20;
+static constexpr uint32_t TILING_FP16 = 21;
+static constexpr uint32_t TILING_FP32 = 22;
+static constexpr uint32_t  CORE_ALLOCATION_THRESHOLD = 4000;
+
+constexpr size_t DIM_0 = 0;
+constexpr size_t DIM_1 = 1;
+
+constexpr int64_t UB_SIZE = static_cast<int64_t>(192) * 1024;
+constexpr uint32_t FP32_DTYPE_SIZE = 4;
+
+struct TilingParams {
+    uint64_t coreNumUse = 0;
+    uint64_t numTokens = 0;
+    uint64_t numHeads = 0;
+    uint64_t headSize = 0;
+    uint64_t rotaryDim = 0;
+    uint64_t kLeadingDimension = 0;
+    uint64_t isNeoxStyle = 0;
+    uint64_t frontCore = 0;
+    uint64_t tailCore = 0;
+    uint64_t numTokensFrontCoreEachLoop = 0;
+    uint64_t numTokensTailCoreEachLoop = 0;
+    uint64_t numTokensEachFrontCore = 0;
+    uint64_t numTokensEachTailCore = 0;
+    uint64_t loopTimeEachFrontCore = 0;
+    uint64_t loopTimeEachTailCore = 0;
+    uint64_t numTokensFrontCoreLastLoop = 0;
+    uint64_t numTokensTailCoreLastLoop = 0;
+    uint64_t tilingKey = 0;
 };
+} // namespace
+
+
+void GetDtypeInfo(const at::Tensor& key, uint64_t& tilingKey) {
+    if (key.scalar_type() == at::ScalarType::BFloat16) {
+        tilingKey = TILING_BF16;
+    } else if (key.scalar_type() == at::ScalarType::Half) {
+        tilingKey = TILING_FP16;
+    } else if (key.scalar_type() == at::ScalarType::Float) {
+        tilingKey = TILING_FP32;
+    } else {
+        throw std::invalid_argument("Unavailable tensor type, only support BF16/FP16/FP32");
+    }
+}
+
+void ComputeTilingParams(TilingParams& params, const at::Tensor& key, const at::Tensor& cosSinCache) {
+    params.numTokens = static_cast<uint64_t>(key.size(DIM_0));
+    params.kLeadingDimension = static_cast<uint64_t>(key.size(DIM_1));
+    params.numHeads = params.kLeadingDimension / params.headSize;
+
+    uint64_t cosSinDimNum = static_cast<uint64_t>(cosSinCache.dim());
+    params.rotaryDim = static_cast<uint64_t>(cosSinCache.size(cosSinDimNum - 1));
+
+    const char* socName = aclrtGetSocName();
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance(socName);
+
+    const uint64_t aivAvailableCores = static_cast<uint64_t>(ascendcPlatform->GetCoreNumAiv());
+    uint64_t totalCoreNum = aivAvailableCores;
+    
+    if (params.numTokens <= CORE_ALLOCATION_THRESHOLD) {
+        totalCoreNum = 8;
+    } else {
+        totalCoreNum = 16;
+    }
+
+    params.coreNumUse = totalCoreNum;
+
+    uint64_t ubSizePlatform = 0;
+    ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSizePlatform);
+    uint64_t maxUbSize = std::min(ubSizePlatform, static_cast<uint64_t>(UB_SIZE)); 
+
+    uint64_t dtypeSize = FP32_DTYPE_SIZE;
+    GetDtypeInfo(key, params.tilingKey);
+
+    uint64_t totalDataNum = params.numTokens;
+    params.frontCore = (totalDataNum % totalCoreNum != 0) ? (totalDataNum % totalCoreNum) : totalCoreNum;
+    params.tailCore = (totalDataNum <= totalCoreNum) ? 0 : (totalCoreNum - params.frontCore);
+    uint64_t blockDim = params.frontCore + params.tailCore;
+    params.coreNumUse = blockDim;
+
+    uint64_t numHeadsMax = params.numHeads;
+
+    uint64_t perTokenUbSize = params.isNeoxStyle == 1 ?
+        (numHeadsMax * (params.rotaryDim * 10 + params.headSize) * dtypeSize) :
+        (numHeadsMax * (params.rotaryDim * 12 + params.headSize) * dtypeSize);
+    uint64_t maxNPerLoopForUb = (perTokenUbSize == 0) ? 0 : (maxUbSize / perTokenUbSize);
+    maxNPerLoopForUb = std::max(maxNPerLoopForUb, static_cast<uint64_t>(1));
+
+    params.numTokensEachFrontCore = (totalDataNum + totalCoreNum - 1) / totalCoreNum;
+    params.loopTimeEachFrontCore = (params.numTokensEachFrontCore + maxNPerLoopForUb - 1) / maxNPerLoopForUb;
+    params.numTokensFrontCoreEachLoop = (params.loopTimeEachFrontCore == 1) ?
+        params.numTokensEachFrontCore : maxNPerLoopForUb;
+    params.numTokensFrontCoreLastLoop = (params.loopTimeEachFrontCore == 1) ?
+        0 : (params.numTokensEachFrontCore - params.numTokensFrontCoreEachLoop * (params.loopTimeEachFrontCore - 1));
+
+    params.numTokensEachTailCore = (totalDataNum <= totalCoreNum) ? 0 : (totalDataNum / totalCoreNum);
+    params.loopTimeEachTailCore = (params.numTokensEachTailCore + maxNPerLoopForUb - 1) / maxNPerLoopForUb;
+    params.numTokensTailCoreEachLoop = (params.loopTimeEachTailCore <= 1) ?
+        params.numTokensEachTailCore : maxNPerLoopForUb;
+    params.numTokensTailCoreLastLoop = (params.loopTimeEachTailCore == 1) ?
+        0 : (params.numTokensEachTailCore - params.numTokensTailCoreEachLoop * (params.loopTimeEachTailCore - 1));
+}
+
+
+template <typename T, typename TENSOR_TYPE>
+T* GetPtr(TENSOR_TYPE& tensor) {
+    torch::Device device = tensor.device();
+    // NPU should be using PrivateUse1
+    if (device.is_privateuseone() || device.is_cuda()) {
+        return static_cast<T*>(tensor.data_ptr());
+    } else if (device.is_cpu()) {
+        // find device ptr based on the host pinned ptr
+        // because acl does not currently support HostGetDevicePointer API
+        void* devPtr = get_device_ptr(tensor.data_ptr());
+        TORCH_CHECK(devPtr != nullptr, "Unable to retrieve device ptr, is this a host registered pointer ?");
+        return reinterpret_cast<T*>(devPtr);
+    } else {
+        TORCH_CHECK(false, "Invalid device. Device must be ascend (PrivateUseOne) or pinned cpu.");
+    }
+}
+
+void rotary_embedding_k_fused(
+    torch::Tensor& oldPositions,
+    torch::Tensor& newPositions,
+    torch::Tensor& key,
+    int64_t headSize,
+    torch::Tensor& cosSinCache,
+    bool isNeox) {
+
+    TilingParams params;
+    params.headSize = static_cast<uint64_t>(headSize);
+    params.isNeoxStyle = static_cast<uint64_t>(isNeox);
+    params.kLeadingDimension = static_cast<uint64_t>(key.size(DIM_1));
+
+    ComputeTilingParams(params, key, cosSinCache);
+
+    uint8_t* oldPositionsPtr = GetPtr<uint8_t, torch::Tensor>(oldPositions);
+    uint8_t* newPositionsPtr = GetPtr<uint8_t, torch::Tensor>(newPositions);
+    uint8_t* keyPtr = GetPtr<uint8_t, torch::Tensor>(key);
+    uint8_t* cosSinCachePtr = GetPtr<uint8_t, torch::Tensor>(cosSinCache);
+    uint8_t* keyOutPtr = keyPtr;
+
+    auto aclStream = c10_npu::getCurrentNPUStream().stream();
+    const char* socName = aclrtGetSocName();
+
+    at_npu::native::OpCommand cmd;
+    cmd.Name("fused_rope");
+    cmd.SetCustomHandler([=]() -> int {
+        kvcache_ops::rotary_embedding_kernel_dispatch(
+            params.coreNumUse, aclStream, oldPositionsPtr, newPositionsPtr,
+            keyPtr, cosSinCachePtr, keyOutPtr,
+            params.numTokens, params.numHeads,
+            params.headSize, params.rotaryDim,
+            params.kLeadingDimension, params.isNeoxStyle,
+            params.frontCore, params.tailCore,
+            params.numTokensFrontCoreEachLoop, params.numTokensTailCoreEachLoop,
+            params.numTokensEachFrontCore, params.numTokensEachTailCore,
+            params.loopTimeEachFrontCore, params.loopTimeEachTailCore,
+            params.numTokensFrontCoreLastLoop, params.numTokensTailCoreLastLoop,
+            params.tilingKey
+        );
+        return 0;
+    });
+    cmd.Run();
+}

--- a/csrc/pos_kernels.h
+++ b/csrc/pos_kernels.h
@@ -2,9 +2,24 @@
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
 #include <torch/torch.h>
+#include "managed_mem.h"
 #include <torch/extension.h>
 
-void rotary_embedding_k_fused(const torch::Tensor& old_positions,
-                              const torch::Tensor& new_positions,
-                              torch::Tensor& key, int64_t head_size,
-                              const torch::Tensor& cos_sin_cache, bool is_neox);
+namespace kvcache_ops{
+void rotary_embedding_kernel_dispatch(
+        uint64_t blockDim, void* stream, uint8_t* oldPositions,
+        uint8_t* newPositions, uint8_t* key, uint8_t* cosSinCache,
+        uint8_t* keyOut, uint64_t numTokens, uint64_t numHeads,
+        uint64_t headSize, uint64_t rotaryDim, uint64_t kLeadingDimension,
+        uint64_t isNeoxStyle, uint64_t frontCore, uint64_t tailCore,
+        uint64_t numTokensFrontCoreEachLoop, uint64_t numTokensTailCoreEachLoop,
+        uint64_t numTokensEachFrontCore, uint64_t numTokensEachTailCore,
+        uint64_t loopTimeEachFrontCore, uint64_t loopTimeEachTailCore,
+        uint64_t numTokensFrontCoreLastLoop, uint64_t numTokensTailCoreLastLoop,
+        uint64_t tilingKey);
+}
+
+void rotary_embedding_k_fused(torch::Tensor& oldPositions,
+                            torch::Tensor& newPositions,
+                            torch::Tensor& key, int64_t headSize,
+                            torch::Tensor& cosSinCache, bool isNeox);

--- a/tests/v1/pos_kernels_performance.py
+++ b/tests/v1/pos_kernels_performance.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Any, Callable, Dict, Optional
+import pytest
+
+# Third Party
+from vllm.model_executor.layers.rotary_embedding import get_rope as vllm_get_rope
+import torch
+from torch.utils.benchmark import Timer 
+import numpy as np
+
+from lmcache_ascend.v1.blend.positional_encoding import (
+    BasicReverseRope,
+    FusedRope,
+)
+
+# First Party
+from lmcache.logging import init_logger
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+# Add and test more types of rope
+# (e.g., rope scaling, (non-)neox style, dtype, etc.)
+
+
+class DummyFusedRope:
+    """
+    This implementation directly uses two separate RoPE kernel calls to ratate K cache from
+    the old positions to the new positions.
+    """
+
+    def __init__(self, rope, reverse_rope, is_neox_style):
+        self.rope = rope
+        self.reverse_rope = reverse_rope
+        self.is_neox_style = is_neox_style
+        self.head_size = rope.head_size
+        self.cos_sin_cache = rope.cos_sin_cache
+
+    def fused_encode(self, old_positions, new_positions, k):
+        q = torch.zeros_like(k)
+        q, k = self.reverse_rope(old_positions, q, k)
+        q, k = self.rope(new_positions, q, k)
+        return k
+
+    def __call__(self, old_positions, new_positions, k):
+        return self.fused_encode(old_positions, new_positions, k)
+
+
+def validate_rope_params(
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: int,
+    is_neox_style: bool = True,
+    rope_scaling: Optional[Dict[str, Any]] = None,
+    dtype: Optional[torch.dtype] = None,
+    partial_rotary_factor: float = 1.0,
+):
+    if rotary_dim != head_size:
+        logger.error("Currently KV blending only support rotary_dim == head_size.")
+        return False
+
+    if rope_scaling is not None:
+        logger.error("Currently KV blending do not support rope scaling.")
+        return False
+
+    if partial_rotary_factor != 1.0:
+        logger.error(
+            "Currently KV blending do not support rotary factor other than 1.0."
+        )
+        return False
+
+    return True
+
+
+def validate_reverse_correctness(
+    rope: Callable, 
+    reverse_rope: BasicReverseRope, 
+    fused_rope: FusedRope, 
+    dummy_fused_rope: DummyFusedRope, 
+    head_size: int, 
+    test_sizes,
+    repeats: int = 10
+) -> bool:
+
+    hidden_dim = head_size * 8
+    all_passed = True
+
+    for num_tokens in test_sizes:
+        
+        q_errors = []
+        k_errors = []
+        fused_k_errors = []
+        dummy_fused_k_errors = []
+
+        print(f"\n===================== num_tokens = {num_tokens} =====================")
+
+        for run in range(repeats):
+            initial_query = torch.rand((num_tokens, hidden_dim), device="npu", dtype=rope.dtype)
+            initial_key = torch.rand((num_tokens, hidden_dim), device="npu", dtype=rope.dtype)
+            old_positions = torch.arange(num_tokens, device="npu")
+
+            query_test = initial_query.clone()
+            key_test = initial_key.clone()
+            query_test, key_test = rope(old_positions, query_test, key_test) # Forward
+            query_test, key_test = reverse_rope(old_positions, query_test, key_test) # Reverse
+
+            current_q_err = (initial_query - query_test).abs().max().item()
+            current_k_err = (initial_key - key_test).abs().max().item()
+            
+            unrotated_query = initial_query.clone()
+            unrotated_key = initial_key.clone()
+            
+            new_positions = torch.arange(100, 100 + num_tokens, device="npu")
+            _, target_k_new_pos = rope(new_positions, unrotated_query, unrotated_key) 
+            
+            k_at_old_pos = unrotated_key.clone()
+            _, k_at_old_pos = rope(old_positions, unrotated_query, k_at_old_pos)
+            
+            # FusedRope
+            k_fused_result = fused_rope(old_positions, new_positions, k_at_old_pos.clone())
+            current_fused_err = (target_k_new_pos - k_fused_result).abs().max().item()
+            
+            # DummyFusedRope
+            k_dummy_fused_result = dummy_fused_rope(old_positions, new_positions, k_at_old_pos.clone())
+            current_dummy_err = (target_k_new_pos - k_dummy_fused_result).abs().max().item()
+
+            q_errors.append(current_q_err)
+            k_errors.append(current_k_err)
+            fused_k_errors.append(current_fused_err)
+            dummy_fused_k_errors.append(current_dummy_err)
+
+        avg_q = np.mean(q_errors)
+        std_q = np.std(q_errors)
+        avg_k = np.mean(k_errors)
+        std_k = np.std(k_errors)
+        avg_fused = np.mean(fused_k_errors)
+        std_fused = np.std(fused_k_errors)
+        avg_dummy = np.mean(dummy_fused_k_errors)
+        std_dummy = np.std(dummy_fused_k_errors)
+
+        print(f"Fused Rope K Error - Mean: {avg_fused:.6f}, Std Dev: {std_fused:.6f}")
+        print(f"Dummy Fused Rope K Error - Mean: {avg_dummy:.6f}, Std Dev: {std_dummy:.6f}")
+
+        threshold = 1
+        size_passed = (avg_q < threshold and avg_k < threshold
+                       and avg_fused < threshold and avg_dummy < threshold)
+        if not size_passed:
+            print(f"Scale {num_tokens} **FAILED** the accuracy test! (Threshold: {threshold})")
+            all_passed = False
+        else:
+            print(f"Scale {num_tokens} **PASSED** the accuracy test.")
+
+    return all_passed
+
+
+def get_fused_rope(
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: float,
+    is_neox_style: bool = True,
+    rope_scaling: Optional[Dict[str, Any]] = None,
+    dtype: Optional[torch.dtype] = None,
+    test_sizes = None,
+    partial_rotary_factor: float = 1.0,
+) -> Optional[Callable[..., Any]]:
+
+    if not validate_rope_params(
+        head_size,
+        rotary_dim,
+        max_position,
+        base,
+        is_neox_style,
+        rope_scaling,
+        dtype,
+        partial_rotary_factor,
+    ):
+        logger.warning(
+            "The rope parameters is not supported! Cannot use cacheblend in this case"
+        )
+        return None
+
+    rope = vllm_get_rope(
+        head_size,
+        rotary_dim,
+        max_position,
+        base,
+        is_neox_style,
+        rope_scaling,
+        dtype,
+        partial_rotary_factor,
+    )
+
+    reverse_rope = BasicReverseRope(rope, rotary_dim, is_neox_style)
+    fused_rope = FusedRope(rope, is_neox_style)
+    dummy_fused_rope = DummyFusedRope(rope, reverse_rope, is_neox_style)
+
+    correct = validate_reverse_correctness(rope, reverse_rope, fused_rope, dummy_fused_rope, head_size, test_sizes)
+    if not correct:
+        logger.error(
+            "Fused/reverse rotary encoding is not correct! Will disable blending!"
+        )
+        return None
+
+    return fused_rope
+
+
+def verify_rope(
+    head_dim: int,
+    max_position: int,
+    rope_theta: float,
+    is_neox_style: bool,
+    dtype: torch.dtype,
+    test_sizes,
+):
+    fused_rotary_emb = get_fused_rope(
+        head_dim,
+        rotary_dim=head_dim,
+        max_position=max_position,
+        base=rope_theta,
+        rope_scaling=None,
+        is_neox_style=is_neox_style,
+        dtype=dtype,
+        test_sizes = test_sizes
+    )
+
+    assert fused_rotary_emb is not None, "Failed to get fused rotary embedding"
+
+
+# -------------------------- pytest --------------------------
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("max_position", [10000])
+@pytest.mark.parametrize("rope_theta", [500000.0])
+@pytest.mark.parametrize("is_neox_style", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("test_sizes", [[100, 256, 512, 1024, 2048, 4096, 8192]])
+def test_fused_rope(head_dim, max_position, rope_theta, is_neox_style, dtype, test_sizes):
+    """
+    Pytest function to verify the correctness of the fused RoPE implementation 
+    across various dimensions and data types.
+    """
+    verify_rope(
+        head_dim=head_dim,
+        max_position=max_position,
+        rope_theta=rope_theta,
+        is_neox_style=is_neox_style,
+        dtype=dtype,
+        test_sizes=test_sizes
+    )

--- a/tests/v1/test_pos_kernels.py
+++ b/tests/v1/test_pos_kernels.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Any, Callable, Dict, Optional
+import pytest
+
+# Third Party
+from vllm.model_executor.layers.rotary_embedding import get_rope as vllm_get_rope
+import torch
+from torch.utils.benchmark import Timer 
+import numpy as np
+
+from lmcache_ascend.v1.blend.positional_encoding import (
+    BasicReverseRope,
+    FusedRope,
+)
+
+# First Party
+from lmcache.logging import init_logger
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+# Add and test more types of rope
+# (e.g., rope scaling, (non-)neox style, dtype, etc.)
+
+
+class DummyFusedRope:
+    """
+    This implementation directly uses two separate RoPE kernel calls to ratate K cache from
+    the old positions to the new positions.
+    """
+
+    def __init__(self, rope, reverse_rope, is_neox_style):
+        self.rope = rope
+        self.reverse_rope = reverse_rope
+        self.is_neox_style = is_neox_style
+        self.head_size = rope.head_size
+        self.cos_sin_cache = rope.cos_sin_cache
+
+    def fused_encode(self, old_positions, new_positions, k):
+        q = torch.zeros_like(k)
+        q, k = self.reverse_rope(old_positions, q, k)
+        q, k = self.rope(new_positions, q, k)
+        return k
+
+    def __call__(self, old_positions, new_positions, k):
+        return self.fused_encode(old_positions, new_positions, k)
+
+
+# --- Validation Functions ---
+
+def validate_rope_params(
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: int,
+    is_neox_style: bool = True,
+    rope_scaling: Optional[Dict[str, Any]] = None,
+    dtype: Optional[torch.dtype] = None,
+    partial_rotary_factor: float = 1.0,
+):
+    if rotary_dim != head_size:
+        logger.error("Currently KV blending only support rotary_dim == head_size.")
+        return False
+
+    if rope_scaling is not None:
+        logger.error("Currently KV blending do not support rope scaling.")
+        return False
+
+    if partial_rotary_factor != 1.0:
+        logger.error(
+            "Currently KV blending do not support rotary factor other than 1.0."
+        )
+        return False
+
+    return True
+
+
+def validate_reverse_correctness(
+    rope: Callable, 
+    reverse_rope: Callable, 
+    fused_rope: Callable, 
+    dummy_fused_rope: Callable, 
+    head_size: int, 
+    test_sizes,
+    repeats: int = 10
+) -> bool:
+
+    hidden_dim = head_size * 8
+    all_passed = True
+
+    for num_tokens in test_sizes:
+        
+        q_errors = []
+        k_errors = []
+        fused_k_errors = []
+        dummy_fused_k_errors = []
+
+        print(f"\n===================== num_tokens = {num_tokens} =====================")
+
+        for run in range(repeats):
+            initial_query = torch.rand((num_tokens, hidden_dim), device="npu", dtype=rope.dtype)
+            initial_key = torch.rand((num_tokens, hidden_dim), device="npu", dtype=rope.dtype)
+            old_positions = torch.arange(num_tokens, device="npu")
+
+            query_test = initial_query.clone()
+            key_test = initial_key.clone()
+            query_test, key_test = rope(old_positions, query_test, key_test) # Forward
+            query_test, key_test = reverse_rope(old_positions, query_test, key_test) # Reverse
+
+            current_q_err = (initial_query - query_test).abs().max().item()
+            current_k_err = (initial_key - key_test).abs().max().item()
+            
+            unrotated_query = initial_query.clone()
+            unrotated_key = initial_key.clone()
+            
+            new_positions = torch.arange(100, 100 + num_tokens, device="npu")
+            _, target_k_new_pos = rope(new_positions, unrotated_query, unrotated_key) 
+            
+            k_at_old_pos = unrotated_key.clone()
+            _, k_at_old_pos = rope(old_positions, unrotated_query, k_at_old_pos)
+            
+            # FusedRope
+            k_fused_result = fused_rope(old_positions, new_positions, k_at_old_pos.clone())
+            current_fused_err = (target_k_new_pos - k_fused_result).abs().max().item()
+            
+            # DummyFusedRope
+            k_dummy_fused_result = dummy_fused_rope(old_positions, new_positions, k_at_old_pos.clone())
+            current_dummy_err = (target_k_new_pos - k_dummy_fused_result).abs().max().item()
+
+            q_errors.append(current_q_err)
+            k_errors.append(current_k_err)
+            fused_k_errors.append(current_fused_err)
+            dummy_fused_k_errors.append(current_dummy_err)
+
+        avg_q = np.mean(q_errors)
+        std_q = np.std(q_errors)
+        avg_k = np.mean(k_errors)
+        std_k = np.std(k_errors)
+        avg_fused = np.mean(fused_k_errors)
+        std_fused = np.std(fused_k_errors)
+        avg_dummy = np.mean(dummy_fused_k_errors)
+        std_dummy = np.std(dummy_fused_k_errors)
+
+        # print(f"Reverse RoPE Q Error - Mean: {avg_q:.6f}, Std Dev: {std_q:.6f}")
+        # print(f"Reverse RoPE K Error - Mean: {avg_k:.6f}, Std Dev: {std_k:.6f}")
+        print(f"Fused Rope K Error - Mean: {avg_fused:.6f}, Std Dev: {std_fused:.6f}")
+        print(f"Dummy Fused Rope K Error - Mean: {avg_dummy:.6f}, Std Dev: {std_dummy:.6f}")
+
+        threshold = 1
+        size_passed = (avg_q < threshold and avg_k < threshold
+                       and avg_fused < threshold and avg_dummy < threshold)
+        if not size_passed:
+            print(f"Scale {num_tokens} **FAILED** the accuracy test! (Threshold: {threshold})")
+            all_passed = False
+        else:
+            print(f"Scale {num_tokens} **PASSED** the accuracy test.")
+
+    return all_passed
+
+
+def get_fused_rope(
+    head_size: int,
+    rotary_dim: int,
+    max_position: int,
+    base: float,
+    is_neox_style: bool = True,
+    rope_scaling: Optional[Dict[str, Any]] = None,
+    dtype: Optional[torch.dtype] = None,
+    test_sizes = None,
+    partial_rotary_factor: float = 1.0,
+) -> Optional[Callable[..., Any]]:
+    # Validate the ROPE parameters
+    if not validate_rope_params(
+        head_size,
+        rotary_dim,
+        max_position,
+        base,
+        is_neox_style,
+        rope_scaling,
+        dtype,
+        partial_rotary_factor,
+    ):
+        logger.warning(
+            "The rope parameters is not supported! Cannot use cacheblend in this case"
+        )
+        return None
+
+    rope = vllm_get_rope(
+        head_size,
+        rotary_dim,
+        max_position,
+        base,
+        is_neox_style,
+        rope_scaling,
+        dtype,
+        partial_rotary_factor,
+    )
+
+    reverse_rope = BasicReverseRope(rope, rotary_dim, is_neox_style)
+    fused_rope = FusedRope(rope, is_neox_style)
+    fused_rope2 = DummyFusedRope(rope, reverse_rope, is_neox_style)
+    
+    print("\n" + "="*85)
+    print(f"**1. Accuracy Test** === Head Size: {head_size} | Neox Style: {is_neox_style} | DType: {dtype} ")
+    print("="*85)
+
+    correct = validate_reverse_correctness(rope, reverse_rope, fused_rope, fused_rope2, head_size, test_sizes)
+    if not correct:
+        logger.error(
+            "Fused/reverse rotary encoding is not correct! Will disable blending!"
+        )
+        return None
+
+    return fused_rope
+
+
+def verify_rope(
+    head_dim,
+    max_position,
+    rope_theta,
+    is_neox_style,
+    dtype,
+    test_sizes,
+):
+    fused_rotary_emb = get_fused_rope(
+        head_dim,
+        rotary_dim=head_dim,
+        max_position=max_position,
+        base=rope_theta,
+        rope_scaling=None,
+        is_neox_style=is_neox_style,
+        dtype=dtype,
+        test_sizes = test_sizes
+    )
+    assert fused_rotary_emb is not None, "Failed to get fused rotary embedding"
+
+
+def benchmark_rope(
+    fused_rope: FusedRope, 
+    dummy_rope: DummyFusedRope, 
+    num_tokens: int, 
+    hidden_dim: int, 
+    device: str, 
+    dtype: torch.dtype, 
+    repeats: int = 100
+):
+    old_positions = torch.arange(num_tokens, device=device)
+    new_positions = torch.arange(100, 100 + num_tokens, device=device)  
+    k = torch.randn((num_tokens, hidden_dim), device=device, dtype=dtype)  
+    
+    # warmup
+    for _ in range(10):
+        fused_rope(old_positions, new_positions, k.clone())
+        dummy_rope(old_positions, new_positions, k.clone())
+    torch.npu.synchronize()  
+
+    fused_start_ev = torch.npu.Event(enable_timing=True)
+    fused_end_ev = torch.npu.Event(enable_timing=True)
+    fused_times = []
+
+    for _ in range(repeats):
+        k_clone = k
+        torch.npu.synchronize()
+        fused_start_ev.record()
+        fused_rope(old_positions, new_positions, k_clone)
+        fused_end_ev.record()
+        torch.npu.synchronize()
+        elapsed = fused_start_ev.elapsed_time(fused_end_ev)
+        fused_times.append(elapsed)
+
+    dummy_start_ev = torch.npu.Event(enable_timing=True)
+    dummy_end_ev = torch.npu.Event(enable_timing=True)
+    dummy_times = []
+
+    for _ in range(repeats):
+        k_clone = k
+        torch.npu.synchronize()
+        dummy_start_ev.record()
+        dummy_rope(old_positions, new_positions, k_clone)
+        dummy_end_ev.record()
+        torch.npu.synchronize()
+        elapsed = dummy_start_ev.elapsed_time(dummy_end_ev)
+        dummy_times.append(elapsed)
+    
+    fused_avg_ms = sum(fused_times) / repeats
+    dummy_avg_ms = sum(dummy_times) / repeats
+    speedup = dummy_avg_ms / fused_avg_ms if fused_avg_ms > 0 else 0
+    
+    return {
+        "num_tokens": num_tokens,
+        "fused_avg_ms": fused_avg_ms,
+        "dummy_avg_ms": dummy_avg_ms,
+        "speedup": speedup
+    }
+
+
+def run_performance_tests(
+    head_dim: int,
+    max_position: int,
+    rope_theta: float,
+    is_neox_style: bool,
+    dtype: torch.dtype,
+    test_sizes,
+    device: str = "npu"
+):
+
+    hidden_dim = head_dim * 8  # hidden_dim = head_size * num_heads
+
+    rope = vllm_get_rope(
+        head_dim,
+        rotary_dim=head_dim,
+        max_position=max_position,
+        base=rope_theta,
+        is_neox_style=is_neox_style,
+        rope_scaling=None,
+        dtype=dtype,
+        partial_rotary_factor=1.0, 
+    )
+
+    reverse_rope = BasicReverseRope(rope, head_dim, is_neox_style)
+    fused_rope = FusedRope(rope, is_neox_style)
+    dummy_rope = DummyFusedRope(rope, reverse_rope, is_neox_style)
+
+    print("\n" + "="*95)
+    print(f"**2. Performance Test** === Device: {device} | DType: {dtype} | Head Dim: {head_dim} ")
+    print("="*95)
+    print(f"{'Token Count':<12} | {'FusedRope (Fused Op) Avg Time (ms)':<32} | {'Dummy (Small Op) Avg Time (ms)':<32} | {'Speedup Ratio':<15}")
+    print("-" * 95)
+
+    for num_tokens in test_sizes:
+        result = benchmark_rope(
+            fused_rope=fused_rope,
+            dummy_rope=dummy_rope,
+            num_tokens=num_tokens,
+            hidden_dim=hidden_dim,
+            device=device,
+            dtype=dtype,
+            repeats=100
+        )
+        print(
+            f"{result['num_tokens']:<12} | "
+            f"{result['fused_avg_ms']:<32.4f} | "
+            f"{result['dummy_avg_ms']:<32.4f} | "
+            f"{result['speedup']:<15.2f}"
+        )
+
+
+if __name__ == "__main__":
+    head_size = 64
+    max_position = 33000
+    rope_theta = 500000.0
+    is_neox_style = True
+    # choices=["bfloat16", "float16", "float32"]
+    dtype = torch.bfloat16
+    test_sizes = [512, 1024, 4096] # num_tokens
+
+    verify_rope(
+        head_dim=head_size, 
+        max_position=max_position, 
+        rope_theta=rope_theta, 
+        is_neox_style=is_neox_style, 
+        dtype=dtype, 
+        test_sizes=test_sizes
+    )
+
+    run_performance_tests(
+        head_dim=head_size, 
+        max_position=max_position, 
+        rope_theta=rope_theta, 
+        is_neox_style=is_neox_style, 
+        dtype=dtype, 
+        test_sizes=test_sizes
+    )


### PR DESCRIPTION
This PR implements Fused RoPE kernel handling both forward and reverse operations.

support for cacheblend
Changes Made:
Fused kernels support positional encoding, delivering 4–25x speedup over individual operators；
Enables fine-grained control over the number of AIV cores utilized；
Made changes to the test_*.py and performance.py that uses the necessary NPU APIs to run successfully, all unit tests passed on our platform(910b).

related issue:https://github.com/LMCache/LMCache-Ascend/issues/15