### PR TITLE
Fix SOC_VERSION error in 310P environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def _get_npu_soc():
     """
     _soc_version = os.getenv("SOC_VERSION")
     if _soc_version:
-        return _soc_version
+        return "Ascend" + _soc_version[6:] if _soc_version.lower().startswith("ascend") else _soc_version
 
     try:
         npu_smi_cmd = ["npu-smi", "info", "-t", "board", "-i", "0", "-c", "0"]


### PR DESCRIPTION
SOC_VERSION should be set as Ascend310, not ASCEND310

<img width="894" height="160" alt="14F78886-1BD9-442E-DB7F-2B2E1AADFD1D" src="https://github.com/user-attachments/assets/0f8cf81a-89e4-43d4-aa97-28a1cd2262af" />

