### PR TITLE
Fix error: tensors need to be on the same device

### DIFF
--- a/lmcache_ascend/v1/blend/positional_encoding.py
+++ b/lmcache_ascend/v1/blend/positional_encoding.py
@@ -177,6 +177,8 @@ def get_fused_rope(
         partial_rotary_factor,
     )
 
+    rope.cos_sin_cache = rope.cos_sin_cache.to("npu")
+    
     reverse_rope = BasicReverseRope(rope, rotary_dim, is_neox_style)
     fused_rope = FusedRope(rope, is_neox_style)
     

--- a/tests/v1/test_pos_kernels.py
+++ b/tests/v1/test_pos_kernels.py
@@ -236,6 +236,8 @@ def rope_modules(head_size, max_position, rope_theta, is_neox_style, dtype):
         partial_rotary_factor=1.0,
     )
 
+    base_rope.cos_sin_cache = base_rope.cos_sin_cache.to("npu")
+    
     reverse_rope = BasicReverseRope(base_rope, head_size, is_neox_style)
     fused_rope = FusedRope(base_rope, is_neox_style)
     dummy_rope = DummyFusedRope(base_rope, reverse_rope, is_neox_style)


### PR DESCRIPTION
Fixed the bug where cossincache and position were not on the same device during the initial accuracy verification.

“RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and npu:0! (when checking argument for argument index in method wrapper_NPU__index_select)”