### PR TITLE
Bugfix: resolve memory registration issue for 310P on MindSpore

### DIFF
--- a/csrc/mindspore/mem_kernels.cpp
+++ b/csrc/mindspore/mem_kernels.cpp
@@ -150,6 +150,83 @@ void multi_layer_kv_transfer(py::array& key_value, // [kv, num_layer, num_tokens
     slot_mapping, page_buffer_size, direction, use_mla);
 }
 
+class MultiLayerKvTransferOp310p : public ms::pynative::PyboostRunner {
+public:
+  using PyboostRunner::PyboostRunner;
+  void LaunchKernel() override {
+
+    auto &lmc_buffer = inputs()[0];
+    auto &key_value_ptrs = inputs()[1];
+    auto &slot_mappings = inputs()[2];
+
+    int num_tokens = slot_mappings.shape()[0];
+
+    int kv_size = use_mla_ ? 1 : 2;
+
+    kvcache_ops::KVCacheFormat kvcache_format = static_cast<kvcache_ops::KVCacheFormat>(kvcache_format_raw_);
+
+    int num_layers = key_value_ptrs.shape()[0] / kv_size;
+
+    ms::TypeId slot_mapping_type = slot_mappings.data_type();
+    auto slot_type = get_dtype_from_ms(slot_mapping_type);
+
+    const char* socName = aclrtGetSocName();
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance(socName);
+    uint32_t aiv_num = ascendcPlatform->GetCoreNumAiv();
+
+    uint8_t* lmc_offset_dptr = static_cast<uint8_t *>(lmc_buffer.GetDataPtr());
+    uint8_t* paged_kv_dev_ptr = static_cast<uint8_t *>(key_value_ptrs.GetDataPtr());
+    uint8_t* slot_mapping_ptr = static_cast<uint8_t *>(slot_mappings.GetDataPtr());
+
+    kvcache_ops::multi_layer_kv_transfer_kernel(key_value_type_, slot_type, kvcache_format, aiv_num, stream(), 
+                    paged_kv_dev_ptr, lmc_offset_dptr, slot_mapping_ptr, 
+                    hidden_dims_, kv_size, num_layers, page_buffer_size_,
+                    num_tokens, direction_);
+  }
+
+  static void Eval(ms::Tensor key_value,
+                   kvcache_ops::AscendType key_value_type,
+                   int hidden_dims,
+                   ms::Tensor key_value_ptrs,
+                   ms::Tensor slot_mappings,
+                   const int page_buffer_size,
+                   const bool direction,
+                   const bool use_mla,
+                   const int kvcache_format_raw)
+    {
+    auto runner = std::make_shared<MultiLayerKvTransferOp310p>("MultiLayerKvTransfer");
+    runner->key_value_type_ = key_value_type;
+    runner->hidden_dims_ = hidden_dims;
+    runner->page_buffer_size_ = page_buffer_size;
+    runner->direction_ = direction;
+    runner->use_mla_ = use_mla;
+    runner->kvcache_format_raw_ = kvcache_format_raw;
+    runner->Run({ key_value, key_value_ptrs, slot_mappings}, {});
+  }
+
+  kvcache_ops::AscendType key_value_type_{0};
+  int hidden_dims_{0};
+  int page_buffer_size_{0};
+  bool direction_{0};
+  bool use_mla_{0};
+  int kvcache_format_raw_{0};
+};
+
+void multi_layer_kv_transfer310p(ms::Tensor& key_value, // [kv, num_layer, num_tokens, hidden]
+                             ms::Tensor key_value_ptrs, // [num_layers]
+                             ms::Tensor slot_mapping, // [num_tokens]
+                             const int page_buffer_size, const int hidden_dims, const bool direction,
+                             const bool use_mla, const int kvcache_format_raw) {
+
+    std::cout << "[CPP_ADAPTER] Entered multi_layer_kv_transfer310p" << std::endl;
+
+    kvcache_ops::AscendType key_value_type = kvcache_ops::AscendType::FP16;
+
+    ms::pynative::PyboostRunner::Call<0>(
+    MultiLayerKvTransferOp310p::Eval, key_value, key_value_type, hidden_dims, key_value_ptrs,
+    slot_mapping, page_buffer_size, direction, use_mla, kvcache_format_raw);
+}
+
 void multi_layer_kv_transfer_unilateral(ms::Tensor& key_value,
                                         const ms::Tensor& key_ptrs,
                                         const ms::Tensor& value_ptrs,

--- a/csrc/mindspore/mem_kernels.h
+++ b/csrc/mindspore/mem_kernels.h
@@ -29,6 +29,12 @@ void multi_layer_kv_transfer(py::array& key_value, // [kv, num_layer, num_tokens
                              const int page_buffer_size, const bool direction,
                              const bool use_mla, const int kvcache_format_raw);
 
+void multi_layer_kv_transfer310p(ms::Tensor& key_value, // [kv, num_layer, num_tokens, hidden]
+                             ms::Tensor key_value_ptrs, // [num_layers]
+                             ms::Tensor slot_mapping, // [num_tokens]
+                             const int page_buffer_size, const int hidden_dims, const bool direction,
+                             const bool use_mla, const int kvcache_format_raw);
+
 void multi_layer_kv_transfer_unilateral(ms::Tensor& key_value,
                                         const ms::Tensor& key_ptrs,
                                         const ms::Tensor& value_ptrs,

--- a/csrc/mindspore/pybind.cpp
+++ b/csrc/mindspore/pybind.cpp
@@ -13,6 +13,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(c_ops, m) {
   m.def("create_pinned_tensor", &create_mmapped_numpy);
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
+  m.def("multi_layer_kv_transfer310p", &multi_layer_kv_transfer310p);
   m.def("single_layer_kv_transfer", &single_layer_kv_transfer);
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);

--- a/lmcache_ascend/mindspore/v1/_tensor.py
+++ b/lmcache_ascend/mindspore/v1/_tensor.py
@@ -39,6 +39,8 @@ def get_itemsize(dtype: torch.dtype):
         elif dtype == np_dtype.bfloat16:
             # np does not have bfloat16
             return 2
+        elif dtype == np.float16:
+            return 2
     return m
         
 
@@ -66,7 +68,7 @@ def get_numel(tensor: Union[torch.Tensor, np.ndarray, torch.Size]):
 def get_element_size(tensor: Union[torch.Tensor, np.ndarray]):
     """Get the size of each element in a torch.Tensor or np.ndarray."""
     if isinstance(tensor, torch.Tensor):
-        return tensor.elemenet_size()
+        return tensor.element_size()
     elif isinstance(tensor, np.ndarray):
         return tensor.itemsize
     else:


### PR DESCRIPTION
This fix addresses the issue where memory registration is not supported on the Ascend 310P specifically for the MindSpore platform.