### PR TITLE
Implementing Staging Copy C++ and fix KVCache format detection bug when using MLA

### DIFF
--- a/csrc/mem_kernels.cpp
+++ b/csrc/mem_kernels.cpp
@@ -38,94 +38,105 @@ void multi_layer_kv_transfer(
     const torch::Device &paged_memory_device, const int page_buffer_size,
     const bool direction, const bool use_mla, const int kvcache_format_raw) {
   uint8_t *key_value_ptr = get_kernel_ptr<uint8_t, torch::Tensor>(key_value);
-  // it is actually a uint8_t**. we will reinterpret it inside the kernel
-  uint8_t *page_buffer_ptrs =
-      get_kernel_ptr<uint8_t, const torch::Tensor>(key_value_ptrs);
-  uint8_t *slot_mapping_ptr =
-      get_kernel_ptr<uint8_t, const torch::Tensor>(slot_mapping);
 
-  int num_layers = key_value.size(1);
-  int num_tokens = slot_mapping.size(0);
-  int hidden_dims = key_value.size(-1);
-  int kv_size = 2;
-  if (use_mla) {
-    kv_size = 1;
-  }
+  MultiLayerKVConfig config = prepare_multi_layer_kv_config(
+      key_value, key_value_ptrs, slot_mapping, paged_memory_device,
+      page_buffer_size, direction, use_mla, kvcache_format_raw);
 
-  kvcache_ops::KVCacheFormat kvcache_format =
-      static_cast<kvcache_ops::KVCacheFormat>(kvcache_format_raw);
-
-  const c10::OptionalDeviceGuard device_guard(paged_memory_device);
-  // we require the kv ptr list to be on the device too
-  const c10::OptionalDeviceGuard kv_device_guard(device_of(key_value_ptrs));
-
-  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
-  at::ScalarType scalar_type = key_value.scalar_type();
-  at::ScalarType slot_type = slot_mapping.scalar_type();
-  const char *socName = aclrtGetSocName();
-  auto ascendcPlatform =
-      platform_ascendc::PlatformAscendCManager::GetInstance(socName);
-  uint64_t ubSize;
-  ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
-  // we only launched with at most 4 aiv
-  uint32_t aiv_num = (uint32_t)std::min(num_layers, 4);
-
-  int32_t numBuffsOnDev = 2;
-  // step 1. use per tokens buff size to derive how many tokens can be allocated
-  // per loop
-  int64_t baseBuffSize = numBuffsOnDev * hidden_dims * key_value.element_size();
-
-  if (ubSize < baseBuffSize) {
-    std::string errStr =
-        "Per TokenBuffer Size: " + std::to_string(baseBuffSize) +
-        " exceeds UB Size: " + std::to_string(ubSize);
-    PyErr_SetString(PyExc_RuntimeError, errStr + " Please contact us.");
-    throw py::error_already_set();
-  }
-
-  // step 2. work out how many tokens per loop
-  int32_t maxTokensPerLoop =
-      (ubSize / baseBuffSize) -
-      1; // Subtract 1 to provide a safety margin and avoid over-allocating the
-         // UB buffer, ensuring we do not exceed hardware limits due to possible
-         // rounding or small additional allocations.
-  maxTokensPerLoop = static_cast<int32_t>(
-      std::min(maxTokensPerLoop, static_cast<int32_t>(num_tokens)));
-
-  // step 3. double check whether the perloop buffer can accommodate everything
-  int64_t totalPerLoopBuffer =
-      static_cast<int64_t>(maxTokensPerLoop) * baseBuffSize;
-  if (ubSize < totalPerLoopBuffer) {
-    std::string errStr =
-        "Per Loop Buffer Size: " + std::to_string(totalPerLoopBuffer) +
-        " exceeds UB Size: " + std::to_string(ubSize);
-    PyErr_SetString(PyExc_RuntimeError, errStr + " Please contact us.");
-    throw py::error_already_set();
-  }
-
-  // using double buffs mean we actually want to allocate half of this per
-  // round.
-  int64_t singlePerLoopBuffer = totalPerLoopBuffer / numBuffsOnDev;
+  // Calculate UB buffer parameters
+  compute_multi_layer_ub_params(config, key_value, paged_memory_device,
+                                key_value_ptrs);
 
   at_npu::native::OpCommand cmd;
   cmd.Name("multi_layer_kv_transfer_kernel_v2");
-  cmd.SetCustomHandler([scalar_type, slot_type, kvcache_format, aiv_num, stream,
-                        page_buffer_ptrs, key_value_ptr, slot_mapping_ptr,
-                        hidden_dims, kv_size, num_layers, page_buffer_size,
-                        num_tokens, singlePerLoopBuffer, maxTokensPerLoop,
-                        direction]() -> int {
-    auto slot_num = vllm_ascend::get_dtype_from_torch(slot_type);
-    auto dtype_num = vllm_ascend::get_dtype_from_torch(scalar_type);
+  cmd.SetCustomHandler([config, key_value_ptr]() -> int {
+    auto slot_num = vllm_ascend::get_dtype_from_torch(config.slot_type);
+    auto dtype_num = vllm_ascend::get_dtype_from_torch(config.scalar_type);
+
     kvcache_ops::multi_layer_kv_transfer_kernel_v2(
-        dtype_num, slot_num, kvcache_format, aiv_num, stream, page_buffer_ptrs,
-        key_value_ptr, slot_mapping_ptr, hidden_dims, kv_size, num_layers,
-        page_buffer_size, num_tokens, singlePerLoopBuffer, maxTokensPerLoop,
-        direction);
+        dtype_num, slot_num, config.kvcache_format, config.aiv_num,
+        config.stream, config.page_buffer_ptrs, key_value_ptr,
+        config.slot_mapping_ptr, config.hidden_dims, config.kv_size,
+        config.num_layers, config.page_buffer_size, config.num_tokens,
+        config.singlePerLoopBuffer, config.maxTokensPerLoop, config.direction);
     return 0;
   });
   cmd.Run();
   return;
 };
+
+void fused_multi_layer_kv_transfer(
+    torch::Tensor &key_value,            // [kv, num_layer, num_tokens, hidden]
+    torch::Tensor &staging_cache,        // staging buffer
+    const torch::Tensor &key_value_ptrs, // [num_layers]
+    const torch::Tensor &slot_mapping,   // [num_tokens]
+    const torch::Device &paged_memory_device, const int page_buffer_size,
+    const bool direction, // true: from_gpu, false: to_gpu
+    const bool use_mla, const int kvcache_format_raw) {
+  // get host cpu buffer pointer for aclrtMemcpyAsync
+  uint8_t *key_value_ptr = static_cast<uint8_t *>(key_value.data_ptr());
+  uint8_t *staging_cache_ptr =
+      get_kernel_ptr<uint8_t, torch::Tensor>(staging_cache);
+
+  MultiLayerKVConfig config = prepare_multi_layer_kv_config(
+      key_value, key_value_ptrs, slot_mapping, paged_memory_device,
+      page_buffer_size, direction, use_mla, kvcache_format_raw);
+
+  compute_multi_layer_ub_params(config, key_value, paged_memory_device,
+                                key_value_ptrs);
+
+  // Calculate and verify the CPU buffer size
+  size_t cpu_buffer_size = static_cast<size_t>(config.kv_size) *
+                           config.num_layers * config.num_tokens *
+                           config.hidden_dims * key_value.element_size();
+
+  TORCH_CHECK(
+      staging_cache.numel() * staging_cache.element_size() >= cpu_buffer_size,
+      "staging_cache size insufficient: need ", cpu_buffer_size, " bytes, got ",
+      staging_cache.numel() * staging_cache.element_size());
+
+  at_npu::native::OpCommand cmd;
+  cmd.Name("fused_multi_layer_kv_transfer_kernel_v2");
+  cmd.SetCustomHandler([config, staging_cache_ptr, key_value_ptr,
+                        cpu_buffer_size]() -> int {
+    auto slot_num = vllm_ascend::get_dtype_from_torch(config.slot_type);
+    auto dtype_num = vllm_ascend::get_dtype_from_torch(config.scalar_type);
+
+    aclError ret;
+    // direction: false = to_gpu (H2D), true = from_gpu (D2H)
+    bool isH2D = !config.direction;
+
+    // Step 1: H2D memcpy (to_gpu) currently not used
+    if (isH2D) {
+      ret = aclrtMemcpyAsync(staging_cache_ptr, cpu_buffer_size, key_value_ptr,
+                             cpu_buffer_size, ACL_MEMCPY_HOST_TO_DEVICE,
+                             config.stream);
+      TORCH_CHECK(ret == ACL_ERROR_NONE,
+                  "H2D memcpy failed: cpu_buffer -> staging_cache, ret=", ret);
+    }
+
+    // Step 2: Kernel (Gather or Scatter)
+    kvcache_ops::multi_layer_kv_transfer_kernel_v2(
+        dtype_num, slot_num, config.kvcache_format, config.aiv_num,
+        config.stream, config.page_buffer_ptrs, staging_cache_ptr,
+        config.slot_mapping_ptr, config.hidden_dims, config.kv_size,
+        config.num_layers, config.page_buffer_size, config.num_tokens,
+        config.singlePerLoopBuffer, config.maxTokensPerLoop, config.direction);
+
+    // Step 3: D2H memcpy (from_gpu)
+    if (!isH2D) {
+      ret = aclrtMemcpyAsync(key_value_ptr, cpu_buffer_size, staging_cache_ptr,
+                             cpu_buffer_size, ACL_MEMCPY_DEVICE_TO_HOST,
+                             config.stream);
+      TORCH_CHECK(ret == ACL_ERROR_NONE,
+                  "D2H memcpy failed: staging_cache -> cpu_buffer, ret=", ret);
+    }
+
+    return 0;
+  });
+  cmd.Run();
+  return;
+}
 
 void multi_layer_kv_transfer_310p(
     torch::Tensor &key_value,            // [kv, num_layer, num_tokens, hidden]
@@ -207,116 +218,215 @@ void single_layer_kv_transfer(
                               // vllm_key_value_cache is [num_blocks, 2,
                               // block_size, num_heads, head_size]
 ) {
-  uint8_t *lmc_key_value_cache_ptr =
-      get_kernel_ptr<uint8_t, torch::Tensor>(lmc_key_value_cache);
-  uint8_t *vllm_key_value_cache_ptr =
-      get_kernel_ptr<uint8_t, torch::Tensor>(vllm_key_value_cache);
-  uint8_t *slot_mapping_ptr =
-      get_kernel_ptr<uint8_t, torch::Tensor>(slot_mapping);
+  SingleLayerKVConfig config = prepare_single_layer_kv_config(
+      lmc_key_value_cache, vllm_key_value_cache, slot_mapping, direction,
+      token_major, vllm_two_major);
 
-  int32_t num_tokens = slot_mapping.size(0);
-  int32_t num_heads = vllm_key_value_cache.size(-2);
-  int32_t head_dims = vllm_key_value_cache.size(-1);
-  int32_t block_size = vllm_key_value_cache.size(-3);
-  bool is_mla = false;
-  int16_t kv_size = 2;
-  if (token_major) {
-    is_mla = lmc_key_value_cache.size(1) == 1;
-  } else {
-    is_mla = lmc_key_value_cache.size(0) == 1;
-  }
-
-  if (is_mla) {
-    PyErr_SetString(
-        PyExc_RuntimeError,
-        " MLA is not supported yet. Please contact LMCache Ascend.");
-    throw py::error_already_set();
-  }
-
-  const c10::OptionalDeviceGuard device_guard(device_of(vllm_key_value_cache));
   const c10::OptionalDeviceGuard slot_device_guard(device_of(slot_mapping));
-  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
-
-  at::ScalarType scalar_type = vllm_key_value_cache.scalar_type();
-  at::ScalarType slot_type = slot_mapping.scalar_type();
-
-  const char *socName = aclrtGetSocName();
-  auto ascendcPlatform =
-      platform_ascendc::PlatformAscendCManager::GetInstance(socName);
-  uint32_t aiv_num = (uint32_t)std::min(4, num_tokens);
-  uint32_t numBuffsOnDev = 2;
-  // each token buffer is kv * heads * headdims * size
-  uint64_t baseBuffSize = numBuffsOnDev * kv_size * num_heads * head_dims *
-                          vllm_key_value_cache.element_size();
-  uint64_t ubSize;
-  ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
-
-  // first check whether one token k cache actually passes the ub
-  if (ubSize < baseBuffSize) {
-    std::string errStr =
-        "Per Token Cache Buffer Size: " + std::to_string(baseBuffSize) +
-        " exceeds UB Size: " + std::to_string(ubSize);
-    PyErr_SetString(PyExc_RuntimeError,
-                    errStr + " Please contact LMCache Ascend.");
-    throw py::error_already_set();
-  }
-
-  // we are going to work out how many tokens to copy maximally per innerloop
-  int32_t max_tokens_per_loop = ubSize / baseBuffSize;
-  max_tokens_per_loop =
-      static_cast<int32_t>(std::min(max_tokens_per_loop, num_tokens));
+  compute_single_layer_ub_params(config, vllm_key_value_cache);
 
   // precompute the strides for lmc_buffer & vllm_buffer
-  int64_t lmc_token_stride;
-  int64_t lmc_value_offset;
-  if (token_major) {
-    // [tokens, 2, heads*headdim]
-    lmc_token_stride = lmc_key_value_cache.stride(0);
-    lmc_value_offset = lmc_key_value_cache.stride(1);
-  } else {
-    // [2, tokens, heads*headdim]
-    lmc_token_stride = lmc_key_value_cache.stride(1);
-    lmc_value_offset = lmc_key_value_cache.stride(0);
-  }
-
-  int64_t vllm_block_stride;
-  int64_t vllm_value_offset;
-  if (vllm_two_major) {
-    // 2, num_blocks, block_size, num_heads, head_size
-    vllm_block_stride = vllm_key_value_cache.stride(1);
-    vllm_value_offset = vllm_key_value_cache.stride(0);
-  } else {
-    // num_blocks, 2, block_size, num_heads, head_size
-    vllm_block_stride = vllm_key_value_cache.stride(0);
-    vllm_value_offset = vllm_key_value_cache.stride(1);
-  }
-  int64_t vllm_buffer_size =
-      static_cast<int64_t>(vllm_key_value_cache.nbytes());
-  int64_t lmc_buffer_size = static_cast<int64_t>(lmc_key_value_cache.nbytes());
+  compute_single_layer_strides(config, lmc_key_value_cache,
+                               vllm_key_value_cache, token_major,
+                               vllm_two_major);
 
   at_npu::native::OpCommand cmd;
   cmd.Name("single_layer_kv_transfer_kernel_v2");
-  cmd.SetCustomHandler(
-      [scalar_type, slot_type, aiv_num, stream, lmc_key_value_cache_ptr,
-       vllm_key_value_cache_ptr, slot_mapping_ptr, vllm_block_stride,
-       vllm_value_offset, vllm_buffer_size, lmc_token_stride, lmc_value_offset,
-       lmc_buffer_size, max_tokens_per_loop, num_heads, head_dims, num_tokens,
-       block_size, direction, token_major]() -> int {
-        auto slot_num = vllm_ascend::get_dtype_from_torch(slot_type);
-        auto dtype_num = vllm_ascend::get_dtype_from_torch(scalar_type);
+  cmd.SetCustomHandler([config]() -> int {
+    auto slot_num = vllm_ascend::get_dtype_from_torch(config.slot_type);
+    auto dtype_num = vllm_ascend::get_dtype_from_torch(config.scalar_type);
 
-        kvcache_ops::single_layer_kv_transfer_kernel_v2(
-            dtype_num, slot_num, aiv_num, stream, lmc_key_value_cache_ptr,
-            vllm_key_value_cache_ptr, slot_mapping_ptr, vllm_block_stride,
-            vllm_value_offset, vllm_buffer_size, lmc_token_stride,
-            lmc_value_offset, lmc_buffer_size, max_tokens_per_loop, num_heads,
-            head_dims, num_tokens, block_size, direction, token_major);
-
-        return 0;
-      });
+    kvcache_ops::single_layer_kv_transfer_kernel_v2(
+        dtype_num, slot_num, config.aiv_num, config.stream,
+        config.lmc_cache_ptr, config.vllm_cache_ptr, config.slot_mapping_ptr,
+        config.vllm_block_stride, config.vllm_value_offset,
+        config.vllm_buffer_size, config.lmc_token_stride,
+        config.lmc_value_offset, config.lmc_buffer_size,
+        config.max_tokens_per_loop, config.num_heads, config.head_dims,
+        config.num_tokens, config.block_size, config.direction,
+        config.token_major);
+    return 0;
+  });
   cmd.Run();
   return;
 };
+
+void batched_fused_single_layer_kv_transfer(
+    std::vector<torch::Tensor>
+        &lmc_tensors, // N CPU pinned memory tensors
+                      // token_major=true:  [num_tokens, 2, num_heads*head_size]
+                      // token_major=false: [2, num_tokens, num_heads*head_size]
+    torch::Tensor &staging_cache, // NPU staging buffer
+                                  // token_major=true:  [num_tokens, 2,
+                                  // num_heads*head_size] token_major=false: [2,
+                                  // num_tokens, num_heads*head_size]
+    torch::Tensor
+        &vllm_key_value_cache,        // vllm_two_major=true:  [2, num_blocks,
+                                      // block_size, num_heads, head_size]
+                                      // vllm_two_major=false: [num_blocks, 2,
+                                      // block_size, num_heads, head_size]
+    torch::Tensor &slot_mapping_full, // [num_tokens]
+    std::vector<int64_t>
+        &chunk_offsets,                // token offset in staging for each chunk
+    std::vector<int64_t> &chunk_sizes, // token count for each chunk
+    const bool direction, // false: CPU -> staging -> paged (to_gpu) true: paged
+                          // -> staging -> CPU (from_gpu)
+    const bool
+        token_major, // true: [tokens, 2, hidden], false: [2, tokens, hidden]
+    const bool vllm_two_major // true: [2, blocks, ...], false: [blocks, 2, ...]
+) {
+  size_t num_chunks = lmc_tensors.size();
+  if (chunk_offsets.size() != num_chunks || chunk_sizes.size() != num_chunks) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "chunk_offsets and chunk_sizes must have the same size as lmc_tensors");
+    throw py::error_already_set();
+  }
+
+  if (num_chunks == 0) {
+    PyErr_SetString(
+        PyExc_ValueError,
+        "num_chunks must be greater than 0. Check 'starts' and 'ends' inputs.");
+    throw py::error_already_set();
+  }
+
+  for (size_t i = 0; i < num_chunks; ++i) {
+    if (lmc_tensors[i].is_cuda() ||
+        lmc_tensors[i].device().type() == c10::DeviceType::PrivateUse1) {
+      std::string errStr = "lmc_tensors[" + std::to_string(i) +
+                           "] must be on CPU (pinned memory)";
+      PyErr_SetString(PyExc_RuntimeError, errStr.c_str());
+      throw py::error_already_set();
+    }
+  }
+
+  SingleLayerKVConfig config = prepare_single_layer_kv_config(
+      staging_cache, vllm_key_value_cache, slot_mapping_full, direction,
+      token_major, vllm_two_major);
+
+  const c10::OptionalDeviceGuard slot_device_guard(
+      device_of(slot_mapping_full));
+  compute_single_layer_ub_params(config, vllm_key_value_cache);
+
+  compute_single_layer_strides(config, staging_cache, vllm_key_value_cache,
+                               token_major, vllm_two_major);
+
+  int64_t element_size = staging_cache.element_size();
+  int64_t bytes_per_token = config.lmc_token_stride * element_size;
+  int64_t staging_v_plane_offset = config.lmc_value_offset * element_size;
+
+  std::vector<uint8_t *> lmc_ptrs(num_chunks);
+  std::vector<int64_t> lmc_copy_sizes(num_chunks);
+  std::vector<int64_t> lmc_v_offsets(num_chunks);
+
+  for (size_t i = 0; i < num_chunks; ++i) {
+    lmc_ptrs[i] = static_cast<uint8_t *>(lmc_tensors[i].data_ptr());
+    lmc_copy_sizes[i] = chunk_sizes[i] * bytes_per_token;
+
+    if (!token_major) {
+      lmc_v_offsets[i] = lmc_tensors[i].stride(0) * element_size;
+    }
+  }
+
+  at_npu::native::OpCommand cmd;
+  cmd.Name("batched_fused_single_layer_kv_transfer_kernel_v2");
+  cmd.SetCustomHandler([config, num_chunks, lmc_ptrs, lmc_copy_sizes,
+                        chunk_offsets, bytes_per_token, staging_v_plane_offset,
+                        lmc_v_offsets]() -> int {
+    auto slot_num = vllm_ascend::get_dtype_from_torch(config.slot_type);
+    auto dtype_num = vllm_ascend::get_dtype_from_torch(config.scalar_type);
+    aclError ret;
+
+    // to_gpu (CPU -> staging -> paged)
+    if (!config.direction) {
+      // Step 1: Multiple H2D memcpy
+      for (size_t i = 0; i < num_chunks; ++i) {
+        uint8_t *staging_base =
+            config.lmc_cache_ptr + chunk_offsets[i] * bytes_per_token;
+        int64_t chunk_kv_bytes = lmc_copy_sizes[i];
+
+        if (config.token_major) {
+          ret = aclrtMemcpyAsync(staging_base, chunk_kv_bytes, lmc_ptrs[i],
+                                 chunk_kv_bytes, ACL_MEMCPY_HOST_TO_DEVICE,
+                                 config.stream);
+          TORCH_CHECK(ret == ACL_ERROR_NONE, "H2D memcpy failed for chunk ", i,
+                      ", ret=", ret);
+        } else {
+          // K plane
+          ret = aclrtMemcpyAsync(staging_base, chunk_kv_bytes, lmc_ptrs[i],
+                                 chunk_kv_bytes, ACL_MEMCPY_HOST_TO_DEVICE,
+                                 config.stream);
+          TORCH_CHECK(ret == ACL_ERROR_NONE, "H2D memcpy (K) failed for chunk ",
+                      i, ", ret=", ret);
+
+          // V plane
+          ret = aclrtMemcpyAsync(staging_base + staging_v_plane_offset,
+                                 chunk_kv_bytes, lmc_ptrs[i] + lmc_v_offsets[i],
+                                 chunk_kv_bytes, ACL_MEMCPY_HOST_TO_DEVICE,
+                                 config.stream);
+          TORCH_CHECK(ret == ACL_ERROR_NONE, "H2D memcpy (V) failed for chunk ",
+                      i, ", ret=", ret);
+        }
+      }
+
+      // Step 2: Scatter (staging -> paged KV cache)
+      kvcache_ops::single_layer_kv_transfer_kernel_v2(
+          dtype_num, slot_num, config.aiv_num, config.stream,
+          config.lmc_cache_ptr, config.vllm_cache_ptr, config.slot_mapping_ptr,
+          config.vllm_block_stride, config.vllm_value_offset,
+          config.vllm_buffer_size, config.lmc_token_stride,
+          config.lmc_value_offset, config.lmc_buffer_size,
+          config.max_tokens_per_loop, config.num_heads, config.head_dims,
+          config.num_tokens, config.block_size, false, config.token_major);
+    }
+    // from_gpu (paged -> staging -> CPU)
+    else {
+      // Step 1: Gather (paged -> staging)
+      kvcache_ops::single_layer_kv_transfer_kernel_v2(
+          dtype_num, slot_num, config.aiv_num, config.stream,
+          config.lmc_cache_ptr, config.vllm_cache_ptr, config.slot_mapping_ptr,
+          config.vllm_block_stride, config.vllm_value_offset,
+          config.vllm_buffer_size, config.lmc_token_stride,
+          config.lmc_value_offset, config.lmc_buffer_size,
+          config.max_tokens_per_loop, config.num_heads, config.head_dims,
+          config.num_tokens, config.block_size, true, config.token_major);
+
+      // Step 2: Multiple D2H memcpy
+      for (size_t i = 0; i < num_chunks; ++i) {
+        uint8_t *staging_base =
+            config.lmc_cache_ptr + chunk_offsets[i] * bytes_per_token;
+        int64_t chunk_kv_bytes = lmc_copy_sizes[i];
+
+        if (config.token_major) {
+          ret = aclrtMemcpyAsync(lmc_ptrs[i], chunk_kv_bytes, staging_base,
+                                 chunk_kv_bytes, ACL_MEMCPY_DEVICE_TO_HOST,
+                                 config.stream);
+          TORCH_CHECK(ret == ACL_ERROR_NONE, "D2H memcpy failed for chunk ", i,
+                      ", ret=", ret);
+        } else {
+          // K
+          ret = aclrtMemcpyAsync(lmc_ptrs[i], chunk_kv_bytes, staging_base,
+                                 chunk_kv_bytes, ACL_MEMCPY_DEVICE_TO_HOST,
+                                 config.stream);
+          TORCH_CHECK(ret == ACL_ERROR_NONE, "D2H memcpy (K) failed for chunk ",
+                      i, ", ret=", ret);
+
+          // V
+          ret = aclrtMemcpyAsync(lmc_ptrs[i] + lmc_v_offsets[i], chunk_kv_bytes,
+                                 staging_base + staging_v_plane_offset,
+                                 chunk_kv_bytes, ACL_MEMCPY_DEVICE_TO_HOST,
+                                 config.stream);
+          TORCH_CHECK(ret == ACL_ERROR_NONE, "D2H memcpy (V) failed for chunk ",
+                      i, ", ret=", ret);
+        }
+      }
+    }
+
+    return 0;
+  });
+  cmd.Run();
+  return;
+}
 
 void load_and_reshape_flash(
     torch::Tensor &key_value, // [2, num_layer, num_tokens, num_heads*head_size]

--- a/csrc/mem_kernels.h
+++ b/csrc/mem_kernels.h
@@ -57,6 +57,13 @@ void multi_layer_kv_transfer(
     const torch::Device &paged_memory_device, const int page_buffer_size,
     const bool direction, const bool use_mla, const int kvcache_format_raw);
 
+void fused_multi_layer_kv_transfer(
+    torch::Tensor &key_value,
+    torch::Tensor &staging_cache, // staging buffer
+    const torch::Tensor &key_value_ptrs, const torch::Tensor &slot_mapping,
+    const torch::Device &paged_memory_device, const int page_buffer_size,
+    const bool direction, const bool use_mla, const int kvcache_format_raw);
+
 void multi_layer_kv_transfer_310p(
     torch::Tensor &key_value,            // [kv, num_layer, num_tokens, hidden]
     const torch::Tensor &key_value_ptrs, // [num_layers]
@@ -76,6 +83,13 @@ void single_layer_kv_transfer(torch::Tensor &lmc_key_value_cache,
                               torch::Tensor &slot_mapping, const bool direction,
                               const bool token_major = false,
                               const bool vllm_two_major = false);
+
+void batched_fused_single_layer_kv_transfer(
+    std::vector<torch::Tensor> &lmc_tensors, torch::Tensor &staging_cache,
+    torch::Tensor &vllm_key_value_cache, torch::Tensor &slot_mapping_full,
+    std::vector<int64_t> &chunk_offsets, std::vector<int64_t> &chunk_sizes,
+    const bool direction, const bool token_major = false,
+    const bool vllm_two_major = false);
 
 void load_and_reshape_flash(torch::Tensor &key_value, torch::Tensor &key_cache,
                             torch::Tensor &value_cache,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -14,8 +14,11 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(c_ops, m) {
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
+  m.def("fused_multi_layer_kv_transfer", &fused_multi_layer_kv_transfer);
   m.def("multi_layer_kv_transfer_310p", &multi_layer_kv_transfer_310p);
   m.def("single_layer_kv_transfer", &single_layer_kv_transfer);
+  m.def("batched_fused_single_layer_kv_transfer",
+        &batched_fused_single_layer_kv_transfer);
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);
   m.def("load_and_reshape_flash", &load_and_reshape_flash);

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -3,6 +3,11 @@
 #include <stdexcept>
 #include <string>
 
+#include <Python.h>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
 namespace vllm_ascend {
 kvcache_ops::AscendType get_dtype_from_torch(at::ScalarType scalarType) {
   if (scalarType == at::ScalarType::Float) {
@@ -20,3 +25,199 @@ kvcache_ops::AscendType get_dtype_from_torch(at::ScalarType scalarType) {
   }
 }
 } // namespace vllm_ascend
+
+MultiLayerKVConfig prepare_multi_layer_kv_config(
+    const torch::Tensor &key_value, const torch::Tensor &key_value_ptrs,
+    const torch::Tensor &slot_mapping, const torch::Device &paged_memory_device,
+    int page_buffer_size, bool direction, bool use_mla,
+    int kvcache_format_raw) {
+  MultiLayerKVConfig config;
+
+  // it is actually a uint8_t**. we will reinterpret it inside the kernel
+  config.page_buffer_ptrs =
+      get_kernel_ptr<uint8_t, const torch::Tensor>(key_value_ptrs);
+  config.slot_mapping_ptr =
+      get_kernel_ptr<uint8_t, const torch::Tensor>(slot_mapping);
+
+  config.num_layers = key_value.size(1);
+  config.num_tokens = slot_mapping.size(0);
+  config.hidden_dims = key_value.size(-1);
+  config.kv_size = use_mla ? 1 : 2;
+
+  config.kvcache_format =
+      static_cast<kvcache_ops::KVCacheFormat>(kvcache_format_raw);
+
+  config.page_buffer_size = page_buffer_size;
+  config.direction = direction;
+
+  config.scalar_type = key_value.scalar_type();
+  config.slot_type = slot_mapping.scalar_type();
+
+  config.socName = aclrtGetSocName();
+
+  return config;
+}
+
+SingleLayerKVConfig prepare_single_layer_kv_config(
+    const torch::Tensor &lmc_cache, const torch::Tensor &vllm_cache,
+    const torch::Tensor &slot_mapping, bool direction, bool token_major,
+    bool vllm_two_major) {
+  SingleLayerKVConfig config;
+
+  config.lmc_cache_ptr =
+      get_kernel_ptr<uint8_t, const torch::Tensor>(lmc_cache);
+  config.vllm_cache_ptr =
+      get_kernel_ptr<uint8_t, const torch::Tensor>(vllm_cache);
+  config.slot_mapping_ptr =
+      get_kernel_ptr<uint8_t, const torch::Tensor>(slot_mapping);
+
+  config.num_tokens = slot_mapping.size(0);
+  config.num_heads = vllm_cache.size(-2);
+  config.head_dims = vllm_cache.size(-1);
+  config.block_size = vllm_cache.size(-3);
+  config.kv_size = 2;
+
+  bool is_mla = false;
+  if (token_major) {
+    is_mla = lmc_cache.size(1) == 1;
+  } else {
+    is_mla = lmc_cache.size(0) == 1;
+  }
+
+  if (is_mla) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "MLA is not supported yet. Please contact LMCache Ascend.");
+    throw py::error_already_set();
+  }
+
+  config.scalar_type = vllm_cache.scalar_type();
+  config.slot_type = slot_mapping.scalar_type();
+  config.socName = aclrtGetSocName();
+
+  config.direction = direction;
+  config.token_major = token_major;
+
+  config.lmc_buffer_size = static_cast<int64_t>(lmc_cache.nbytes());
+  config.vllm_buffer_size = static_cast<int64_t>(vllm_cache.nbytes());
+
+  return config;
+}
+
+void compute_multi_layer_ub_params(MultiLayerKVConfig &config,
+                                   const torch::Tensor &key_value,
+                                   const torch::Device &paged_memory_device,
+                                   const torch::Tensor &key_value_ptrs) {
+  const c10::OptionalDeviceGuard device_guard(paged_memory_device);
+  // we require the kv ptr list to be on the device too
+  const c10::OptionalDeviceGuard kv_device_guard(device_of(key_value_ptrs));
+
+  config.stream = c10_npu::getCurrentNPUStream().stream();
+
+  auto ascendcPlatform =
+      platform_ascendc::PlatformAscendCManager::GetInstance(config.socName);
+  uint64_t ubSize;
+  ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+  // we only launched with at most 4 aiv
+  config.aiv_num = static_cast<uint32_t>(std::min(config.num_layers, 4));
+
+  constexpr int32_t numBuffsOnDev = 2;
+  // step 1. use per tokens buff size to derive how many tokens can be allocated
+  // per loop
+  int64_t baseBuffSize =
+      numBuffsOnDev * config.hidden_dims * key_value.element_size();
+
+  if (ubSize < static_cast<uint64_t>(baseBuffSize)) {
+    std::string errStr =
+        "Per TokenBuffer Size: " + std::to_string(baseBuffSize) +
+        " exceeds UB Size: " + std::to_string(ubSize);
+    PyErr_SetString(PyExc_RuntimeError,
+                    (errStr + " Please contact us.").c_str());
+    throw py::error_already_set();
+  }
+
+  // step 2. work out how many tokens per loop
+  config.maxTokensPerLoop =
+      static_cast<int32_t>(ubSize / baseBuffSize) -
+      1; // Subtract 1 to provide a safety margin and avoid over-allocating the
+         // UB buffer, ensuring we do not exceed hardware limits due to possible
+         // rounding or small additional allocations.
+  config.maxTokensPerLoop = std::min(config.maxTokensPerLoop,
+                                     static_cast<int32_t>(config.num_tokens));
+
+  // step 3. double check whether the perloop buffer can accommodate everything
+  int64_t totalPerLoopBuffer =
+      static_cast<int64_t>(config.maxTokensPerLoop) * baseBuffSize;
+  if (ubSize < static_cast<uint64_t>(totalPerLoopBuffer)) {
+    std::string errStr =
+        "Per Loop Buffer Size: " + std::to_string(totalPerLoopBuffer) +
+        " exceeds UB Size: " + std::to_string(ubSize);
+    PyErr_SetString(PyExc_RuntimeError,
+                    (errStr + " Please contact us.").c_str());
+    throw py::error_already_set();
+  }
+
+  // using double buffs mean we actually want to allocate half of this per
+  // round.
+  config.singlePerLoopBuffer = totalPerLoopBuffer / numBuffsOnDev;
+}
+
+void compute_single_layer_ub_params(SingleLayerKVConfig &config,
+                                    const torch::Tensor &vllm_cache) {
+  const c10::OptionalDeviceGuard device_guard(device_of(vllm_cache));
+
+  config.stream = c10_npu::getCurrentNPUStream().stream();
+
+  auto ascendcPlatform =
+      platform_ascendc::PlatformAscendCManager::GetInstance(config.socName);
+  uint64_t ubSize;
+  ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+  config.aiv_num =
+      static_cast<uint32_t>(std::min(4, static_cast<int>(config.num_tokens)));
+
+  uint32_t numBuffsOnDev = 2;
+  // each token buffer is kv * heads * headdims * size
+  uint64_t baseBuffSize = numBuffsOnDev * config.kv_size * config.num_heads *
+                          config.head_dims * vllm_cache.element_size();
+
+  // first check whether one token k cache actually passes the ub
+  if (ubSize < baseBuffSize) {
+    std::string errStr =
+        "Per Token Cache Buffer Size: " + std::to_string(baseBuffSize) +
+        " exceeds UB Size: " + std::to_string(ubSize);
+    PyErr_SetString(PyExc_RuntimeError,
+                    (errStr + " Please contact LMCache Ascend.").c_str());
+    throw py::error_already_set();
+  }
+
+  // we are going to work out how many tokens to copy maximally per innerloop
+  config.max_tokens_per_loop = static_cast<int32_t>(ubSize / baseBuffSize);
+  config.max_tokens_per_loop =
+      std::min(config.max_tokens_per_loop, config.num_tokens);
+}
+
+void compute_single_layer_strides(SingleLayerKVConfig &config,
+                                  const torch::Tensor &lmc_cache,
+                                  const torch::Tensor &vllm_cache,
+                                  bool token_major, bool vllm_two_major) {
+  // LMC buffer strides
+  if (token_major) {
+    // [tokens, 2, heads*headdim]
+    config.lmc_token_stride = lmc_cache.stride(0);
+    config.lmc_value_offset = lmc_cache.stride(1);
+  } else {
+    // [2, tokens, heads*headdim]
+    config.lmc_token_stride = lmc_cache.stride(1);
+    config.lmc_value_offset = lmc_cache.stride(0);
+  }
+
+  // vLLM buffer strides
+  if (vllm_two_major) {
+    // [2, num_blocks, block_size, num_heads, head_size]
+    config.vllm_block_stride = vllm_cache.stride(1);
+    config.vllm_value_offset = vllm_cache.stride(0);
+  } else {
+    // [num_blocks, 2, block_size, num_heads, head_size]
+    config.vllm_block_stride = vllm_cache.stride(0);
+    config.vllm_value_offset = vllm_cache.stride(1);
+  }
+}

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -21,6 +21,9 @@
 #include <string>
 #include <torch/torch.h>
 
+#include "tiling/platform/platform_ascendc.h"
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+
 namespace vllm_ascend {
 kvcache_ops::AscendType get_dtype_from_torch(at::ScalarType scalarType);
 } // namespace vllm_ascend
@@ -45,3 +48,82 @@ T *get_kernel_ptr(TENSOR_TYPE &tensor) {
         "Invalid device. Device must be ascend (PrivateUseOne) or pinned cpu.");
   }
 }
+
+struct MultiLayerKVConfig {
+  uint8_t *page_buffer_ptrs;
+  uint8_t *slot_mapping_ptr;
+
+  int num_layers;
+  int num_tokens;
+  int hidden_dims;
+  int kv_size;
+
+  kvcache_ops::KVCacheFormat kvcache_format;
+
+  aclrtStream stream;
+  at::ScalarType scalar_type;
+  at::ScalarType slot_type;
+  const char *socName;
+
+  uint32_t aiv_num;
+  int32_t maxTokensPerLoop;
+  int64_t singlePerLoopBuffer;
+
+  int page_buffer_size;
+  bool direction;
+};
+
+MultiLayerKVConfig prepare_multi_layer_kv_config(
+    const torch::Tensor &key_value, const torch::Tensor &key_value_ptrs,
+    const torch::Tensor &slot_mapping, const torch::Device &paged_memory_device,
+    int page_buffer_size, bool direction, bool use_mla, int kvcache_format_raw);
+
+void compute_multi_layer_ub_params(MultiLayerKVConfig &config,
+                                   const torch::Tensor &key_value,
+                                   const torch::Device &paged_memory_device,
+                                   const torch::Tensor &key_value_ptrs);
+
+struct SingleLayerKVConfig {
+
+  uint8_t *lmc_cache_ptr;
+  uint8_t *vllm_cache_ptr;
+  uint8_t *slot_mapping_ptr;
+
+  int32_t num_tokens;
+  int32_t num_heads;
+  int32_t head_dims;
+  int32_t block_size;
+  int16_t kv_size;
+
+  aclrtStream stream;
+  at::ScalarType scalar_type;
+  at::ScalarType slot_type;
+  const char *socName;
+
+  uint32_t aiv_num;
+  int32_t max_tokens_per_loop;
+
+  int64_t lmc_token_stride;
+  int64_t lmc_value_offset;
+  int64_t vllm_block_stride;
+  int64_t vllm_value_offset;
+
+  int64_t lmc_buffer_size;
+  int64_t vllm_buffer_size;
+
+  bool direction;
+  bool token_major;
+};
+
+SingleLayerKVConfig prepare_single_layer_kv_config(
+    const torch::Tensor &lmc_cache, const torch::Tensor &vllm_cache,
+    const torch::Tensor &slot_mapping, bool direction, bool token_major,
+    bool vllm_two_major);
+
+void compute_single_layer_ub_params(SingleLayerKVConfig &config,
+                                    const torch::Tensor &vllm_cache);
+
+void compute_single_layer_strides(SingleLayerKVConfig &config,
+                                  const torch::Tensor &lmc_cache,
+                                  const torch::Tensor &vllm_cache,
+                                  bool token_major, bool vllm_two_major);

--- a/lmcache_ascend/mindspore/v1/npu_connector.py
+++ b/lmcache_ascend/mindspore/v1/npu_connector.py
@@ -50,9 +50,8 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         self.is_310p = is_310p()
 
     def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
-
         self.kv_format = KVCacheFormat.detect(kv_caches, use_mla=self.use_mla)
-        
+
         if self.kv_format == KVCacheFormat.UNDEFINED:
             raise ValueError(
                 "Undefined KV cache format detected. "

--- a/lmcache_ascend/v1/npu_connector.py
+++ b/lmcache_ascend/v1/npu_connector.py
@@ -66,8 +66,8 @@ class KVCacheFormat(Enum):
     @staticmethod
     def detect(
         kvcaches: List[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]],
-        use_mla: bool = False
-    ) -> 'KVCacheFormat':
+        use_mla: bool = False,
+    ) -> "KVCacheFormat":
         if not kvcaches:
             return KVCacheFormat.UNDEFINED
 
@@ -78,12 +78,14 @@ class KVCacheFormat(Enum):
         elif isinstance(first_cache, torch.Tensor):
             ndim = first_cache.ndim
             shape = first_cache.shape
-            
+
             # MLA detect
+            # MLA Shape: [num_blocks, block_size, head_size] (3D)
+            #         or: [1, num_blocks, block_size, head_size] (4D with first dim = 1)
             is_mla_shape = (ndim == 3) or (ndim == 4 and shape[0] == 1)
             if use_mla or is_mla_shape:
                 return KVCacheFormat.MERGED_KV
-            
+
             if shape[0] == 2:
                 return KVCacheFormat.MERGED_KV
 
@@ -121,9 +123,8 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             self.device = kwargs["device"]
 
     def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
-
         self.kv_format = KVCacheFormat.detect(kv_caches, use_mla=self.use_mla)
-        
+
         if self.kv_format == KVCacheFormat.UNDEFINED:
             raise ValueError(
                 "Undefined KV cache format detected. "
@@ -406,6 +407,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             raise ValueError("KV cache format is not initialized!")
 
         with torch.cuda.stream(self.store_stream):
+            # No staging buffer or token count mismatch
             if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
                 lmc_ops.multi_layer_kv_transfer(
                     memory_obj.tensor,
@@ -420,17 +422,17 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             else:
                 assert self.gpu_buffer.device == self.kvcaches_device
                 tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
-                lmc_ops.multi_layer_kv_transfer(
-                    tmp_gpu_buffer,
-                    kv_cache_pointers,
+                lmc_ops.fused_multi_layer_kv_transfer(
+                    memory_obj.tensor,  # dst: CPU buffer
+                    tmp_gpu_buffer,  # staging cache
+                    kv_cache_pointers,  # src: paged KV cache
                     slot_mapping[start:end],
                     self.kvcaches_device,
                     self.page_buffer_size,
-                    True,
+                    True,  # from_gpu
                     self.use_mla,
                     self.kv_format.value,  # 1:MERGED_KV / 2:SEPARATE_KV
                 )
-                memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
         if not memory_obj.tensor.is_cuda:
             # Force a synchronize if the target buffer is NOT CUDA device
@@ -508,20 +510,28 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
 
         num_tokens = len(slot_mapping_full)
 
+        chunk_offsets = []
+        chunk_sizes = []
+        current_offset = 0
+
+        for start, end in zip(starts, ends, strict=False):
+            chunk_size = end - start
+            chunk_sizes.append(chunk_size)
+            chunk_offsets.append(current_offset)
+            current_offset += chunk_size
+
+        tmp_gpu_buffer_obj: Optional[MemoryObj] = None
         if self.use_gpu:
             buffer_shape = self.get_shape(num_tokens)
             assert self.gpu_buffer_allocator is not None
-            tmp_gpu_buffer_obj: Optional[MemoryObj] = (
-                self.gpu_buffer_allocator.allocate(
-                    buffer_shape, self.dtype, MemoryFormat.KV_T2D
-                )
+            tmp_gpu_buffer_obj = self.gpu_buffer_allocator.allocate(
+                buffer_shape, self.dtype, MemoryFormat.KV_T2D
             )
             assert tmp_gpu_buffer_obj is not None, (
                 "Failed to allocate NPU buffer in NPUConnector"
             )
             assert tmp_gpu_buffer_obj.tensor is not None
 
-        offset = starts[0]
         current_stream = torch.cuda.current_stream()
 
         for layer_id in range(self.num_layers):
@@ -530,18 +540,33 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
                 current_stream.wait_stream(self.load_stream)
             if layer_id > 0:
                 logger.debug(f"Finished loading layer {layer_id - 1}")
-
             # memobj -> gpu_buffer -> kvcaches
             with torch.cuda.stream(self.load_stream):
-                for start, end, memory_obj in zip(
-                    starts, ends, memory_objs_layer, strict=False
-                ):
-                    assert memory_obj.metadata.fmt == MemoryFormat.KV_T2D
-                    if self.use_gpu:
-                        tmp_gpu_buffer_obj.tensor[start - offset : end - offset].copy_(
-                            memory_obj.tensor, non_blocking=True
-                        )
-                    else:
+                if self.use_gpu:
+                    cpu_tensors = []
+                    for memory_obj in memory_objs_layer:
+                        assert memory_obj.tensor is not None
+                        assert memory_obj.metadata.fmt == MemoryFormat.KV_T2D
+                        cpu_tensors.append(memory_obj.tensor)
+
+                    # Fused transfer: N H2D memcpy + 1 scatter kernel
+                    lmc_ops.batched_fused_single_layer_kv_transfer(
+                        cpu_tensors,  # CPU memory objects
+                        tmp_gpu_buffer_obj.tensor,  # GPU staging buffer
+                        self.kvcaches[layer_id],  # paged KV cache
+                        slot_mapping_full,
+                        chunk_offsets,  # offset for each chunk
+                        chunk_sizes,  # size for each chunk
+                        False,  # to_gpu
+                        True,  # token_major
+                        self.vllm_two_major,
+                    )
+
+                else:
+                    for start, end, memory_obj in zip(
+                        starts, ends, memory_objs_layer, strict=False
+                    ):
+                        assert memory_obj.tensor is not None
                         lmc_ops.single_layer_kv_transfer(
                             memory_obj.tensor,
                             self.kvcaches[layer_id],
@@ -551,15 +576,6 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
                             self.vllm_two_major,
                         )
 
-                if self.use_gpu:
-                    lmc_ops.single_layer_kv_transfer(
-                        tmp_gpu_buffer_obj.tensor,
-                        self.kvcaches[layer_id],
-                        slot_mapping_full,
-                        False,
-                        True,
-                        self.vllm_two_major,
-                    )
         yield
 
         # synchronize the last layer
@@ -567,7 +583,7 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
             current_stream.wait_stream(self.load_stream)
 
         # free the buffer memory
-        if self.use_gpu:
+        if self.use_gpu and tmp_gpu_buffer_obj is not None:
             tmp_gpu_buffer_obj.ref_count_down()
 
         logger.debug(f"Finished loading layer {layer_id}")
@@ -627,20 +643,28 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
 
         num_tokens = len(slot_mapping_full)
 
+        chunk_offsets = []
+        chunk_sizes = []
+        current_offset = 0
+
+        for start, end in zip(starts, ends, strict=False):
+            chunk_size = end - start
+            chunk_sizes.append(chunk_size)
+            chunk_offsets.append(current_offset)
+            current_offset += chunk_size
+
+        tmp_gpu_buffer_obj: Optional[MemoryObj] = None
         if self.use_gpu:
             buffer_shape = self.get_shape(num_tokens)
             assert self.gpu_buffer_allocator is not None
-            tmp_gpu_buffer_obj: Optional[MemoryObj] = (
-                self.gpu_buffer_allocator.allocate(
-                    buffer_shape, self.dtype, MemoryFormat.KV_T2D
-                )
+            tmp_gpu_buffer_obj = self.gpu_buffer_allocator.allocate(
+                buffer_shape, self.dtype, MemoryFormat.KV_T2D
             )
             assert tmp_gpu_buffer_obj is not None, (
                 "Failed to allocate NPU buffer in NPUConnector"
             )
             assert tmp_gpu_buffer_obj.tensor is not None
 
-        offset = starts[0]
         current_stream = torch.cuda.current_stream()
 
         for layer_id in range(self.num_layers):
@@ -648,25 +672,30 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
             # kvcaches -> gpu_buffer -> memobj
             with torch.cuda.stream(self.store_stream):
                 self.store_stream.wait_stream(current_stream)
+
                 if self.use_gpu:
-                    lmc_ops.single_layer_kv_transfer(
+                    cpu_tensors = []
+                    for memory_obj in memory_objs_layer:
+                        assert memory_obj.tensor is not None
+                        cpu_tensors.append(memory_obj.tensor)
+
+                    # Fused transfer: 1 scatter kernel + N D2H memcpy
+                    lmc_ops.batched_fused_single_layer_kv_transfer(
+                        cpu_tensors,
                         tmp_gpu_buffer_obj.tensor,
                         self.kvcaches[layer_id],
                         slot_mapping_full,
-                        True,
-                        True,
+                        chunk_offsets,
+                        chunk_sizes,
+                        True,  # from_gpu
+                        True,  # token_major
                         self.vllm_two_major,
                     )
-                for start, end, memory_obj in zip(
-                    starts, ends, memory_objs_layer, strict=False
-                ):
-                    assert memory_obj.tensor is not None
-                    if self.use_gpu:
-                        memory_obj.tensor.copy_(
-                            tmp_gpu_buffer_obj.tensor[start - offset : end - offset],
-                            non_blocking=True,
-                        )
-                    else:
+                else:
+                    for start, end, memory_obj in zip(
+                        starts, ends, memory_objs_layer, strict=False
+                    ):
+                        assert memory_obj.tensor is not None
                         lmc_ops.single_layer_kv_transfer(
                             memory_obj.tensor,
                             self.kvcaches[layer_id],
@@ -675,13 +704,14 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
                             True,
                             self.vllm_two_major,
                         )
-
             yield
+
             if sync:
                 self.store_stream.synchronize()
+
             logger.debug(f"Finished offloading layer {layer_id}")
 
         # free the buffer memory
-        if self.use_gpu:
+        if self.use_gpu and tmp_gpu_buffer_obj is not None:
             tmp_gpu_buffer_obj.ref_count_down()
         yield

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -256,6 +256,281 @@ def test_multi_layer_kernel_kvcache_separate_fmt(
     mem_allocator.close()
 
 
+@pytest.mark.parametrize("num_tokens", [256, 500, 1024, 2048])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("chunk_size", [256, 512])
+@pytest.mark.parametrize("num_layers", [1, 32])
+@pytest.mark.parametrize("block_size", [128])
+@pytest.mark.parametrize("head_size", [256])
+def test_fused_multi_layer_kvcache_merged_fmt(
+    num_tokens, num_heads, chunk_size, num_layers, block_size, head_size
+):
+    """
+    - from_gpu: Verify that the output of the fused method is
+      consistent with the baseline method.
+    - to_gpu: Verify that the KV cache content is correct
+      after data is written back.
+    """
+    device = "npu"
+    num_blocks = 256
+    dtype = torch.bfloat16
+    kvs = 2
+    hidden_dim_size = num_heads * head_size
+
+    kv_cache = generate_kv_cache_paged_list_tensors(
+        num_blocks, device, num_layers, num_heads, head_size, block_size, dtype
+    )
+    page_buffer_size = num_blocks * block_size
+
+    slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping, device=device)
+    slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
+
+    pinned_cpu_size = 4 * 1024 * 1024 * 1024  # 4GB
+    mem_allocator = PinMemoryAllocator(pinned_cpu_size)
+
+    # kv_cache_pointers
+    kv_cache_pointers = torch.empty(
+        num_layers, dtype=torch.int64, device="cpu", pin_memory=True
+    )
+    for i in range(num_layers):
+        kv_cache_pointers[i] = kv_cache[i].data_ptr()
+    kv_cache_pointers = kv_cache_pointers.npu()
+
+    # Staging buffer for fused method
+    staging_buffer = torch.empty(
+        [kvs, num_layers, chunk_size, hidden_dim_size], dtype=dtype, device=device
+    )
+
+    # from_gpu: Baseline method for data extraction
+    memory_obj_baseline_list = []
+    start_event = torch.npu.Event(enable_timing=True)
+    end_event = torch.npu.Event(enable_timing=True)
+    start_event.record()
+
+    for slot_temp in slot_mapping_chunked:
+        mem_obj_shape = [kvs, num_layers, len(slot_temp), hidden_dim_size]
+        memory_obj = mem_allocator.allocate(mem_obj_shape, dtype)
+        lmc_ops.multi_layer_kv_transfer(
+            memory_obj.tensor,
+            kv_cache_pointers,
+            slot_temp,
+            kv_cache[0].device,
+            page_buffer_size,
+            True,  # from_gpu
+            False,
+            1,  # MERGED_KV
+        )
+        memory_obj_baseline_list.append(memory_obj)
+
+    end_event.record()
+    torch.npu.synchronize()
+    elapsed_time_ms = start_event.elapsed_time(end_event)
+    print(f"\nBaseline from_gpu time: {elapsed_time_ms:.6f} ms")
+
+    # from_gpu: Fused method for data extraction
+    memory_obj_fused_list = []
+    start_event = torch.npu.Event(enable_timing=True)
+    end_event = torch.npu.Event(enable_timing=True)
+    start_event.record()
+
+    for slot_temp in slot_mapping_chunked:
+        mem_obj_shape = [kvs, num_layers, len(slot_temp), hidden_dim_size]
+        memory_obj = mem_allocator.allocate(mem_obj_shape, dtype)
+        staging_cache = staging_buffer[:, :, : len(slot_temp), :]
+        lmc_ops.fused_multi_layer_kv_transfer(
+            memory_obj.tensor,
+            staging_cache,
+            kv_cache_pointers,
+            slot_temp,
+            kv_cache[0].device,
+            page_buffer_size,
+            True,  # from_gpu
+            False,
+            1,  # MERGED_KV
+        )
+        memory_obj_fused_list.append(memory_obj)
+
+    end_event.record()
+    torch.npu.synchronize()
+    elapsed_time_ms = start_event.elapsed_time(end_event)
+    print(f"Fused from_gpu time: {elapsed_time_ms:.6f} ms")
+
+    check_mem_obj_equal(memory_obj_baseline_list, memory_obj_fused_list)
+
+    kv_cache_new = generate_kv_cache_paged_list_tensors(
+        num_blocks, device, num_layers, num_heads, head_size, block_size, dtype
+    )
+
+    kv_cache_pointers_new = torch.empty(
+        num_layers, dtype=torch.int64, device="cpu", pin_memory=True
+    )
+    for i in range(num_layers):
+        kv_cache_pointers_new[i] = kv_cache_new[i].data_ptr()
+    kv_cache_pointers_new = kv_cache_pointers_new.npu()
+
+    for chunk_id, slot_temp in enumerate(slot_mapping_chunked):
+        lmc_ops.multi_layer_kv_transfer(
+            memory_obj_fused_list[chunk_id].tensor,
+            kv_cache_pointers_new,
+            slot_temp,
+            kv_cache_new[0].device,
+            page_buffer_size,
+            False,  # to_gpu
+            False,
+            1,  # MERGED_KV
+        )
+
+    check_paged_kv_cache_equal(
+        kv_cache,
+        kv_cache_new,
+        slot_mapping,
+        num_heads=num_heads,
+        head_size=head_size,
+    )
+
+    mem_allocator.close()
+
+
+@pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("chunk_size", [256, 512])
+@pytest.mark.parametrize("num_layers", [1, 32])
+@pytest.mark.parametrize("block_size", [16])
+@pytest.mark.parametrize("head_size", [128])
+def test_fused_multi_layer_kvcache_separate_fmt(
+    num_tokens, num_heads, chunk_size, num_layers, block_size, head_size
+):
+    """
+    - from_gpu: Verify that the output of the fused method is
+      consistent with the baseline method.
+    - to_gpu: Verify that the KV cache content is correct
+      after data is written back.
+    """
+    device = "npu"
+    num_blocks = 1000
+    dtype = torch.bfloat16
+    kvs = 2
+    hidden_dim_size = num_heads * head_size
+
+    kv_cache = generate_kv_cache_paged_list_tuple_tensors(
+        num_blocks, device, num_layers, num_heads, head_size, block_size, dtype
+    )
+    page_buffer_size = num_blocks * block_size
+
+    slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping, device=device)
+    slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
+
+    pinned_cpu_size = 4 * 1024 * 1024 * 1024  # 4GB
+    mem_allocator = PinMemoryAllocator(pinned_cpu_size)
+
+    kv_cache_pointers = torch.empty(
+        num_layers * 2, dtype=torch.int64, device="cpu", pin_memory=True
+    )
+
+    for i in range(num_layers):
+        kv_cache_pointers[i * 2 + 0] = kv_cache[i][0].data_ptr()  # Key pointer
+        kv_cache_pointers[i * 2 + 1] = kv_cache[i][1].data_ptr()  # Value pointer
+    kv_cache_pointers = kv_cache_pointers.npu()
+
+    # Staging buffer for fused method
+    staging_buffer = torch.empty(
+        [kvs, num_layers, chunk_size, hidden_dim_size], dtype=dtype, device=device
+    )
+
+    # from_gpu: Baseline method for data extraction
+    memory_obj_baseline_list = []
+    start_event = torch.npu.Event(enable_timing=True)
+    end_event = torch.npu.Event(enable_timing=True)
+    start_event.record()
+
+    for slot_temp in slot_mapping_chunked:
+        mem_obj_shape = [kvs, num_layers, len(slot_temp), hidden_dim_size]
+        memory_obj = mem_allocator.allocate(mem_obj_shape, dtype)
+        lmc_ops.multi_layer_kv_transfer(
+            memory_obj.tensor,
+            kv_cache_pointers,
+            slot_temp,
+            kv_cache[0][0].device,
+            page_buffer_size,
+            True,  # from_gpu
+            False,
+            2,  # SEPARATE_KV
+        )
+        memory_obj_baseline_list.append(memory_obj)
+
+    end_event.record()
+    torch.npu.synchronize()
+    elapsed_time_ms = start_event.elapsed_time(end_event)
+    print(f"\nBaseline from_gpu time: {elapsed_time_ms:.6f} ms")
+
+    # from_gpu: Fused method for data extraction
+    memory_obj_fused_list = []
+    start_event = torch.npu.Event(enable_timing=True)
+    end_event = torch.npu.Event(enable_timing=True)
+    start_event.record()
+
+    for slot_temp in slot_mapping_chunked:
+        mem_obj_shape = [kvs, num_layers, len(slot_temp), hidden_dim_size]
+        memory_obj = mem_allocator.allocate(mem_obj_shape, dtype)
+        staging_cache = staging_buffer[:, :, : len(slot_temp), :]
+        lmc_ops.fused_multi_layer_kv_transfer(
+            memory_obj.tensor,
+            staging_cache,
+            kv_cache_pointers,
+            slot_temp,
+            kv_cache[0][0].device,
+            page_buffer_size,
+            True,  # from_gpu
+            False,
+            2,  # SEPARATE_KV
+        )
+        memory_obj_fused_list.append(memory_obj)
+
+    end_event.record()
+    torch.npu.synchronize()
+    elapsed_time_ms = start_event.elapsed_time(end_event)
+    print(f"Fused from_gpu time: {elapsed_time_ms:.6f} ms")
+
+    check_mem_obj_equal(memory_obj_baseline_list, memory_obj_fused_list)
+
+    kv_cache_new = generate_kv_cache_paged_list_tuple_tensors(
+        num_blocks, device, num_layers, num_heads, head_size, block_size, dtype
+    )
+
+    kv_cache_pointers_new = torch.empty(
+        num_layers * 2, dtype=torch.int64, device="cpu", pin_memory=True
+    )
+
+    for i in range(num_layers):
+        kv_cache_pointers_new[i * 2 + 0] = kv_cache_new[i][0].data_ptr()
+        kv_cache_pointers_new[i * 2 + 1] = kv_cache_new[i][1].data_ptr()
+    kv_cache_pointers_new = kv_cache_pointers_new.npu()
+
+    for chunk_id, slot_temp in enumerate(slot_mapping_chunked):
+        lmc_ops.multi_layer_kv_transfer(
+            memory_obj_fused_list[chunk_id].tensor,
+            kv_cache_pointers_new,
+            slot_temp,
+            kv_cache_new[0][0].device,
+            page_buffer_size,
+            False,  # to_gpu
+            False,
+            2,  # SEPARATE_KV
+        )
+
+    check_paged_kv_cache_equal(
+        kv_cache,
+        kv_cache_new,
+        slot_mapping,
+        num_heads=num_heads,
+        head_size=head_size,
+    )
+
+    mem_allocator.close()
+
+
 # TODO: MLA is not supported for layerwise yet
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 @pytest.mark.parametrize("num_layers", [1, 32])
@@ -337,3 +612,275 @@ def test_single_layer_kernel(
         head_size=head_size,
         vllm_two_major=vllm_two_major,
     )
+
+
+# TODO: MLA is not supported for layerwise yet
+@pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
+@pytest.mark.parametrize("num_layers", [1, 32])
+@pytest.mark.parametrize("num_chunks", [1, 3, 5])
+@pytest.mark.parametrize("num_blocks", [1000])
+@pytest.mark.parametrize("block_size", [16])
+@pytest.mark.parametrize("num_heads", [8])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("token_major", [True, False])
+@pytest.mark.parametrize("vllm_two_major", [True, False])
+def test_batched_fused_single_layer_kernel(
+    num_tokens,
+    num_layers,
+    num_chunks,
+    num_blocks,
+    block_size,
+    num_heads,
+    head_size,
+    token_major,
+    vllm_two_major,
+):
+    """
+    - Baseline: 1 kernel call + N torch.copy_ calls
+    - Batched fusion: batched_fused_single_layer_kv_transfer
+    """
+    device = "npu"
+    kvs = 2
+    hidden_dim_size = num_heads * head_size
+    dtype = torch.bfloat16
+
+    # Compute chunk partitioning
+    base_chunk_size = num_tokens // num_chunks
+    remainder = num_tokens % num_chunks
+
+    chunk_sizes = []
+    chunk_offsets = []
+    current_offset = 0
+
+    for i in range(num_chunks):
+        size = base_chunk_size + (1 if i < remainder else 0)
+        chunk_sizes.append(size)
+        chunk_offsets.append(current_offset)
+        current_offset += size
+
+    kv_cache_src = generate_kv_cache_paged_list_tensors(
+        num_blocks,
+        device,
+        num_layers,
+        num_heads,
+        head_size,
+        block_size,
+        dtype,
+        vllm_two_major=vllm_two_major,
+    )
+
+    kv_cache_dst_baseline = generate_kv_cache_paged_list_tensors(
+        num_blocks,
+        device,
+        num_layers,
+        num_heads,
+        head_size,
+        block_size,
+        dtype,
+        vllm_two_major=vllm_two_major,
+    )
+
+    kv_cache_dst_fused = generate_kv_cache_paged_list_tensors(
+        num_blocks,
+        device,
+        num_layers,
+        num_heads,
+        head_size,
+        block_size,
+        dtype,
+        vllm_two_major=vllm_two_major,
+    )
+
+    slot_mapping_list = random.sample(range(0, num_blocks * block_size), num_tokens)
+    slot_mapping_full = torch.tensor(slot_mapping_list, device=device)
+
+    # Buffer shapes
+    def get_buffer_shape(n_tokens):
+        if token_major:
+            return (n_tokens, kvs, hidden_dim_size)
+        else:
+            return (kvs, n_tokens, hidden_dim_size)
+
+    full_buffer_shape = get_buffer_shape(num_tokens)
+    chunk_buffer_shapes = [get_buffer_shape(chunk_sizes[i]) for i in range(num_chunks)]
+
+    # Staging buffers
+    staging_cache_baseline = torch.empty(full_buffer_shape, dtype=dtype, device=device)
+    staging_cache_fused = torch.empty(full_buffer_shape, dtype=dtype, device=device)
+
+    total_cpu_bytes = 0
+    for chunk_size in chunk_sizes:
+        chunk_bytes = chunk_size * kvs * hidden_dim_size * torch.finfo(dtype).bits // 8
+        total_cpu_bytes += chunk_bytes * num_layers
+    total_cpu_bytes *= 2
+    total_cpu_bytes = int(total_cpu_bytes * 1.2)
+
+    mem_allocator = PinMemoryAllocator(total_cpu_bytes)
+
+    try:
+
+        def create_chunked_cpu_buffers():
+            cpu_memory_objs = []
+            cpu_tensors = []
+            for layer_id in range(num_layers):
+                layer_memory_objs = []
+                layer_tensors = []
+                for chunk_id in range(num_chunks):
+                    chunk_shape = list(chunk_buffer_shapes[chunk_id])
+                    memory_obj = mem_allocator.allocate(chunk_shape, dtype)
+                    layer_memory_objs.append(memory_obj)
+                    layer_tensors.append(memory_obj.tensor)
+                cpu_memory_objs.append(layer_memory_objs)
+                cpu_tensors.append(layer_tensors)
+            return cpu_memory_objs, cpu_tensors
+
+        cpu_mem_objs_baseline, cpu_baseline = create_chunked_cpu_buffers()
+        cpu_mem_objs_fused, cpu_fused = create_chunked_cpu_buffers()
+
+        # from_gpu: Baseline
+        start_event = torch.npu.Event(enable_timing=True)
+        end_event = torch.npu.Event(enable_timing=True)
+        start_event.record()
+
+        for layer_id in range(num_layers):
+            lmc_ops.single_layer_kv_transfer(
+                staging_cache_baseline,
+                kv_cache_src[layer_id],
+                slot_mapping_full,
+                True,
+                token_major,
+                vllm_two_major,
+            )
+
+            for chunk_id in range(num_chunks):
+                offset = chunk_offsets[chunk_id]
+                chunk_size = chunk_sizes[chunk_id]
+
+                if token_major:
+                    staging_chunk = staging_cache_baseline[offset : offset + chunk_size]
+                else:
+                    staging_chunk = staging_cache_baseline[
+                        :, offset : offset + chunk_size
+                    ]
+
+                cpu_baseline[layer_id][chunk_id].copy_(staging_chunk, non_blocking=True)
+
+        end_event.record()
+        torch.npu.synchronize()
+        baseline_from_time = start_event.elapsed_time(end_event)
+
+        # from_gpu: Batched Fused
+        start_event.record()
+
+        for layer_id in range(num_layers):
+            lmc_ops.batched_fused_single_layer_kv_transfer(
+                cpu_fused[layer_id],
+                staging_cache_fused,
+                kv_cache_src[layer_id],
+                slot_mapping_full,
+                chunk_offsets,
+                chunk_sizes,
+                True,
+                token_major,
+                vllm_two_major,
+            )
+
+        end_event.record()
+        torch.npu.synchronize()
+        fused_from_time = start_event.elapsed_time(end_event)
+
+        print(
+            f"\n[from_gpu] Baseline: {baseline_from_time:.3f} ms, "
+            f"Fused: {fused_from_time:.3f} ms"
+        )
+
+        # Verify from_gpu correctness
+        for layer_id in range(num_layers):
+            for chunk_id in range(num_chunks):
+                assert torch.equal(
+                    cpu_baseline[layer_id][chunk_id], cpu_fused[layer_id][chunk_id]
+                ), f"from_gpu mismatch at layer={layer_id}, chunk={chunk_id}"
+
+        # to_gpu: Baseline
+        start_event.record()
+
+        for layer_id in range(num_layers):
+            for chunk_id in range(num_chunks):
+                offset = chunk_offsets[chunk_id]
+                chunk_size = chunk_sizes[chunk_id]
+
+                if token_major:
+                    staging_chunk = staging_cache_baseline[offset : offset + chunk_size]
+                else:
+                    staging_chunk = staging_cache_baseline[
+                        :, offset : offset + chunk_size
+                    ]
+
+                staging_chunk.copy_(cpu_baseline[layer_id][chunk_id], non_blocking=True)
+
+            lmc_ops.single_layer_kv_transfer(
+                staging_cache_baseline,
+                kv_cache_dst_baseline[layer_id],
+                slot_mapping_full,
+                False,
+                token_major,
+                vllm_two_major,
+            )
+
+        end_event.record()
+        torch.npu.synchronize()
+        baseline_to_time = start_event.elapsed_time(end_event)
+
+        # to_gpu: Batched Fused
+        start_event.record()
+
+        for layer_id in range(num_layers):
+            lmc_ops.batched_fused_single_layer_kv_transfer(
+                cpu_baseline[layer_id],
+                staging_cache_fused,
+                kv_cache_dst_fused[layer_id],
+                slot_mapping_full,
+                chunk_offsets,
+                chunk_sizes,
+                False,
+                token_major,
+                vllm_two_major,
+            )
+
+        end_event.record()
+        torch.npu.synchronize()
+        fused_to_time = start_event.elapsed_time(end_event)
+
+        print(
+            f"\n[to_gpu] Baseline: {baseline_to_time:.3f} ms, "
+            f"Fused: {fused_to_time:.3f} ms"
+        )
+
+        check_paged_kv_cache_equal(
+            kv_cache_src,
+            kv_cache_dst_baseline,
+            slot_mapping_full,
+            num_heads=num_heads,
+            head_size=head_size,
+            vllm_two_major=vllm_two_major,
+        )
+
+        check_paged_kv_cache_equal(
+            kv_cache_src,
+            kv_cache_dst_fused,
+            slot_mapping_full,
+            num_heads=num_heads,
+            head_size=head_size,
+            vllm_two_major=vllm_two_major,
+        )
+
+    finally:
+        mem_allocator.close()
+        del kv_cache_src
+        del kv_cache_dst_baseline
+        del kv_cache_dst_fused
+        del staging_cache_baseline
+        del staging_cache_fused
+        del cpu_baseline
+        del cpu_fused
+        torch.npu.empty_cache()


### PR DESCRIPTION
## Changes
- Performance Optimization: Replaced NativeTorch copy + kernel transfer with a Staging Copy (C++ host-side memcpy) strategy. 
- Bug Fix: Fixed the KV Cache format detection logic specifically when using MLA

## Fix and Related issue
- Related to #60 
- Fixes #111 

## Testing
Verified functionality and performance on:
- vLLM 0.10.2: Tested with both multi_layer and layerwise modes.
- vLLM 0.11.0rc1: Tested with multi_layer mode. (not support layerwise now)

## ToDo
- [ ] Add support for Ascend 310P.
- [ ] Adapt layerwise mode for vLLM 0.11.x.