### PR TITLE
Remove redundant std::endl in error handling

### DIFF
--- a/csrc/common/managed_mem.cpp
+++ b/csrc/common/managed_mem.cpp
@@ -93,7 +93,6 @@ HostRegisteredMemoryManager::halRegisterHostPtr(void *hostPtr,
   if (drvRet != 0) {
     std::cerr << "Unable to halHostRegister: " << drvRet
               << " . Please ensure your driver version >= 24.1.0" << std::endl;
-    std::endl;
     return nullptr;
   }
 


### PR DESCRIPTION
Removed unnecessary std::endl statement after error message.