### PR TITLE
Update badge label from 'CI' to 'CodeQuality'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   LMCache-Ascend Plugin
   </h3>
 
-  [![CodeQuality](https://github.com/LMCache/LMCache-Ascend/actions/workflows/code-quality.yml/badge.svg?branch=main)](https://github.com/LMCache/LMCache-Ascend/actions/workflows/code-quality.yml)
+  [![Code Quality](https://github.com/LMCache/LMCache-Ascend/actions/workflows/code-quality.yml/badge.svg?branch=main)](https://github.com/LMCache/LMCache-Ascend/actions/workflows/code-quality.yml)
 
   <br />
 


### PR DESCRIPTION
This pull request makes a minor change to the `README.md` file, updating the CI badge label from "CI" to "CodeQuality" for improved clarity.