### PR TITLE
Update branches in build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:   
   workflow_run:
     workflows: ["Code Quality"]
-    branches: [main, '*-dev']
     types: [completed]
 
 permissions:


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by removing the branch filter from the `workflow_run` trigger in `.github/workflows/build-and-test.yml`. This means the workflow will run for all branches when the "Code Quality" workflow completes.' branches from workflow_run.