### PR TITLE
Specify environment for unit tests on 910B

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,10 @@ jobs:
     name: Unit Tests on 910B
     runs-on: [self-hosted, Linux, ARM64, 910b4]
     timeout-minutes: 30
+
+    environment: 
+      name: 910b-hardware
+    
     if: >
       github.event_name != 'workflow_run' || 
       github.event.workflow_run.conclusion == 'success'


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by specifying an environment for the unit test job on 910B hardware.

- Workflow configuration:
  * In `.github/workflows/build-and-test.yml`, the `Unit Tests on 910B` job now specifies the environment `910b-hardware`, which can help with environment-specific secrets or protection rules.