### PR TITLE
Attach two devices to enable p2p test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,7 @@ jobs:
         --label owner=ci-test-runner
         --add-host=host.docker.internal:192.168.1.1
         --device /dev/davinci0
+        --device /dev/davinci1
         --device /dev/davinci_manager
         --device /dev/devmm_svm
         --device /dev/hisi_hdc


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by adding an additional device to the CI test runner configuration.

* CI/CD configuration:
  * [`.github/workflows/build-and-test.yml`]: Added `--device /dev/davinci1` to the list of devices made available in the CI test runner container.