### PR TITLE
Minor P2P sharing clarifications

### DIFF
--- a/examples/kv_cache_reuse/share_across_instances/p2p_sharing/README.md
+++ b/examples/kv_cache_reuse/share_across_instances/p2p_sharing/README.md
@@ -68,7 +68,7 @@ This example demonstrates how to run LMCache with P2P KV Cache Sharing using HCC
 
 ### Usage
 
-Prerequisites: ensure the LMCache config files are correctly configured for the desired paralellism level. To use P2P KV Cache Sharing across hosts, substitute `localhost` with the IP of the corresponding server.
+Prerequisites: ensure the LMCache config files are correctly configured for the desired parallelism level. To use P2P KV Cache Sharing across hosts, substitute localhost with the IP of the corresponding server.
 
 
 Launch controller


### PR DESCRIPTION
Minor doc fixes and clarifications on running P2P KV cache sharing across hosts.