### PR TITLE
Move the log info to right code block

### DIFF
--- a/lmcache_ascend/v1/npu_connector.py
+++ b/lmcache_ascend/v1/npu_connector.py
@@ -1101,7 +1101,7 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
                             True,
                             self.vllm_two_major,
                         )
-
+                logger.debug(f"Finished loading layer {layer_id}")
         yield
 
         # synchronize the last layer
@@ -1112,7 +1112,6 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
         if self.use_gpu and tmp_gpu_buffer_obj is not None:
             tmp_gpu_buffer_obj.ref_count_down()
 
-        logger.debug(f"Finished loading layer {layer_id}")
         yield
 
     def batched_from_gpu(
@@ -1233,12 +1232,11 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
                             True,
                             self.vllm_two_major,
                         )
+                logger.debug(f"Finished offloading layer {layer_id}")
             yield
 
             if sync:
                 self.store_stream.synchronize()
-
-            logger.debug(f"Finished offloading layer {layer_id}")
 
         # free the buffer memory
         if self.use_gpu and tmp_gpu_buffer_obj is not None:


### PR DESCRIPTION
Move the log info to right code block, local variable 'layer_id' can't be referenced before assignment.