### PR TITLE
Fix failed to register memory

### DIFF
--- a/examples/kv_cache_reuse/share_across_instances/p2p_sharing/README.md
+++ b/examples/kv_cache_reuse/share_across_instances/p2p_sharing/README.md
@@ -86,7 +86,7 @@ export VLLM_ENABLE_V1_MULTIPROCESSING=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export PYTHONHASHSEED=123
 export VLLM_VERSION=0.11.0
-export LMCACHE_MAX_LOCAL_CPU_SIZE=72
+export LMCACHE_MAX_LOCAL_CPU_SIZE=16
 python \
     -m vllm.entrypoints.openai.api_server \
     --port 8010 \
@@ -110,7 +110,7 @@ export VLLM_ENABLE_V1_MULTIPROCESSING=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export PYTHONHASHSEED=123
 export VLLM_VERSION=0.11.0
-export LMCACHE_MAX_LOCAL_CPU_SIZE=72
+export LMCACHE_MAX_LOCAL_CPU_SIZE=16
 python \
     -m vllm.entrypoints.openai.api_server \
     --port 8011 \


### PR DESCRIPTION

Met `RuntimeError: Failed to register memory | HCCL Error Code: 19` when try to run p2p sharing example, and tried to add some debug code. it seems that hccl can't regist host memory when the size is bigger then the npu card(64GB). So I tried to reduce `LMCACHE_MAX_LOCAL_CPU_SIZE` from 72 to 16, then the p2p sharing example run success.

Tracktrace
```
[root@pod-1458388014826762240 ~]# export LMCACHE_MAX_LOCAL_CPU_SIZE=72
[root@pod-1458388014826762240 ~]# 
[root@pod-1458388014826762240 ~]# python     -m vllm.entrypoints.openai.api_server     --port 8010     --model /workspace/cache/ai-ops/models/Qwen/Qwen3-8B/     --enforce-eager     --tensor-parallel-size 2    --trust-remote-code     --disable-log-requests     --block-size 128     --rope-scaling '{"rope_type": "yarn", "factor": 4.0, "original_max_position_embeddings": 32768}'     --max-model-len 32768     --kv-transfer-config '{"kv_connector":"LMCacheAscendConnectorV1Dynamic","kv_role":"kv_both", "kv_connector_module_path":"lmcache_ascend.integration.vllm.lmcache_ascend_connector_v1"}' 
INFO 03-01 20:54:32 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 03-01 20:54:32 [__init__.py:38] - ascend -> vllm_ascend:register
INFO 03-01 20:54:32 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 03-01 20:54:32 [__init__.py:207] Platform plugin ascend is activated
/usr/local/lib64/python3.11/site-packages/torch_npu/dynamo/torchair/__init__.py:8: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources

...
...

Loading LMCache config file /vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/examples/kv_cache_reuse/share_across_instances/p2p_sharing/example1.yaml (utils.py:58:lmcache.integration.vllm.utils)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,872] LMCache INFO: num_layer: 36, chunk_size: 256, num_kv_head (per gpu): 4, head_size: 128, hidden_dim (D) for KV (per gpu): 512, use mla: False, kv shape: (36, 2, 256, 4, 128), num_draft_layers:0 (vllm_v1_adapter.py:109:lmcache_ascend.integration.vllm.vllm_v1_adapter)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,902] LMCache INFO: Creating LMCacheEngine instance vllm-instance (cache_engine.py:1779:lmcache.v1.cache_engine)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,902] LMCache INFO: NUMA mapping for instance vllm-instance: None (cache_engine.py:1782:lmcache.v1.cache_engine)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,903] LMCache WARNING: Could not load 'builtin' from vLLM. Using builtin hash. This may cause inconsistencies in distributed caching. (token_database.py:136:lmcache.v1.token_database)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,903] LMCache INFO: Initialized NONE_HASH=-6197052367682486848 from vLLM (>= PR#20511) (token_database.py:74:lmcache.v1.token_database)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,903] LMCache INFO: Using hash algorithm: builtin (token_database.py:84:lmcache.v1.token_database)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,908] LMCache INFO: Creating LMCacheEngine with config: {'chunk_size': 256, 'local_cpu': True, 'max_local_cpu_size': 72.0, 'reserve_local_cpu_size': 0.0, 'local_disk': None, 'max_local_disk_size': 0.0, 'remote_url': None, 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'pre_caching_hash_algorithm': 'builtin', 'enable_blending': False, 'blend_recompute_ratios': None, 'blend_thresholds': None, 'blend_check_layers': None, 'blend_min_tokens': 256, 'blend_special_str': ' # # ', 'enable_p2p': True, 'p2p_host': 'localhost', 'p2p_init_ports': [9960, 9961], 'p2p_lookup_ports': [9962, 9963], 'enable_controller': True, 'lmcache_instance_id': 'lmcache_instance_1', 'controller_pull_url': 'localhost:8600', 'controller_reply_url': 'localhost:8700', 'lmcache_worker_ports': [9950, 9951], 'lmcache_worker_ids': None, 'lmcache_worker_heartbeat_delay_time': 10, 'lmcache_worker_heartbeat_time': None, 'enable_pd': False, 'pd_role': None, 'pd_buffer_size': None, 'pd_buffer_device': None, 'pd_peer_host': None, 'pd_peer_init_port': None, 'pd_peer_alloc_port': None, 'pd_proxy_host': None, 'pd_proxy_port': None, 'transfer_channel': 'hccl', 'nixl_backends': None, 'nixl_buffer_size': None, 'nixl_buffer_device': None, 'gds_path': None, 'cufile_buffer_size': None, 'audit_actual_remote_url': None, 'internal_api_server_host': '0.0.0.0', 'extra_config': {'lookup_backoff_time': 0.001}, 'save_unfull_chunk': False, 'blocking_timeout_secs': 10, 'external_lookup_client': None, 'py_enable_gc': True, 'cache_policy': 'LRU', 'numa_mode': None, 'enable_async_loading': True, 'internal_api_server_enabled': False, 'internal_api_server_port_start': 6999, 'priority_limit': None, 'internal_api_server_include_index_list': None, 'internal_api_server_socket_path_prefix': None, 'runtime_plugin_locations': None, 'storage_plugins': None, 'lookup_timeout_ms': 3000, 'hit_miss_ratio': None, 'lookup_server_worker_ids': None, 'enable_scheduler_bypass_lookup': False, 'script_allowed_imports': None, 'enable_lazy_memory_allocator': False, 'lazy_memory_initial_ratio': 0.2, 'lazy_memory_expand_trigger_ratio': 0.5, 'lazy_memory_step_ratio': 0.1, 'lazy_memory_safe_size': 0.0, 'enable_chunk_statistics': False, 'chunk_statistics_auto_start_statistics': False, 'chunk_statistics_auto_exit_timeout_hours': 0.0, 'chunk_statistics_auto_exit_target_unique_chunks': 0, 'chunk_statistics_strategy': 'memory_bloom_filter', 'enable_kv_events': False, 'use_gpu_connector_v3': False, 'pin_timeout_sec': 300, 'pin_check_interval_sec': 30} (cache_engine.py:101:lmcache.v1.cache_engine)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,916] LMCache INFO: Reply socket established at *:9951 (worker.py:147:lmcache.v1.cache_controller.worker)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,916] LMCache INFO: KV events are disabled. (cache_engine.py:172:lmcache.v1.cache_engine)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,917] LMCache INFO: Initializing usage context. (usage_context.py:412:lmcache.usage_context)
(Worker_TP1 pid=74488) [2026-03-01 20:55:20,917] LMCache INFO: Registering lmcache instance-worker: ('lmcache_instance_1', 1) (worker.py:167:lmcache.v1.cache_controller.worker)
(Worker_TP0 pid=74487) INFO 03-01 20:55:21 [factory.py:51] Creating v1 connector with name: LMCacheAscendConnectorV1Dynamic and engine_id: 6901dd87-ef40-4c21-9dfd-7403975da14e
(Worker_TP0 pid=74487) WARNING 03-01 20:55:21 [base.py:86] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,769] LMCache INFO: Loading LMCache config file /vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/examples/kv_cache_reuse/share_across_instances/p2p_sharing/example1.yaml (utils.py:58:lmcache.integration.vllm.utils)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,773] LMCache INFO: num_layer: 36, chunk_size: 256, num_kv_head (per gpu): 4, head_size: 128, hidden_dim (D) for KV (per gpu): 512, use mla: False, kv shape: (36, 2, 256, 4, 128), num_draft_layers:0 (vllm_v1_adapter.py:109:lmcache_ascend.integration.vllm.vllm_v1_adapter)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,806] LMCache INFO: Creating LMCacheEngine instance vllm-instance (cache_engine.py:1779:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,806] LMCache INFO: NUMA mapping for instance vllm-instance: None (cache_engine.py:1782:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,807] LMCache WARNING: Could not load 'builtin' from vLLM. Using builtin hash. This may cause inconsistencies in distributed caching. (token_database.py:136:lmcache.v1.token_database)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,807] LMCache INFO: Initialized NONE_HASH=-6197052367682486848 from vLLM (>= PR#20511) (token_database.py:74:lmcache.v1.token_database)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,807] LMCache INFO: Using hash algorithm: builtin (token_database.py:84:lmcache.v1.token_database)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,817] LMCache INFO: Creating LMCacheEngine with config: {'chunk_size': 256, 'local_cpu': True, 'max_local_cpu_size': 72.0, 'reserve_local_cpu_size': 0.0, 'local_disk': None, 'max_local_disk_size': 0.0, 'remote_url': None, 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'pre_caching_hash_algorithm': 'builtin', 'enable_blending': False, 'blend_recompute_ratios': None, 'blend_thresholds': None, 'blend_check_layers': None, 'blend_min_tokens': 256, 'blend_special_str': ' # # ', 'enable_p2p': True, 'p2p_host': 'localhost', 'p2p_init_ports': [9960, 9961], 'p2p_lookup_ports': [9962, 9963], 'enable_controller': True, 'lmcache_instance_id': 'lmcache_instance_1', 'controller_pull_url': 'localhost:8600', 'controller_reply_url': 'localhost:8700', 'lmcache_worker_ports': [9950, 9951], 'lmcache_worker_ids': None, 'lmcache_worker_heartbeat_delay_time': 10, 'lmcache_worker_heartbeat_time': None, 'enable_pd': False, 'pd_role': None, 'pd_buffer_size': None, 'pd_buffer_device': None, 'pd_peer_host': None, 'pd_peer_init_port': None, 'pd_peer_alloc_port': None, 'pd_proxy_host': None, 'pd_proxy_port': None, 'transfer_channel': 'hccl', 'nixl_backends': None, 'nixl_buffer_size': None, 'nixl_buffer_device': None, 'gds_path': None, 'cufile_buffer_size': None, 'audit_actual_remote_url': None, 'internal_api_server_host': '0.0.0.0', 'extra_config': {'lookup_backoff_time': 0.001}, 'save_unfull_chunk': False, 'blocking_timeout_secs': 10, 'external_lookup_client': None, 'py_enable_gc': True, 'cache_policy': 'LRU', 'numa_mode': None, 'enable_async_loading': True, 'internal_api_server_enabled': False, 'internal_api_server_port_start': 6999, 'priority_limit': None, 'internal_api_server_include_index_list': None, 'internal_api_server_socket_path_prefix': None, 'runtime_plugin_locations': None, 'storage_plugins': None, 'lookup_timeout_ms': 3000, 'hit_miss_ratio': None, 'lookup_server_worker_ids': None, 'enable_scheduler_bypass_lookup': False, 'script_allowed_imports': None, 'enable_lazy_memory_allocator': False, 'lazy_memory_initial_ratio': 0.2, 'lazy_memory_expand_trigger_ratio': 0.5, 'lazy_memory_step_ratio': 0.1, 'lazy_memory_safe_size': 0.0, 'enable_chunk_statistics': False, 'chunk_statistics_auto_start_statistics': False, 'chunk_statistics_auto_exit_timeout_hours': 0.0, 'chunk_statistics_auto_exit_target_unique_chunks': 0, 'chunk_statistics_strategy': 'memory_bloom_filter', 'enable_kv_events': False, 'use_gpu_connector_v3': False, 'pin_timeout_sec': 300, 'pin_check_interval_sec': 30} (cache_engine.py:101:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,820] LMCache INFO: Reply socket established at *:9950 (worker.py:147:lmcache.v1.cache_controller.worker)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,821] LMCache INFO: KV events are disabled. (cache_engine.py:172:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,821] LMCache INFO: Initializing usage context. (usage_context.py:412:lmcache.usage_context)
(Worker_TP0 pid=74487) [2026-03-01 20:55:21,821] LMCache INFO: Registering lmcache instance-worker: ('lmcache_instance_1', 0) (worker.py:167:lmcache.v1.cache_controller.worker)
(Worker_TP1 pid=74488) [2026-03-01 20:55:22,178] LMCache INFO: Starting PinMonitor background thread (pin_monitor.py:156:lmcache.v1.pin_monitor)
(Worker_TP1 pid=74488) [2026-03-01 20:55:22,178] LMCache INFO: PinMonitor check: pinned_objects=0, timeout_objects=0, force_unpin_success=0 (pin_monitor.py:121:lmcache.v1.pin_monitor)
(Worker_TP1 pid=74488) [2026-03-01 20:55:22,178] LMCache INFO: PinMonitor started (pin_monitor.py:176:lmcache.v1.pin_monitor)
(Worker_TP1 pid=74488) [2026-03-01 20:55:22,579] LMCache INFO: lmcache lookup server start with scheduler socket path /tmp/engine_6901dd87-ef40-4c21-9dfd-7403975da14e_service_lookup_scheduler_lmcache_rpc_port_0, worker socket path /tmp/engine_6901dd87-ef40-4c21-9dfd-7403975da14e_service_lookup_worker_lmcache_rpc_port_1 (lmcache_async_lookup_client.py:338:lmcache.v1.lookup_client.lmcache_async_lookup_client)
(Worker_TP1 pid=74488) [2026-03-01 20:55:22,582] LMCache INFO: Internal API server disabled. internal_api_server_enabled=False, port_offset=2, port=7001, socket_path=None, include_index_list=None (api_server.py:50:lmcache.v1.internal_api_server.api_server)
(Worker_TP1 pid=74488) [2026-03-01 20:55:22,583] LMCache INFO: LMCache initialized for role KVConnectorRole.WORKER with version 0.3.13.dev0-g78697950e, vllm version 0.11.0, lmcache cache_engine metadata: LMCacheEngineMetadata(model_name='/workspace/cache/ai-ops/models/Qwen/Qwen3-8B/', world_size=2, worker_id=1, fmt='vllm', kv_dtype=torch.bfloat16, kv_shape=(36, 2, 256, 4, 128), use_mla=False, role='worker', served_model_name='/workspace/cache/ai-ops/models/Qwen/Qwen3-8B/', chunk_size=256, kv_layer_groups_manager=KVLayerGroupsManager(kv_layer_groups=[])) (vllm_v1_adapter.py:840:lmcache.integration.vllm.vllm_v1_adapter)
(Worker_TP0 pid=74487) [2026-03-01 20:55:24,801] LMCache INFO: Starting PinMonitor background thread (pin_monitor.py:156:lmcache.v1.pin_monitor)
(Worker_TP0 pid=74487) [2026-03-01 20:55:24,801] LMCache INFO: PinMonitor started (pin_monitor.py:176:lmcache.v1.pin_monitor)
(Worker_TP0 pid=74487) [2026-03-01 20:55:24,801] LMCache INFO: PinMonitor check: pinned_objects=0, timeout_objects=0, force_unpin_success=0 (pin_monitor.py:121:lmcache.v1.pin_monitor)
(Worker_TP0 pid=74487) [2026-03-01 20:55:25,276] LMCache INFO: lmcache lookup server start with scheduler socket path /tmp/engine_6901dd87-ef40-4c21-9dfd-7403975da14e_service_lookup_scheduler_lmcache_rpc_port_0, worker socket path /tmp/engine_6901dd87-ef40-4c21-9dfd-7403975da14e_service_lookup_worker_lmcache_rpc_port_0 (lmcache_async_lookup_client.py:338:lmcache.v1.lookup_client.lmcache_async_lookup_client)
(Worker_TP0 pid=74487) [2026-03-01 20:55:25,312] LMCache INFO: Internal API server disabled. internal_api_server_enabled=False, port_offset=1, port=7000, socket_path=None, include_index_list=None (api_server.py:50:lmcache.v1.internal_api_server.api_server)
(Worker_TP0 pid=74487) [2026-03-01 20:55:25,313] LMCache INFO: LMCache initialized for role KVConnectorRole.WORKER with version 0.3.13.dev0-g78697950e, vllm version 0.11.0, lmcache cache_engine metadata: LMCacheEngineMetadata(model_name='/workspace/cache/ai-ops/models/Qwen/Qwen3-8B/', world_size=2, worker_id=0, fmt='vllm', kv_dtype=torch.bfloat16, kv_shape=(36, 2, 256, 4, 128), use_mla=False, role='worker', served_model_name='/workspace/cache/ai-ops/models/Qwen/Qwen3-8B/', chunk_size=256, kv_layer_groups_manager=KVLayerGroupsManager(kv_layer_groups=[])) (vllm_v1_adapter.py:840:lmcache.integration.vllm.vllm_v1_adapter)
(Worker_TP1 pid=74488) WARNING 03-01 20:55:25 [cudagraph_dispatcher.py:106] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(Worker_TP0 pid=74487) WARNING 03-01 20:55:25 [cudagraph_dispatcher.py:106] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(Worker_TP1 pid=74488) INFO 03-01 20:55:27 [worker_v1.py:258] Available memory: 48856621056, total memory: 65452113920
(Worker_TP0 pid=74487) INFO 03-01 20:55:27 [worker_v1.py:258] Available memory: 48856444928, total memory: 65452113920
(EngineCore_DP0 pid=74317) INFO 03-01 20:55:27 [kv_cache_utils.py:1087] GPU KV cache size: 662,656 tokens
(EngineCore_DP0 pid=74317) INFO 03-01 20:55:27 [kv_cache_utils.py:1091] Maximum concurrency for 32,768 tokens per request: 20.22x
(EngineCore_DP0 pid=74317) INFO 03-01 20:55:27 [kv_cache_utils.py:1087] GPU KV cache size: 662,656 tokens
(EngineCore_DP0 pid=74317) INFO 03-01 20:55:27 [kv_cache_utils.py:1091] Maximum concurrency for 32,768 tokens per request: 20.22x
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,024] LMCache INFO: Registering KV caches (vllm_v1_adapter.py:967:lmcache.integration.vllm.vllm_v1_adapter)
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,025] LMCache INFO: KV layer groups: [KVLayerGroupInfo(layers=36, indices=0-35, shape=torch.Size([5177, 128, 4, 128]), dtype=torch.bfloat16)] (kv_layer_groups.py:105:lmcache_ascend.v1.kv_layer_groups)
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,025] LMCache INFO: Post initializing LMCacheEngine (cache_engine.py:221:lmcache.v1.cache_engine)
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,025] LMCache INFO: Initialize storage manager on rank 1, use layerwise: False,save only first rank: False (cache_engine.py:233:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,025] LMCache INFO: Registering KV caches (vllm_v1_adapter.py:967:lmcache.integration.vllm.vllm_v1_adapter)
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,026] LMCache INFO: Initializing LRUCachePolicy (lru.py:22:lmcache.v1.storage_backend.cache_policy.lru)
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,026] LMCache INFO: NUMA mapping None (local_cpu_backend.py:350:lmcache.v1.storage_backend.local_cpu_backend)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,026] LMCache INFO: KV layer groups: [KVLayerGroupInfo(layers=36, indices=0-35, shape=torch.Size([5177, 128, 4, 128]), dtype=torch.bfloat16)] (kv_layer_groups.py:105:lmcache_ascend.v1.kv_layer_groups)
(Worker_TP1 pid=74488) [2026-03-01 20:55:28,026] LMCache INFO: Auto align cpu size bytes, origin: 77309411328, aligned: 77309411328, chunk size: 18874368 (local_cpu_backend.py:368:lmcache.v1.storage_backend.local_cpu_backend)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,026] LMCache INFO: Post initializing LMCacheEngine (cache_engine.py:221:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,026] LMCache INFO: Initialize storage manager on rank 0, use layerwise: False,save only first rank: False (cache_engine.py:233:lmcache.v1.cache_engine)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,027] LMCache INFO: Initializing LRUCachePolicy (lru.py:22:lmcache.v1.storage_backend.cache_policy.lru)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,027] LMCache INFO: NUMA mapping None (local_cpu_backend.py:350:lmcache.v1.storage_backend.local_cpu_backend)
(Worker_TP0 pid=74487) [2026-03-01 20:55:28,027] LMCache INFO: Auto align cpu size bytes, origin: 77309411328, aligned: 77309411328, chunk size: 18874368 (local_cpu_backend.py:368:lmcache.v1.storage_backend.local_cpu_backend)
内存位置类型1：HOST(主机内存)
(Worker_TP0 pid=74487) [2026-03-01 20:55:30,431] LMCache INFO: Paged tensor memory allocator initialized, shapes: [torch.Size([2, 36, 256, 512])], dtypes: [torch.bfloat16], align bytes: 18874368 (memory_management.py:1262:lmcache.v1.memory_management)
内存位置类型1：HOST(主机内存)
(Worker_TP1 pid=74488) [2026-03-01 20:55:30,483] LMCache INFO: Paged tensor memory allocator initialized, shapes: [torch.Size([2, 36, 256, 512])], dtypes: [torch.bfloat16], align bytes: 18874368 (memory_management.py:1262:lmcache.v1.memory_management)
[RegisterMem] 开始注册内存 - 地址: 0x12d640000000, 大小: 77309411328 bytes
[RegisterMem] 内存属性 - 类型: 1 (HOST=0/DEVICE=1/USER=2)
内存位置类型_2 : HOST(主机内存)
[RegisterMem] 转换为HCCL内存类型: 1 (HOST=0/DEVICE=1)
[RegisterMem] 调用HcclMemReg注册内存...
[RegisterMem] 开始注册内存 - 地址: 0x12d640000000, 大小: 77309411328 bytes
[RegisterMem] 内存属性 - 类型: 1 (HOST=0/DEVICE=1/USER=2)
内存位置类型_2 : HOST(主机内存)
[RegisterMem] 转换为HCCL内存类型: 1 (HOST=0/DEVICE=1)
[RegisterMem] 调用HcclMemReg注册内存...
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671] WorkerProc hit an exception.
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671] Traceback (most recent call last):
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py", line 666, in worker_busy_loop
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     output = func(*args, **kwargs)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/worker/worker_base.py", line 254, in initialize_from_config
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/worker_v1.py", line 363, in initialize_from_config
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.model_runner.initialize_kv_cache(kv_cache_config)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2756, in initialize_kv_cache
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     get_kv_transfer_group().register_kv_caches(kv_caches)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/lmcache_connector_v1.py", line 46, in register_kv_caches
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self._lmcache_engine.register_kv_caches(kv_caches)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 978, in register_kv_caches
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.lmcache_engine.post_init(async_lookup_server=async_lookup_server)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/cache_engine.py", line 239, in post_init
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.storage_manager = StorageManager(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                            ^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/storage_manager.py", line 235, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     CreateStorageBackends(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/__init__.py", line 155, in CreateStorageBackends
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     p2p_backend = P2PBackend(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                   ^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/p2p_backend.py", line 222, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.transfer_channel = CreateTransferChannel(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                             ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/__init__.py", line 57, in CreateTransferChannel
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     transfer_channel = HcclChannel(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                        ^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 78, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.hccl_wrapper = HcclAgentWrapper(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                         ^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 706, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     mem_handle = hccl_agent.register_mem(buffer_ptr, buffer_size)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671] RuntimeError: Failed to register memory | HCCL Error Code: 19
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671] Traceback (most recent call last):
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py", line 666, in worker_busy_loop
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     output = func(*args, **kwargs)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/worker/worker_base.py", line 254, in initialize_from_config
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/worker_v1.py", line 363, in initialize_from_config
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.model_runner.initialize_kv_cache(kv_cache_config)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2756, in initialize_kv_cache
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     get_kv_transfer_group().register_kv_caches(kv_caches)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/lmcache_connector_v1.py", line 46, in register_kv_caches
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self._lmcache_engine.register_kv_caches(kv_caches)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 978, in register_kv_caches
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.lmcache_engine.post_init(async_lookup_server=async_lookup_server)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/cache_engine.py", line 239, in post_init
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.storage_manager = StorageManager(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                            ^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/storage_manager.py", line 235, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     CreateStorageBackends(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/__init__.py", line 155, in CreateStorageBackends
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     p2p_backend = P2PBackend(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                   ^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/p2p_backend.py", line 222, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.transfer_channel = CreateTransferChannel(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                             ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/__init__.py", line 57, in CreateTransferChannel
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     transfer_channel = HcclChannel(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                        ^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 78, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     self.hccl_wrapper = HcclAgentWrapper(
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                         ^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 706, in __init__
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]     mem_handle = hccl_agent.register_mem(buffer_ptr, buffer_size)
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671] RuntimeError: Failed to register memory | HCCL Error Code: 19
(Worker_TP1 pid=74488) ERROR 03-01 20:55:33 [multiproc_executor.py:671] 
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671] WorkerProc hit an exception.
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671] Traceback (most recent call last):
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py", line 666, in worker_busy_loop
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     output = func(*args, **kwargs)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/worker/worker_base.py", line 254, in initialize_from_config
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/worker_v1.py", line 363, in initialize_from_config
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.model_runner.initialize_kv_cache(kv_cache_config)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2756, in initialize_kv_cache
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     get_kv_transfer_group().register_kv_caches(kv_caches)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/lmcache_connector_v1.py", line 46, in register_kv_caches
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self._lmcache_engine.register_kv_caches(kv_caches)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 978, in register_kv_caches
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.lmcache_engine.post_init(async_lookup_server=async_lookup_server)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/cache_engine.py", line 239, in post_init
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.storage_manager = StorageManager(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                            ^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/storage_manager.py", line 235, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     CreateStorageBackends(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/__init__.py", line 155, in CreateStorageBackends
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     p2p_backend = P2PBackend(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                   ^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/p2p_backend.py", line 222, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.transfer_channel = CreateTransferChannel(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                             ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/__init__.py", line 57, in CreateTransferChannel
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     transfer_channel = HcclChannel(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                        ^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 78, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.hccl_wrapper = HcclAgentWrapper(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                         ^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 706, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     mem_handle = hccl_agent.register_mem(buffer_ptr, buffer_size)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671] RuntimeError: Failed to register memory | HCCL Error Code: 19
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671] Traceback (most recent call last):
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py", line 666, in worker_busy_loop
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     output = func(*args, **kwargs)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm/vllm/worker/worker_base.py", line 254, in initialize_from_config
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/worker_v1.py", line 363, in initialize_from_config
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.model_runner.initialize_kv_cache(kv_cache_config)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2756, in initialize_kv_cache
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     get_kv_transfer_group().register_kv_caches(kv_caches)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/lmcache_connector_v1.py", line 46, in register_kv_caches
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self._lmcache_engine.register_kv_caches(kv_caches)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 978, in register_kv_caches
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.lmcache_engine.post_init(async_lookup_server=async_lookup_server)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/cache_engine.py", line 239, in post_init
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.storage_manager = StorageManager(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                            ^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/storage_manager.py", line 235, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     CreateStorageBackends(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/__init__.py", line 155, in CreateStorageBackends
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     p2p_backend = P2PBackend(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                   ^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/p2p_backend.py", line 222, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.transfer_channel = CreateTransferChannel(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                             ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/__init__.py", line 57, in CreateTransferChannel
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     transfer_channel = HcclChannel(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                        ^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 78, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     self.hccl_wrapper = HcclAgentWrapper(
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                         ^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/transfer_channel/hccl_channel.py", line 706, in __init__
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]     mem_handle = hccl_agent.register_mem(buffer_ptr, buffer_size)
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671] RuntimeError: Failed to register memory | HCCL Error Code: 19
(Worker_TP0 pid=74487) ERROR 03-01 20:55:34 [multiproc_executor.py:671] 
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58] EngineCore failed to start.
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58] Traceback (most recent call last):
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/patch/platform/patch_core.py", line 49, in run_engine_core
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 498, in __init__
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     super().__init__(vllm_config, executor_class, log_stats,
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 92, in __init__
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     self._initialize_kv_caches(vllm_config)
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 207, in _initialize_kv_caches
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/abstract.py", line 73, in initialize_from_config
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     self.collective_rpc("initialize_from_config",
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py", line 264, in collective_rpc
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     result = get_response(w, dequeue_timeout,
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py", line 248, in get_response
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58]     raise RuntimeError(
(EngineCore_DP0 pid=74317) ERROR 03-01 20:55:34 [patch_core.py:58] RuntimeError: Worker failed with error 'Failed to register memory | HCCL Error Code: 19', please check the stack trace above for the root cause
(Worker_TP1 pid=74488) /vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py:520: ResourceWarning: Unclosed socket <zmq.Socket(zmq.XPUB) at 0xfffef952d400>
(Worker_TP0 pid=74487) /vector-engine-workspace/alg-product/vllm/vllm/v1/executor/multiproc_executor.py:520: ResourceWarning: Unclosed socket <zmq.Socket(zmq.XPUB) at 0xffff0888d400>
(Worker_TP1 pid=74488)   self.worker_response_mq = None
(Worker_TP0 pid=74487)   self.worker_response_mq = None
```

Debug code
```

HcclResult HcclAgent::RegisterMem(void *ptr, uint64_t size,
                                  hccl::TransportMem::RmaMemDesc &memHandle) {
  std::lock_guard<std::mutex> lock(agentMutex_);
  // 新增：打印函数入参（内存地址、大小）
  std::cout << "[RegisterMem] 开始注册内存 - 地址: " << ptr << ", 大小: " << size << " bytes" << std::endl;

  if (state_ != State::INITIALIZED) {
    // 新增：打印状态错误
    std::cerr << "[RegisterMem] 错误：HcclAgent未初始化，当前状态非INITIALIZED" << std::endl;
    return HCCL_E_INTERNAL;
  }

  auto it = registeredMems_.find(ptr);
  if (it != registeredMems_.end()) {
    // 新增：打印内存已注册，引用计数增加
    it->second.refCount++;
    std::cout << "[RegisterMem] 内存已注册，引用计数+1，当前计数: " << it->second.refCount << std::endl;
  } else {
    rtPointerAttributes_t attributes;
    ACL_CHECK(rtPointerGetAttributes(&attributes, ptr));

    // 新增：打印内存属性（类型）
    std::cout << "[RegisterMem] 内存属性 - 类型: " << attributes.memoryType 
              << " (HOST=0/DEVICE=1/USER=2)" << std::endl;


    aclrtPtrAttributes attr;       
    aclrtPointerGetAttributes(ptr, &attr);
    printf("内存位置类型_2 : %s\n", attr.location.type == ACL_MEM_LOCATION_TYPE_HOST ? "HOST(主机内存)" : "DEVICE(设备内存)");       

    
    HcclMem mem;
    mem.addr = ptr;
    mem.size = size;
    if (attributes.memoryType == RT_MEMORY_TYPE_HOST ||
        attributes.memoryType == RT_MEMORY_TYPE_USER) {
      mem.type = HCCL_MEM_TYPE_HOST;
    } else {
      mem.type = HCCL_MEM_TYPE_DEVICE;
    }

    // 新增：打印转换后的HCCL内存类型
    std::cout << "[RegisterMem] 转换为HCCL内存类型: " << mem.type 
              << " (HOST=0/DEVICE=1)" << std::endl;

    HcclBuf buf;
    // 新增：打印准备调用HcclMemReg
    std::cout << "[RegisterMem] 调用HcclMemReg注册内存..." << std::endl;
    HCCL_CHECK(HcclMemReg(nicNetDevCtx_, &mem, &buf));
    // 新增：打印HcclMemReg执行成功
    std::cout << "[RegisterMem] HcclMemReg执行成功，buf.handle: " << buf.handle << std::endl;

    hccl::RmaBuffer *rmaPtr = reinterpret_cast<hccl::RmaBuffer *>(buf.handle);
    registeredMems_[ptr] = {buf, 1, rmaPtr->GetDevAddr()};
    // 新增：打印内存注册完成，记录设备地址
    std::cout << "[RegisterMem] 内存注册完成，设备地址: " << rmaPtr->GetDevAddr() << std::endl;
  }

  char *desc = nullptr;
  uint64_t desc_len = 0;
  // 新增：打印准备导出内存描述
  std::cout << "[RegisterMem] 导出内存描述信息..." << std::endl;
  HCCL_CHECK(HcclMemExport(&registeredMems_[ptr].handle, &desc, &desc_len));
  // 新增：打印导出结果
  std::cout << "[RegisterMem] 内存描述导出成功 - 长度: " << desc_len << ", 内容地址: " << desc << std::endl;

  memset(memHandle.memDesc, 0, hccl::TRANSPORT_EMD_ESC_SIZE);
  memcpy(memHandle.memDesc, desc, desc_len);

  memHandle.localRankId = devId_;
  // 新增：打印函数执行完成
  std::cout << "[RegisterMem] 内存注册流程完成，返回HCCL_SUCCESS" << std::endl;
  return HCCL_SUCCESS;
}
```

