### PR TITLE
Fix build main branch error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,38 +145,43 @@ def _get_npu_soc():
             else _soc_version
         )
 
-    try:
-        npu_smi_cmd = ["npu-smi", "info", "-t", "board", "-i", "0", "-c", "0"]
-        full_output = subprocess.check_output(npu_smi_cmd, text=True)
-
-        npu_info = {}
-        for line in full_output.strip().splitlines():
-            if ":" in line:
-                key, value = line.split(":", 1)
-                npu_info[key.strip()] = value.strip()
-
-        chip_name = npu_info.get("Chip Name", None)
-        npu_name = npu_info.get("NPU Name", None)
-
-        if not chip_name:
-            raise RuntimeError("Could not find 'Chip Name' in npu-smi output.")
-
-        if npu_name:
-            # New Format for npu-smi info on 910C machines: "Ascend910_9392"
-            _soc_version = f"{chip_name}_{npu_name}"
-        else:
-            # Old Format for npu-smi info on 910B machines: "Ascend910B4"
-            if chip_name.startswith("Ascend"):
-                _soc_version = chip_name
-            else:
-                _soc_version = "Ascend" + chip_name
-
-        return _soc_version
-
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise RuntimeError(
-            f"Failed to execute npu-smi command and retrieve SoC version: {e}"
-        ) from e
+    # Iterate through common NPU IDs (0-7) to find an available one.
+    for npu_id in [0, 1, 2, 3, 4, 5, 6, 7]:
+        try:
+            npu_smi_cmd = [
+                "npu-smi",
+                "info",
+                "-t",
+                "board",
+                "-i",
+                str(npu_id),
+                "-c",
+                "0",
+            ]
+            full_output = subprocess.check_output(npu_smi_cmd, text=True)
+            npu_info = {}
+            for line in full_output.strip().splitlines():
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    npu_info[key.strip()] = value.strip()
+            chip_name = npu_info.get("Chip Name", None)
+            if chip_name:
+                npu_name = npu_info.get("NPU Name", None)
+                if npu_name:
+                    _soc_version = f"{chip_name}_{npu_name}"
+                else:
+                    if chip_name.startswith("Ascend"):
+                        _soc_version = chip_name
+                    else:
+                        _soc_version = "Ascend" + chip_name
+                return _soc_version
+        except subprocess.CalledProcessError:
+            continue
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                f"Failed to execute npu-smi command and retrieve SoC version: {e}"
+            ) from e
+    raise RuntimeError("No available NPU found, please check npu-smi info")
 
 
 def _get_aicore_arch_number(ascend_path, soc_version, host_arch):


### PR DESCRIPTION
Met build main branch error when the pod only contains 2npu cards. we can try to iterate through common NPU IDs (0-7) to find an available one.

```
[root@pod-1477782314865819648 LMCache-Ascend]# npu-smi info
+------------------------------------------------------------------------------------------------+
| npu-smi 25.2.0                   Version: 25.2.0                                               |
+---------------------------+---------------+----------------------------------------------------+
| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
| Chip                      | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+===========================+===============+====================================================+
| 6     910B2               | OK            | 91.4        34                0    / 0             |
| 0                         | 0000:41:00.0  | 0           0    / 0          3399 / 65536         |
+===========================+===============+====================================================+
| 7     910B2               | OK            | 93.0        37                0    / 0             |
| 0                         | 0000:42:00.0  | 0           0    / 0          3399 / 65536         |
+===========================+===============+====================================================+
+---------------------------+---------------+----------------------------------------------------+
| NPU     Chip              | Process id    | Process name             | Process memory(MB)      |
+===========================+===============+====================================================+
| No running processes found in NPU 6                                                            |
+===========================+===============+====================================================+
| No running processes found in NPU 7                                                            |
+===========================+===============+====================================================+
[root@pod-1477782314865819648 LMCache-Ascend]# 
[root@pod-1477782314865819648 LMCache-Ascend]# 
[root@pod-1477782314865819648 LMCache-Ascend]# 
[root@pod-1477782314865819648 LMCache-Ascend]# pip install -v --no-build-isolation -e .
Using pip 26.0.1 from /usr/local/lib/python3.11/site-packages/pip (python 3.11)
Looking in indexes: https://mirrors.aliyun.com/pypi/simple/
Obtaining file:///vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend
  Running command Checking if build backend supports build_editable
  Checking if build backend supports build_editable ... done
  Running command Preparing editable metadata (pyproject.toml)
  /usr/local/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!

          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

          By 2027-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    corresp(dist, value, root_dir)
  INFO:root:running dist_info
  INFO:root:creating /tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend.egg-info
  INFO:root:writing /tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend.egg-info/PKG-INFO
  INFO:root:writing dependency_links to /tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend.egg-info/dependency_links.txt
  INFO:root:writing top-level names to /tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend.egg-info/top_level.txt
  INFO:root:writing manifest file '/tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend.egg-info/SOURCES.txt'
  INFO:root:adding license file 'LICENSE'
  INFO:root:writing manifest file '/tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend.egg-info/SOURCES.txt'
  INFO:root:creating '/tmp/pip-modern-metadata-3ohpwzl_/lmcache_ascend-0.3.8.dev28.dist-info'
  Building Ascend extensions
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: lmcache-ascend
  Running command Building editable for lmcache-ascend (pyproject.toml)
  /usr/local/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!

          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

          By 2027-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************

  !!
    corresp(dist, value, root_dir)
  INFO:root:running editable_wheel
  INFO:root:creating /tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend.egg-info
  INFO:root:writing /tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend.egg-info/PKG-INFO
  INFO:root:writing dependency_links to /tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend.egg-info/dependency_links.txt
  INFO:root:writing top-level names to /tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend.egg-info/top_level.txt
  INFO:root:writing manifest file '/tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend.egg-info/SOURCES.txt'
  INFO:root:adding license file 'LICENSE'
  INFO:root:writing manifest file '/tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend.egg-info/SOURCES.txt'
  INFO:root:creating '/tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend-0.3.8.dev28.dist-info'
  INFO:root:creating /tmp/pip-ephem-wheel-cache-1b5q0yzk/wheels/3d/68/23/468e5743d724c1eb73e304c5153d95d052cd828a6e3fcbb288/tmp2rdhqd22/.tmp-hpt7i7ix/lmcache_ascend-0.3.8.dev28.dist-info/WHEEL
  INFO:root:running build_py
  /usr/local/lib/python3.11/site-packages/setuptools/command/editable_wheel.py:298: SetuptoolsDeprecationWarning: Customization incompatible with editable install
  !!

          ********************************************************************************
                          Traceback (most recent call last):
            File "<string>", line 95, in _get_npu_soc
            File "/usr/lib64/python3.11/subprocess.py", line 466, in check_output
              return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/usr/lib64/python3.11/subprocess.py", line 571, in run
              raise CalledProcessError(retcode, process.args,
          subprocess.CalledProcessError: Command '['npu-smi', 'info', '-t', 'board', '-i', '0', '-c', '0']' returned non-zero exit status 215.

          The above exception was the direct cause of the following exception:

          Traceback (most recent call last):
            File "/usr/local/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 304, in _safely_run
              return self.run_command(cmd_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
              self.distribution.run_command(command)
            File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 1107, in run_command
              super().run_command(command)
            File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
              cmd_obj.run()
            File "<string>", line 161, in run
            File "<string>", line 122, in _get_npu_soc
          RuntimeError: Failed to execute npu-smi command and retrieve SoC version: Command '['npu-smi', 'info', '-t', 'board', '-i', '0', '-c', '0']' returned non-zero exit status 215.


                          If you are seeing this warning it is very likely that a setuptools
                          plugin or customization overrides the `build_py` command, without
                          taking into consideration how editable installs run build steps
                          starting from setuptools v64.0.0.

                          Plugin authors and developers relying on custom build steps are
                          encouraged to update their `build_py` implementation considering the
                          information about editable installs in
                          https://setuptools.pypa.io/en/latest/userguide/extension.html.

                          For the time being `setuptools` will silence this error and ignore
                          the faulty command, but this behavior will change in future versions.

          ********************************************************************************

  !!
    self._safely_run(name)
  INFO:root:running build_ext
  INFO:__main__:Building c_ops.so ...
  Building Ascend extensions
  Traceback (most recent call last):
    File "<string>", line 95, in _get_npu_soc
    File "/usr/lib64/python3.11/subprocess.py", line 466, in check_output
      return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib64/python3.11/subprocess.py", line 571, in run
      raise CalledProcessError(retcode, process.args,
  subprocess.CalledProcessError: Command '['npu-smi', 'info', '-t', 'board', '-i', '0', '-c', '0']' returned non-zero exit status 215.

  The above exception was the direct cause of the following exception:

  Traceback (most recent call last):
    File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
      main()
    File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 303, in build_editable
      return hook(wheel_directory, config_settings, metadata_directory)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/setuptools/build_meta.py", line 472, in build_editable
      return self._build_with_temp_dir(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/setuptools/build_meta.py", line 408, in _build_with_temp_dir
      self.run_setup()
    File "/usr/local/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
      exec(code, locals())
    File "<string>", line 369, in <module>
    File "/usr/local/lib/python3.11/site-packages/setuptools/__init__.py", line 117, in setup
      return distutils.core.setup(**attrs)  # type: ignore[return-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 186, in setup
      return run_commands(dist)
             ^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
      dist.run_commands()
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
      self.run_command(cmd)
    File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 1107, in run_command
      super().run_command(command)
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 140, in run
      self._create_wheel_file(bdist_wheel)
    File "/usr/local/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 350, in _create_wheel_file
      files, mapping = self._run_build_commands(dist_name, unpacked, lib, tmp)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 273, in _run_build_commands
      self._run_build_subcommands()
    File "/usr/local/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 300, in _run_build_subcommands
      self.run_command(name)
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
      self.distribution.run_command(command)
    File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 1107, in run_command
      super().run_command(command)
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.11/site-packages/setuptools/command/build_ext.py", line 97, in run
      _build_ext.run(self)
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 368, in run
      self.build_extensions()
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 484, in build_extensions
      self._build_extensions_serial()
    File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 510, in _build_extensions_serial
      self.build_extension(ext)
    File "<string>", line 204, in build_extension
    File "<string>", line 122, in _get_npu_soc
  RuntimeError: Failed to execute npu-smi command and retrieve SoC version: Command '['npu-smi', 'info', '-t', 'board', '-i', '0', '-c', '0']' returned non-zero exit status 215.
  An error occurred when building editable wheel for lmcache-ascend.
  See debugging tips in: https://setuptools.pypa.io/en/latest/userguide/development_mode.html#debugging-tips
  error: subprocess-exited-with-error
  
  × Building editable for lmcache-ascend (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> No available output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/bin/python3 /usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_editable /tmp/tmpn01ls6ug
  cwd: /vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend
  Building editable for lmcache-ascend (pyproject.toml) ... error
  ERROR: Failed building editable for lmcache-ascend
Failed to build lmcache-ascend
error: failed-wheel-build-for-install

× Failed to build installable wheels for some pyproject.toml based projects
╰─> lmcache-ascend
[root@pod-1477782314865819648 LMCache-Ascend]# 

[root@pod-1477782314865819648 LMCache-Ascend]# 
```