### PR TITLE
Exit loop when zmq socket closed

### DIFF
--- a/lmcache_ascend/v1/storage_backend/pd/receiver_mixin.py
+++ b/lmcache_ascend/v1/storage_backend/pd/receiver_mixin.py
@@ -407,7 +407,7 @@ class AscendPDReceiverMixin:
                 msg_bytes = self.alloc_side_channel.recv()
             except zmq.Again:
                 continue
-            except zmq.error.ContextTerminated as e:
+            except zmq.error.ContextTerminated:
                 logger.error("ZMQ socket closed, exiting _mem_alloc_loop thread")
                 break
             except Exception as e:

--- a/lmcache_ascend/v1/transfer_channel/base_channel.py
+++ b/lmcache_ascend/v1/transfer_channel/base_channel.py
@@ -161,7 +161,7 @@ class BaseMultiBufferChannel(BaseTransferChannel):
                 self.init_side_channel.send(msgspec.msgpack.encode(resp))
             except zmq.Again:
                 continue
-            except zmq.error.ContextTerminated as e:
+            except zmq.error.ContextTerminated:
                 logger.error("ZMQ socket closed, exiting _init_loop thread")
                 break
             except Exception as e:


### PR DESCRIPTION
When this process is actively killed (via the kill command), a large number of duplicate messages are printed to the console.

```
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=355839) INFO 03-10 14:11:01 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=355839) WARNING 03-10 14:11:01 [warnings.py:109] /usr/local/lib64/python3.11/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
(APIServer pid=355839) WARNING 03-10 14:11:01 [warnings.py:109] /usr/local/lib/python3.11/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
(APIServer pid=355839) INFO:     Started server process [355839]
(APIServer pid=355839) INFO:     Waiting for application startup.
(APIServer pid=355839) INFO:     Application startup complete.
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:21,616] LMCache INFO: PinMonitor check: pinned_objects=0, timeout_objects=0, force_unpin_success=0 (pin_monitor.py:121:lmcache.v1.pin_monitor)
^C(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,720] LMCache INFO: Starting LMCacheConnector shutdown... (vllm_v1_adapter.py:1433:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,720] LMCache INFO: Closing runtime_plugin_launcher... (vllm_v1_adapter.py:1441:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,720] LMCache INFO: runtime_plugin_launcher closed successfully (vllm_v1_adapter.py:1446:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,720] LMCache INFO: Closing api_server... (vllm_v1_adapter.py:1441:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,721] LMCache INFO: api_server closed successfully (vllm_v1_adapter.py:1446:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,721] LMCache INFO: Closing lookup_client... (vllm_v1_adapter.py:1441:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,721] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,722] LMCache ERROR: ZMQ error in offload server: Context was terminated (zmq_server.py:72:lmcache.v1.offload_server.zmq_server)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,722] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,732] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,732] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(APIServer pid=355839) INFO 03-10 14:11:32 [launcher.py:110] Shutting down FastAPI HTTP server.
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,742] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,742] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,753] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,753] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,763] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,763] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,773] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,773] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,783] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,783] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,794] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,794] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,804] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,804] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,814] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,814] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,824] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,824] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,835] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,835] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,845] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,845] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,855] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,855] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,865] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,865] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,875] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,876] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,886] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,886] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,896] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,896] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,906] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,906] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,916] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,917] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,927] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,927] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,937] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:32,937] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
...
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,635] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,645] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,646] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,656] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,656] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,666] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,666] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,676] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,676] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,686] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,687] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,697] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,697] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,707] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,707] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,717] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,717] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,727] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,727] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,738] LMCache ERROR: Failed to process hcomm_onesided initialization loop: Context was terminated (base_channel.py:165:lmcache_ascend.v1.transfer_channel.base_channel)
(EngineCore_DP0 pid=356230) [2026-03-10 14:11:37,738] LMCache ERROR: Failed to send hcomm_onesided error response: Context was terminated (base_channel.py:175:lmcache_ascend.v1.transfer_channel.base_channel)
(APIServer pid=355839) INFO:     Shutting down
(APIServer pid=355839) INFO:     Waiting for application shutdown.
(APIServer pid=355839) INFO:     Application shutdown complete.
(APIServer pid=355839) sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
[root@pod-1458388014826762240 ~]# /usr/lib64/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '

```