### PR TITLE
Fix TypeError when use cpu buffer

### DIFF
--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -210,7 +210,6 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
             # or configured to use CPU as the buffer device.
             # Falls back to pd_buffer_size when pd_cpu_buffer_size is not set.
             cpu_buffer_size = config.pd_cpu_buffer_size or config.pd_buffer_size
-
             cpu_aligned_byte = (
                 (cpu_buffer_size + total_size - 1) // total_size * total_size
             )


### PR DESCRIPTION
Fix TypeError when use cpu buffer, the default value of the `pd_cpu_buffer_size` is `None`, so the `getattr` will return `None`.

```
Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  33% Completed | 1/3 [00:00<00:01,  1.97it/s]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:01<00:00,  1.57it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:01<00:00,  2.21it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:01<00:00,  2.04it/s]
(EngineCore_DP0 pid=479184) 
(EngineCore_DP0 pid=479184) INFO 03-11 00:20:42 [default_loader.py:291] Loading weights took 1.48 seconds
(EngineCore_DP0 pid=479184) INFO 03-11 00:20:43 [model_runner_v1.py:2205] Loading model weights took 7.5220 GB
(EngineCore_DP0 pid=479184) INFO 03-11 00:20:45 [worker.py:291] Available memory: 50210221568, total memory: 65452113920
(EngineCore_DP0 pid=479184) INFO 03-11 00:20:45 [kv_cache_utils.py:1305] GPU KV cache size: 340,480 tokens
(EngineCore_DP0 pid=479184) INFO 03-11 00:20:45 [kv_cache_utils.py:1310] Maximum concurrency for 32,768 tokens per request: 10.39x
(EngineCore_DP0 pid=479184) [2026-03-11 00:20:45,922] LMCache INFO: Registering KV caches (vllm_v1_adapter.py:967:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=479184) [2026-03-11 00:20:45,922] LMCache INFO: KV layer groups: [KVLayerGroupInfo(layers=36, indices=0-35, shape=torch.Size([2660, 128, 8, 128]), dtype=torch.bfloat16)] (kv_layer_groups.py:105:lmcache_ascend.v1.kv_layer_groups)
(EngineCore_DP0 pid=479184) [2026-03-11 00:20:45,923] LMCache INFO: Post initializing LMCacheEngine (cache_engine.py:221:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=479184) [2026-03-11 00:20:45,923] LMCache INFO: Initialize storage manager on rank 0, use layerwise: False,save only first rank: False (cache_engine.py:233:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=479184) /usr/lib64/python3.11/contextlib.py:188: ResourceWarning: Unclosed context <zmq.Context() at 0xfffcfceca750>
(EngineCore_DP0 pid=479184)   exc.__traceback__ = traceback
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936] EngineCore failed to start.
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936] Traceback (most recent call last):
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 927, in run_engine_core
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 692, in __init__
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     super().__init__(
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 113, in __init__
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 270, in _initialize_kv_caches
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/abstract.py", line 115, in initialize_from_config
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.collective_rpc("initialize_from_config", args=(kv_cache_configs,))
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/serial_utils.py", line 461, in run_method
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     return func(*args, **kwargs)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/worker/worker_base.py", line 320, in initialize_from_config
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/worker.py", line 451, in initialize_from_config
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.model_runner.initialize_kv_cache(kv_cache_config)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/vllm-ascend/vllm_ascend/worker/model_runner_v1.py", line 2239, in initialize_kv_cache
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     get_kv_transfer_group().register_kv_caches(kv_caches)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/lmcache_connector_v1.py", line 46, in register_kv_caches
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self._lmcache_engine.register_kv_caches(kv_caches)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 978, in register_kv_caches
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.lmcache_engine.post_init(async_lookup_server=async_lookup_server)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/cache_engine.py", line 239, in post_init
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.storage_manager = StorageManager(
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]                            ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache/lmcache/v1/storage_backend/storage_manager.py", line 235, in __init__
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     CreateStorageBackends(
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/storage_backend/__init__.py", line 72, in CreateStorageBackends
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     storage_backends["PDBackend"] = AscendPDBackend(config, metadata)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/storage_backend/pd/backend.py", line 78, in __init__
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     self.memory_allocator = self.initialize_allocator(config, metadata)
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]   File "/vector-engine-workspace/alg-product/ai-cache/LMCache-Ascend/lmcache_ascend/v1/storage_backend/pd/backend.py", line 216, in initialize_allocator
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]     (cpu_buffer_size + total_size - 1) // total_size * total_size
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936]      ~~~~~~~~~~~~~~~~^~~~~~~~~~~~
(EngineCore_DP0 pid=479184) ERROR 03-11 00:20:45 [core.py:936] TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
(EngineCore_DP0 pid=479184) Process EngineCore_DP0:
(EngineCore_DP0 pid=479184) Traceback (most recent call last):
(EngineCore_DP0 pid=479184)   File "/usr/lib64/python3.11/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=479184)     self.run()
(EngineCore_DP0 pid=479184)   File "/usr/lib64/python3.11/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=479184)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 940, in run_engine_core
(EngineCore_DP0 pid=479184)     raise e
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 927, in run_engine_core
(EngineCore_DP0 pid=479184)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=479184)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 692, in __init__
(EngineCore_DP0 pid=479184)     super().__init__(
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 113, in __init__
(EngineCore_DP0 pid=479184)     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=479184)                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/engine/core.py", line 270, in _initialize_kv_caches
(EngineCore_DP0 pid=479184)     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/abstract.py", line 115, in initialize_from_config
(EngineCore_DP0 pid=479184)     self.collective_rpc("initialize_from_config", args=(kv_cache_configs,))
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP0 pid=479184)     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=479184)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=479184)   File "/vector-engine-workspace/alg-product/vllm/vllm/v1/serial_utils.py", line 461, in run_method
(EngineCore_DP0 pid=479184)     return func(*args, **kwargs)
(EngineCore_DP0 pid=479184)            ^^^^^^^^^^^^^^^^^^^^^
```