### PR TITLE
[BugFix] Implement scatter-done event handling for RDMA writes

### DIFF
--- a/lmcache_ascend/v1/npu_connector.py
+++ b/lmcache_ascend/v1/npu_connector.py
@@ -885,6 +885,14 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             assert not is_310p(), "Batched P2P transfer is not supported on 310P."
 
             self._remote_batched_to_gpu(memory_objs, starts, ends, **kwargs)
+
+            # NOTE (gingfung): Ensure the compute stream waits for
+            # load_stream's KV scatter to complete before attention
+            # reads the same pages.
+            # load_stream.synchronize() in _remote_batched_to_gpu is
+            # host-side only, the compute stream has no knowledge of it
+            # and can race ahead.
+            torch.npu.current_stream().wait_stream(self.load_stream)
         else:
             with torch.cuda.stream(self.load_stream):
                 for memory_obj, start, end in zip(


### PR DESCRIPTION

This pull request adds synchronization mechanisms to prevent race conditions when using RDMA writes and scatter operations on the same memory pool in `lmcache_ascend/v1/npu_connector.py`. The changes ensure that RDMA operations do not overwrite buffers that are still being read by a scatter operation, improving data integrity and correctness.

**Synchronization improvements for RDMA and scatter operations:**

* Introduced per-pool scatter-done events (`pool_scatter_events`) and flags (`pool_scatter_recorded`) to ensure that an RDMA write does not race with an ongoing scatter read from the same pool. The code now waits for the previous scatter to complete before allowing RDMA writes to proceed.
* Implemented recording of scatter-done events on the `load_stream` after each scatter operation, and updated the logic to track which pool's event was recorded, ensuring proper synchronization for subsequent RDMA writes.