### PR TITLE
[BugFix] Refactor Ascend P2P backend for done signal handling and retries

### DIFF
--- a/lmcache_ascend/v1/storage_backend/p2p_backend.py
+++ b/lmcache_ascend/v1/storage_backend/p2p_backend.py
@@ -82,6 +82,14 @@ class AscendBatchedLookupAndPutMsg(BatchedLookupAndPutMsg):
     buffer_uuids: list[str] = []
 
 
+class AscendQueryDonePortMsg(msgspec.Struct, tag=True):
+    pass
+
+
+class AscendQueryDonePortRetMsg(msgspec.Struct, tag=True):
+    done_url: str
+
+
 AscendP2PMsg = Union[
     AscendBatchedLookupAndGetMsg,
     AscendBatchedLookupAndGetRetMsg,
@@ -90,6 +98,8 @@ AscendP2PMsg = Union[
     P2PErrorMsg,
     AscendBatchedLookupAndGetDoneMsg,
     AscendBatchedLookupAndGetDoneRetMsg,
+    AscendQueryDonePortMsg,
+    AscendQueryDonePortRetMsg,
 ]
 
 
@@ -265,9 +275,17 @@ class AscendP2PBackend(P2PBackend):
         self.running.set()
         self.async_context: Optional[zmq.asyncio.Context] = None
         self.async_peer_socket: Optional[zmq.asyncio.Socket] = None
+        self.async_done_socket: Optional[zmq.asyncio.Socket] = None
+        self.peer_done_url: Optional[str] = None
+
+        # Per-peer done sockets (client side) keyed by target_peer_url.
+        # Each value is (asyncio.Lock, zmq.asyncio.Socket).
+        self.done_peer_sockets: dict[str, tuple[asyncio.Lock, zmq.asyncio.Socket]] = {}
+
         asyncio.run_coroutine_threadsafe(
             self._run_peer_request_handler_with_recovery(), loop
         )
+        asyncio.run_coroutine_threadsafe(self._run_done_handler_with_recovery(), loop)
         asyncio.run_coroutine_threadsafe(
             self._sweep_expired_pending_pull_resources(), loop
         )
@@ -309,6 +327,11 @@ class AscendP2PBackend(P2PBackend):
                 ret_msg = await self._handle_batched_lookup_and_put(msg)
             elif isinstance(msg, AscendBatchedLookupAndGetDoneMsg):
                 ret_msg = await self._handle_batched_lookup_and_get_done(msg)
+            elif isinstance(msg, AscendQueryDonePortMsg):
+                assert self.peer_done_url is not None, (
+                    "Done signal handler not ready: peer_done_url is None"
+                )
+                ret_msg = AscendQueryDonePortRetMsg(done_url=self.peer_done_url)
             else:
                 logger.error("Unknown message type: %s", type(msg))
                 ret_msg = P2PErrorMsg(error_code=P2PErrorCode.UNKNOWN_MSG_TYPE)
@@ -320,6 +343,59 @@ class AscendP2PBackend(P2PBackend):
                 logger.debug("P2P transfer finished for control signal with no tokens.")
 
             await self.async_peer_socket.send(msgspec.msgpack.encode(ret_msg))
+
+    async def _handle_done_signal_requests(self):
+        """Dedicated handler loop for Done signals on a separate REP socket.
+
+        Binds to an OS-assigned port so there are no port collisions.
+        """
+        assert self.async_context is not None
+        self.async_done_socket = get_zmq_socket_with_timeout(
+            self.async_context,
+            f"{self.peer_host}:0",
+            "tcp",
+            zmq.REP,
+            "bind",
+            self.socket_recv_timeout_ms,
+            self.socket_send_timeout_ms,
+        )
+        endpoint: bytes = self.async_done_socket.getsockopt(zmq.LAST_ENDPOINT)
+        self.peer_done_url = endpoint.decode("utf-8").replace("tcp://", "")
+        logger.info("Starting P2P done signal handler at %s", self.peer_done_url)
+
+        while self.running.is_set():
+            msg_bytes = await self.async_done_socket.recv()
+            msg = msgspec.msgpack.decode(
+                msg_bytes, type=AscendBatchedLookupAndGetDoneMsg
+            )
+            ret_msg = await self._handle_batched_lookup_and_get_done(msg)
+            await self.async_done_socket.send(msgspec.msgpack.encode(ret_msg))
+
+    async def _run_done_handler_with_recovery(self) -> None:
+        """Wrapper that runs _handle_done_signal_requests with crash recovery.
+
+        Waits for the main handler to initialise ``async_context`` first,
+        then keeps the done-signal handler alive across unexpected errors.
+        """
+        while self.running.is_set() and self.async_context is None:
+            await asyncio.sleep(0.05)
+
+        while self.running.is_set():
+            try:
+                await self._handle_done_signal_requests()
+                break
+            except asyncio.CancelledError:
+                logger.info("Done signal handler cancelled, shutting down")
+                break
+            except Exception as e:
+                logger.error("Done signal handler crashed: %s", e, exc_info=True)
+                await asyncio.sleep(0.1)
+                if self.async_done_socket is not None:
+                    try:
+                        self.async_done_socket.close(linger=0)
+                    except Exception:
+                        pass
+                    self.async_done_socket = None
 
     async def _handle_batched_lookup_and_get(
         self, msg: AscendBatchedLookupAndGetMsg
@@ -575,31 +651,141 @@ class AscendP2PBackend(P2PBackend):
                     return None
         return None
 
+    async def _ensure_done_peer_connection(
+        self,
+        target_peer_url: str,
+        force: bool = False,
+    ) -> None:
+        """Ensure a dedicated done-signal socket exists for *target_peer_url*.
+
+        On the first call for a peer, queries the peer's done-port via the
+        lookup socket (one-time) and connects a dedicated REQ socket.
+        Subsequent calls return immediately unless *force* is True, which
+        closes the old socket and re-queries (e.g. after a ZMQ error).
+        """
+        if not force and target_peer_url in self.done_peer_sockets:
+            return
+
+        if force and target_peer_url in self.done_peer_sockets:
+            _, old_socket = self.done_peer_sockets.pop(target_peer_url)
+            try:
+                old_socket.close(linger=0)
+            except Exception:
+                pass
+
+        query_msg = AscendQueryDonePortMsg()
+        ret_bytes = None
+        for query_attempt in range(2):
+            peer_info = self.target_peer_info_mapping[target_peer_url]
+            async with peer_info.lookup_lock:
+                try:
+                    await peer_info.lookup_socket.send(
+                        msgspec.msgpack.encode(query_msg)
+                    )
+                    ret_bytes = await peer_info.lookup_socket.recv()
+                    break
+                except zmq.ZMQError:
+                    if query_attempt == 0:
+                        pass
+                    else:
+                        raise
+            if ret_bytes is not None:
+                break
+            await self._ensure_peer_connection(target_peer_url, True)
+
+        if ret_bytes is None:
+            raise RuntimeError(
+                "Done port query failed for %s (lookup socket in bad state)"
+                % target_peer_url
+            )
+        ret_msg = msgspec.msgpack.decode(ret_bytes, type=AscendP2PMsg)
+        if not isinstance(ret_msg, AscendQueryDonePortRetMsg):
+            raise RuntimeError(
+                f"Unexpected response to AscendQueryDonePortMsg: {type(ret_msg)}"
+            )
+        done_url = ret_msg.done_url
+        logger.info(
+            "Discovered done port for peer %s: %s",
+            target_peer_url,
+            done_url,
+        )
+
+        ctx = get_zmq_context()
+        done_socket = get_zmq_socket_with_timeout(
+            ctx,
+            done_url,
+            "tcp",
+            zmq.REQ,
+            "connect",
+            self.socket_recv_timeout_ms,
+            self.socket_send_timeout_ms,
+        )
+        self.done_peer_sockets[target_peer_url] = (
+            asyncio.Lock(),
+            done_socket,
+        )
+        # ZMQ connect() is asynchronous; yield so the TCP connection can
+        # establish before the first send (avoids EAGAIN "Resource temporarily
+        # unavailable" on immediate send).
+        await asyncio.sleep(0.05)
+
     async def _send_done_signal(
         self,
         lookup_id: str,
         target_peer_url: str,
     ) -> None:
-        """Send Done signal to peer so it can release pinned resources.
+        """Send Done signal on the dedicated done socket with retry.
 
-        This is critical to prevent memory leaks on the server side.
+        Uses a per-peer done socket that is fully isolated from the
+        lookup socket, preventing the ZMQ REQ/REP state-machine
+        poisoning cascade.
         """
-        try:
-            done_msg = AscendBatchedLookupAndGetDoneMsg(
-                lookup_id=lookup_id,
-            )
-            peer_info = self.target_peer_info_mapping[target_peer_url]
-            async with peer_info.lookup_lock:
-                await peer_info.lookup_socket.send(msgspec.msgpack.encode(done_msg))
-                # Wait for Ack (required for ZMQ REQ/REP state machine)
-                await peer_info.lookup_socket.recv()
-        except Exception as e:
-            logger.error(
-                "Error sending P2P Done signal for lookup_id %s: %s",
-                lookup_id,
-                e,
-                exc_info=True,
-            )
+        done_msg = AscendBatchedLookupAndGetDoneMsg(lookup_id=lookup_id)
+        encoded = msgspec.msgpack.encode(done_msg)
+
+        for attempt in range(self.max_retry_count):
+            try:
+                await self._ensure_done_peer_connection(target_peer_url)
+            except Exception as e:
+                logger.error(
+                    "Failed to ensure done peer connection for "
+                    "lookup_id %s (attempt %d/%d): %s",
+                    lookup_id,
+                    attempt + 1,
+                    self.max_retry_count,
+                    e,
+                )
+                continue
+
+            done_lock, done_socket = self.done_peer_sockets[target_peer_url]
+            async with done_lock:
+                try:
+                    await done_socket.send(encoded)
+                    await done_socket.recv()
+                    return
+                except zmq.ZMQError as e:
+                    logger.warning(
+                        "ZMQ error sending Done for %s (attempt %d/%d): %s",
+                        lookup_id,
+                        attempt + 1,
+                        self.max_retry_count,
+                        e,
+                    )
+                    await self._ensure_done_peer_connection(target_peer_url, force=True)
+                except Exception as e:
+                    logger.error(
+                        "Error sending Done for %s: %s",
+                        lookup_id,
+                        e,
+                        exc_info=True,
+                    )
+                    return
+
+        logger.error(
+            "Failed to send Done for %s after %d attempts",
+            lookup_id,
+            self.max_retry_count,
+        )
 
     async def _handle_pull_mode_transfer(
         self,
@@ -771,3 +957,25 @@ class AscendP2PBackend(P2PBackend):
         transfer_spec: Any = None,
     ) -> None:
         raise NotImplementedError("Batched put is not implemented for AscendP2PBackend")
+
+    def close(self) -> None:
+        """Close the Ascend P2P backend, including dedicated done sockets."""
+        for peer_url, (_, sock) in self.done_peer_sockets.items():
+            try:
+                sock.close(linger=0)
+            except Exception as e:
+                logger.warning(
+                    "Failed to close done socket for peer %s: %s",
+                    peer_url,
+                    e,
+                )
+        self.done_peer_sockets.clear()
+
+        if self.async_done_socket is not None:
+            try:
+                self.async_done_socket.close(linger=0)
+            except Exception as e:
+                logger.warning("Failed to close async done socket: %s", e)
+            self.async_done_socket = None
+
+        super().close()

--- a/lmcache_ascend/v1/storage_backend/p2p_backend.py
+++ b/lmcache_ascend/v1/storage_backend/p2p_backend.py
@@ -670,8 +670,8 @@ class AscendP2PBackend(P2PBackend):
             _, old_socket = self.done_peer_sockets.pop(target_peer_url)
             try:
                 old_socket.close(linger=0)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to close old done socket for peer %s: %s", target_peer_url, e)
 
         query_msg = AscendQueryDonePortMsg()
         ret_bytes = None

--- a/lmcache_ascend/v1/storage_backend/p2p_backend.py
+++ b/lmcache_ascend/v1/storage_backend/p2p_backend.py
@@ -671,7 +671,11 @@ class AscendP2PBackend(P2PBackend):
             try:
                 old_socket.close(linger=0)
             except Exception as e:
-                logger.warning("Failed to close old done socket for peer %s: %s", target_peer_url, e)
+                logger.warning(
+                    "Failed to close old done socket for peer %s: %s",
+                    target_peer_url,
+                    e,
+                )
 
         query_msg = AscendQueryDonePortMsg()
         ret_bytes = None

--- a/lmcache_ascend/v1/transfer_channel/hcomm_onesided_channel.py
+++ b/lmcache_ascend/v1/transfer_channel/hcomm_onesided_channel.py
@@ -152,6 +152,22 @@ class HcommOneSidedChannel(BaseMultiBufferChannel):
         peer_init_url: str,
         init_side_msg: Optional[InitSideMsgBase] = None,
     ) -> Optional[InitSideRetMsgBase]:
+        with self._state_lock:
+            already_has_peer = peer_id in self._peers
+        if already_has_peer:
+            if init_side_msg is None:
+                return None
+            init_tmp_socket = get_zmq_socket(
+                self.zmq_context, peer_init_url, "tcp", zmq.REQ, "connect"
+            )
+            try:
+                return self.send_init_side_msg(init_tmp_socket, init_side_msg)
+            except Exception as e:
+                logger.error("Failed to send init side message: %s", e)
+                return None
+            finally:
+                init_tmp_socket.close()
+
         init_tmp_socket = get_zmq_socket(
             self.zmq_context, peer_init_url, "tcp", zmq.REQ, "connect"
         )
@@ -225,6 +241,24 @@ class HcommOneSidedChannel(BaseMultiBufferChannel):
         peer_init_url: str,
         init_side_msg: Optional[InitSideMsgBase] = None,
     ) -> Optional[InitSideRetMsgBase]:
+        with self._state_lock:
+            already_has_peer = peer_id in self._peers
+        if already_has_peer:
+            if init_side_msg is None:
+                return None
+            init_tmp_socket = get_zmq_socket(
+                self.zmq_context, peer_init_url, "tcp", zmq.REQ, "connect"
+            )
+            try:
+                return await self.async_send_init_side_msg(
+                    init_tmp_socket, init_side_msg
+                )
+            except Exception as e:
+                logger.error("Failed to send init side message: %s", e)
+                return None
+            finally:
+                init_tmp_socket.close()
+
         init_tmp_socket = get_zmq_socket(
             self.zmq_context, peer_init_url, "tcp", zmq.REQ, "connect"
         )

--- a/lmcache_ascend/v1/transfer_channel/hcomm_onesided_runtime.py
+++ b/lmcache_ascend/v1/transfer_channel/hcomm_onesided_runtime.py
@@ -6,6 +6,7 @@ import os
 import random
 import socket
 import subprocess
+import threading
 import time
 
 # Third Party
@@ -34,9 +35,47 @@ _V2_SOC_NAMES = frozenset(
     }
 )
 
-_HCOMM_INIT_MAX_RETRIES = int(os.environ.get("LMCACHE_HCOMM_INIT_MAX_RETRIES", "5"))
-_HCOMM_INIT_BASE_DELAY = 0.1
+_HCOMM_INIT_MAX_RETRIES = int(os.environ.get("LMCACHE_HCOMM_INIT_MAX_RETRIES", "3"))
+_HCOMM_INIT_BASE_DELAY = 0.5
 _HCOMM_INIT_MAX_DELAY = 5.0
+
+_HCOMM_PREPARE_MAX_RETRIES = int(
+    os.environ.get("LMCACHE_HCOMM_PREPARE_MAX_RETRIES", "10")
+)
+_HCOMM_PREPARE_BASE_DELAY = 0.2
+_HCOMM_PREPARE_MAX_DELAY = 1.0
+
+# Serialize init_comm_cluster_info / bind_mem / destroy_comm within a process.
+# The global one-sided comm registry (g_oneSidedCommHcomInfos) in libhcomm
+# is not thread-safe; concurrent calls from the server init thread and the
+# client init path corrupt the map and leave zombie comm names that block
+# subsequent retries with "comm Name exist" (HCCL_E_PARA).
+# NOTE: prepare() must NOT be called under this lock -- it is a blocking
+# rendezvous that needs both sides to call concurrently.
+_hccl_init_lock = threading.Lock()
+
+
+def _cleanup_failed_comm(comm: int, mem_handles: List[int]) -> None:
+    """Best-effort teardown of a comm whose prepare or bind failed.
+
+    Mirrors the cleanup sequence in ``HcommOneSidedChannel._destroy_peer_comm``
+    (unbind all handles, then destroy the comm) so that the comm name is
+    removed from ``g_oneSidedCommHcomInfos`` and the next retry can re-use it.
+
+    Must be serialized via ``_hccl_init_lock`` because ``destroy_comm``
+    modifies the same thread-unsafe global registry that
+    ``init_comm_cluster_info`` writes to.
+    """
+    with _hccl_init_lock:
+        for mh in mem_handles:
+            try:
+                hcomm_os.unbind_mem(comm, mh)
+            except Exception:
+                logger.warning("Failed to unbind mem %d from comm %d", mh, comm)
+        try:
+            hcomm_os.destroy_comm(comm)
+        except Exception:
+            logger.error("Failed to destroy comm %d", comm)
 
 
 def _init_comm_and_prepare(
@@ -45,41 +84,88 @@ def _init_comm_and_prepare(
     rank: int,
     mem_handles: List[int],
 ) -> int:
-    """Blocking helper: init comm via cluster-info JSON, bind all mem handles, prepare.
+    """Blocking helper: init comm, bind mem handles, prepare with two-level retry.
 
-    Retries ``init_comm_cluster_info`` with exponential back-off because
-    concurrent calls to HcclCommInitClusterInfoMemConfig from different
-    processes on the same node can transiently fail (HCCL error 7).
+    **Outer loop** (``_HCOMM_INIT_MAX_RETRIES``): retries the full
+    init_comm + bind_mem sequence.  On failure the comm is destroyed so
+    the name is freed in ``g_oneSidedCommHcomInfos``.
+
+    **Inner loop** (``_HCOMM_PREPARE_MAX_RETRIES``): retries only
+    ``prepare()`` on the *same* comm.  The HCCL C++ layer cleans socket
+    resources on prepare failure (``CleanSocketResource``) but leaves the
+    comm and bound memory intact, so calling ``HcclCommPrepare`` again is
+    safe -- it re-runs ``CreateLinkFullmesh`` from scratch.  Keeping the
+    comm alive avoids destroying the remote side's in-progress prepare
+    and prevents the cascading desynchronization that exhausts retries on
+    both sides.
+
+    ``_hccl_init_lock`` serializes only ``init_comm_cluster_info`` and
+    ``bind_mem`` (the operations that mutate the thread-unsafe global
+    comm registry).  ``prepare()`` runs **outside** the lock.
     """
     last_err: Optional[RuntimeError] = None
-    for attempt in range(_HCOMM_INIT_MAX_RETRIES):
+
+    for init_attempt in range(_HCOMM_INIT_MAX_RETRIES):
+        comm = None
         try:
-            comm = hcomm_os.init_comm_cluster_info(cluster_json, rank, comm_name)
-            break
+            with _hccl_init_lock:
+                comm = hcomm_os.init_comm_cluster_info(cluster_json, rank, comm_name)
+                for mh in mem_handles:
+                    hcomm_os.bind_mem(comm, mh)
         except RuntimeError as e:
+            if comm is not None:
+                _cleanup_failed_comm(comm, mem_handles)
             last_err = e
             delay = min(
-                _HCOMM_INIT_BASE_DELAY * (2**attempt),
+                _HCOMM_INIT_BASE_DELAY * (2**init_attempt),
                 _HCOMM_INIT_MAX_DELAY,
             )
             delay *= random.uniform(0.5, 1.5)
             logger.warning(
-                "init_comm_cluster_info failed (attempt %d/%d): %s  retrying in %.2fs",
-                attempt + 1,
+                "init/bind failed (attempt %d/%d): %s  retrying in %.2fs",
+                init_attempt + 1,
                 _HCOMM_INIT_MAX_RETRIES,
                 e,
                 delay,
             )
             time.sleep(delay)
-    else:
-        raise RuntimeError(
-            f"init_comm_cluster_info failed after {_HCOMM_INIT_MAX_RETRIES} attempts"
-        ) from last_err
+            continue
 
-    for mh in mem_handles:
-        hcomm_os.bind_mem(comm, mh)
-    hcomm_os.prepare(comm, timeout=120)
-    return comm
+        # init + bind succeeded -- retry prepare on the same comm
+        for prep_attempt in range(_HCOMM_PREPARE_MAX_RETRIES):
+            try:
+                hcomm_os.prepare(comm, timeout=120)
+                return comm
+            except RuntimeError as e:
+                last_err = e
+                delay = min(
+                    _HCOMM_PREPARE_BASE_DELAY * (2**prep_attempt),
+                    _HCOMM_PREPARE_MAX_DELAY,
+                )
+                delay *= random.uniform(0.5, 1.5)
+                logger.warning(
+                    "prepare failed (attempt %d/%d) for comm %s: %s  retrying in %.2fs",
+                    prep_attempt + 1,
+                    _HCOMM_PREPARE_MAX_RETRIES,
+                    comm_name,
+                    e,
+                    delay,
+                )
+                time.sleep(delay)
+
+        # prepare retries exhausted -- tear down and start full cycle over
+        logger.error(
+            "prepare exhausted %d retries for comm %s, destroying comm",
+            _HCOMM_PREPARE_MAX_RETRIES,
+            comm_name,
+        )
+        _cleanup_failed_comm(comm, mem_handles)
+
+    raise RuntimeError(
+        f"_init_comm_and_prepare failed after "
+        f"{_HCOMM_INIT_MAX_RETRIES} init attempts "
+        f"(each with {_HCOMM_PREPARE_MAX_RETRIES} prepare retries)"
+    ) from last_err
 
 
 def _is_device_memory(ptr: int) -> bool:

--- a/lmcache_ascend/v1/transfer_channel/hcomm_onesided_runtime.py
+++ b/lmcache_ascend/v1/transfer_channel/hcomm_onesided_runtime.py
@@ -60,7 +60,7 @@ def _cleanup_failed_comm(comm: int, mem_handles: List[int]) -> None:
 
     Mirrors the cleanup sequence in ``HcommOneSidedChannel._destroy_peer_comm``
     (unbind all handles, then destroy the comm) so that the comm name is
-    removed from ``g_oneSidedCommHcomInfos`` and the next retry can re-use it.
+    removed from ``g_oneSidedCommHcomInfos`` and the next retry can reuse it.
 
     Must be serialized via ``_hccl_init_lock`` because ``destroy_comm``
     modifies the same thread-unsafe global registry that


### PR DESCRIPTION
This PR addresses the following issues in the AscendP2PBackend:
1. Lookup & done (from delaypull) sockets can corrupt each other.
2. Avoid constant re-connection of the HCCLComm from lazy_init
3. Make sure we address concurrency for HCCLComm Init

**Ascend P2P Backend Improvements**
- Added dedicated per-peer "done" signal sockets to isolate resource-release signals from regular lookup sockets, preventing ZMQ REQ/REP state-machine poisoning and improving reliability. This includes new message types (`AscendQueryDonePortMsg`, `AscendQueryDonePortRetMsg`), socket management, and handler loops for done signals. 

**HCCL One-Sided Communication Initialization**
- Refactored the comm initialization process to use a two-level retry strategy: one for `init_comm_cluster_info` and `bind_mem`, and a separate, inner retry loop for `prepare()`. Added explicit cleanup of failed comms and introduced a global lock to serialize non-thread-safe operations, preventing resource leaks and zombie comm names. 

**Peer Connection Management**
- Improved logic in `lazy_init_peer_connection` and `async_lazy_init_peer_connection` to avoid redundant peer initialization and allow sending initialization messages to already-connected peers. 

**Configuration and Retry Parameters**
- Adjusted retry and delay parameters for both initialization and preparation steps, making them configurable via environment variables and increasing base delays for greater stability.

**Resource Cleanup**
- Implemented robust resource cleanup for sockets and comms, ensuring proper closure of dedicated done sockets and handling exceptions during shutdown. 

These changes collectively improve the stability, reliability, and error recovery of the distributed storage backend and one-sided communication layer.