### PR TITLE
Make NPUConnectors to take LayoutHints following upstream

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
 
     container:
       # TODO (gingfung): use strategy matrix for version tests
-      image: quay.io/ascend/vllm-ascend:v0.11.0-openeuler
+      image: quay.io/ascend/vllm-ascend:v0.18.0rc1
       env:
         SOC_VERSION: Ascend910B4
         PIP_INDEX_URL: https://mirrors.aliyun.com/pypi/simple
@@ -111,7 +111,7 @@ jobs:
           
           echo ">>> Installing LMCache Core..."
           # TODO (gingfung): use strategy matrix for different version tests
-          pip install lmcache==0.4.2
+          pip install lmcache==0.4.3
 
           echo ">>> Building LMCache-Ascend..."
           export CPLUS_INCLUDE_PATH=/usr/include/c++/12:/usr/include/c++/12/backward:/usr/include/c++/12/`uname -i`-openEuler-linux/:$CPLUS_INCLUDE_PATH
@@ -308,7 +308,7 @@ jobs:
           
           echo ">>> Installing LMCache Core..."
           # TODO (gingfung): use strategy matrix for different version tests
-          pip install lmcache==0.4.2
+          pip install lmcache==0.4.3
 
           echo ">>> Building LMCache-Ascend..."
           export CPLUS_INCLUDE_PATH=/usr/include/c++/12:/usr/include/c++/12/backward:/usr/include/c++/12/`uname -i`-openEuler-linux/:$CPLUS_INCLUDE_PATH

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please ensure your environment matches the versions below.
 #### For PyTorch / vLLM
 | LMCache-Ascend | LMCache | vLLM Version | PyTorch / Torch-NPU | Status |
 | :--- | :--- | :--- | :--- | :--- |
-| **main** | **v0.4.2** | **>=v0.11.0** | **>=2.7.1** | 🚧 **Experimental** |
+| **main** | **v0.4.3** | **>=v0.14.0** | **>=2.7.1** | 🚧 **Experimental** |
 | **v0.3.12** | **v0.3.12** | **>=v0.11.0** | **>=2.7.1** | ✅ **Verified (Recommended)** |
 
 #### For PyTorch / SGLang

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -13,7 +13,7 @@ from lmcache_ascend import _build_info
 
 # NOTE: Must be manually edited per each version and
 # is also used by the test infrastructure.
-LMCACHE_UPSTREAM_TAG = "v0.4.2"
+LMCACHE_UPSTREAM_TAG = "v0.4.3"
 LMCACHE_ASCEND_PATCHED = False
 
 

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -1,4 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
+
+# The version.py should be independent library, and we always import the
+# version library first.  Such assumption is critical for some customization.
+from ._version import __version__ as __version__  # noqa: F401  # isort:skip
+from ._version import __version_tuple__ as __version_tuple__  # noqa: F401  # isort:skip
+
+# Standard
+import sys
+
 # First Party
 from lmcache_ascend import _build_info
 
@@ -293,12 +302,35 @@ def _patch_gpu_connector():
     In LMCache 0.4.2, engine initialization uses CreateGPUConnector()
     as a factory function. We patch it to return Ascend NPU connectors
     instead of the default CUDA ones.
+
+    ``permute_kv_caches_to_contiguous`` must be patched on
+    ``lmcache.v1.gpu_connector.utils`` *before* importing
+    ``lmcache.v1.gpu_connector``, so the import in ``gpu_connectors`` binds
+    the Ascend implementation. If ``gpu_connectors`` was already loaded,
+    also replace its cached reference (same pattern as ``CreateGPUConnector``
+    on ``lmcache.v1.manager``).
     """
+    # Standard
+
+    # Third Party
+    import lmcache.v1.gpu_connector.utils as gpu_utils
+
+    # First Party
+    from lmcache_ascend.v1.npu_connector.utils import permute_kv_caches_to_contiguous
+
+    gpu_utils.permute_kv_caches_to_contiguous = permute_kv_caches_to_contiguous
+
+    _gpu_connectors_mod = sys.modules.get("lmcache.v1.gpu_connector.gpu_connectors")
+    if _gpu_connectors_mod is not None:
+        _gpu_connectors_mod.permute_kv_caches_to_contiguous = (
+            permute_kv_caches_to_contiguous
+        )
+
     # Third Party
     import lmcache.v1.gpu_connector as lm_gpu_connector
 
     # First Party
-    from lmcache_ascend.v1.gpu_connector import CreateNPUConnector
+    from lmcache_ascend.v1.npu_connector import CreateNPUConnector
 
     lm_gpu_connector.CreateGPUConnector = CreateNPUConnector
 

--- a/lmcache_ascend/integration/patch/apply_patch.py
+++ b/lmcache_ascend/integration/patch/apply_patch.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 # First Party
-from lmcache_ascend.v1.gpu_connector.npu_connectors import is_310p
+from lmcache_ascend.v1.npu_connector.npu_connectors import is_310p
 
 logger = logging.getLogger(__name__)
 

--- a/lmcache_ascend/mindspore/v1/npu_connector.py
+++ b/lmcache_ascend/mindspore/v1/npu_connector.py
@@ -28,7 +28,7 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache_ascend.v1.gpu_connector.npu_connectors import KVCacheFormat, is_310p
+from lmcache_ascend.v1.npu_connector.npu_connectors import KVCacheFormat, is_310p
 import lmcache_ascend.c_ops as lmc_ops
 
 logger = init_logger(__name__)

--- a/lmcache_ascend/mindspore/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/mindspore/v1/storage_backend/storage_manager.py
@@ -23,7 +23,7 @@ from lmcache.v1.storage_backend.storage_manager import (
 import torch
 
 # First Party
-from lmcache_ascend.v1.gpu_connector.npu_connectors import is_310p
+from lmcache_ascend.v1.npu_connector.npu_connectors import is_310p
 
 if TYPE_CHECKING:
     # Third Party

--- a/lmcache_ascend/v1/npu_connector/__init__.py
+++ b/lmcache_ascend/v1/npu_connector/__init__.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from typing import Optional
+
 # Third Party
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector.gpu_connectors import GPUConnectorInterface
-from lmcache.v1.gpu_connector.utils import need_gpu_interm_buffer
+from lmcache.v1.gpu_connector.utils import LayoutHints, need_gpu_interm_buffer
 from lmcache.v1.metadata import LMCacheMetadata
 import torch
 
@@ -14,7 +16,7 @@ from lmcache_ascend import _build_info
 
 if _build_info.__framework_name__ == "pytorch":
     # First Party
-    from lmcache_ascend.v1.gpu_connector.npu_connectors import (
+    from lmcache_ascend.v1.npu_connector.npu_connectors import (
         VLLMBufferLayerwiseNPUConnector,
         VLLMPagedMemLayerwiseNPUConnector,
         VLLMPagedMemNPUConnectorV2,
@@ -34,6 +36,7 @@ def CreateNPUConnector(
     config: LMCacheEngineConfig,
     metadata: LMCacheMetadata,
     engine: EngineType,
+    layout_hints: Optional[LayoutHints] = None,
 ) -> GPUConnectorInterface:
     """Factory function to create NPU connectors on Ascend.
 
@@ -56,11 +59,11 @@ def CreateNPUConnector(
         if config.use_layerwise:
             if config.enable_blending:
                 return VLLMBufferLayerwiseNPUConnector.from_metadata(
-                    metadata, use_gpu, device
+                    metadata, use_gpu, device, layout_hints=layout_hints
                 )
             else:
                 return VLLMPagedMemLayerwiseNPUConnector.from_metadata(
-                    metadata, use_gpu, device
+                    metadata, use_gpu, device, layout_hints=layout_hints
                 )
 
         if config.use_gpu_connector_v3:
@@ -68,10 +71,12 @@ def CreateNPUConnector(
                 "GPU Connector v3 is not supported yet. Please contact LMCache-Ascend."
             )
         else:
-            return VLLMPagedMemNPUConnectorV2.from_metadata(metadata, use_gpu, device)
+            return VLLMPagedMemNPUConnectorV2.from_metadata(
+                metadata, use_gpu, device, layout_hints=layout_hints
+            )
     elif engine == EngineType.SGLANG:
         # First Party
-        from lmcache_ascend.v1.gpu_connector.npu_connectors import (
+        from lmcache_ascend.v1.npu_connector.npu_connectors import (
             SGLangLayerwiseNPUConnector,
             SGLangNPUConnector,
         )

--- a/lmcache_ascend/v1/npu_connector/npu_connectors.py
+++ b/lmcache_ascend/v1/npu_connector/npu_connectors.py
@@ -15,6 +15,7 @@ from lmcache.v1.gpu_connector.gpu_connectors import (
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemLayerwiseGPUConnector,
 )
+from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.memory_management import GPUMemoryAllocator, MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
 import torch
@@ -527,6 +528,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         metadata: LMCacheMetadata,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
+        layout_hints: Optional[LayoutHints] = None,
     ) -> "VLLMPagedMemGPUConnectorV2":
         """Create a connector from LMCacheMetadata.
 
@@ -534,6 +536,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             metadata: The LMCache engine metadata containing model configuration.
             use_gpu: Whether to use GPU intermediate buffer.
             device: The device to use for the connector.
+            layout_hints: Optional KV layout hints from the serving engine.
 
         Returns:
             A new instance of VLLMPagedMemGPUConnectorV2.
@@ -556,6 +559,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             use_mla=metadata.use_mla,
             num_kv_head=num_kv_head,
             head_size=head_size,
+            layout_hints=layout_hints,
         )
 
     def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
@@ -806,7 +810,6 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
 
         kv_cache_pointers = self._initialize_pointers(self.kvcaches)
-
         lmc_ops.multi_layer_kv_transfer(
             memory_obj.tensor,
             kv_cache_pointers,

--- a/lmcache_ascend/v1/npu_connector/npu_connectors.py
+++ b/lmcache_ascend/v1/npu_connector/npu_connectors.py
@@ -539,7 +539,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             layout_hints: Optional KV layout hints from the serving engine.
 
         Returns:
-            A new instance of VLLMPagedMemGPUConnectorV2.
+            A new instance of VLLMPagedMemNPUConnectorV2.
         """
         # Extract parameters from metadata
         # kv_shape: (num_layer, 2 or 1, chunk_size, num_kv_head, head_size)

--- a/lmcache_ascend/v1/npu_connector/utils.py
+++ b/lmcache_ascend/v1/npu_connector/utils.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import List, Union
+
+# Third Party
+from lmcache.v1.gpu_connector.utils import permute_to_contiguous
+import torch
+
+_KVTupleTwoOrMore = tuple[torch.Tensor, torch.Tensor, *tuple[torch.Tensor, ...]]
+_KVLayer = Union[torch.Tensor, _KVTupleTwoOrMore]
+
+
+def permute_kv_caches_to_contiguous(
+    kv_caches: List[_KVLayer],
+) -> List[_KVLayer]:
+    """Apply :func:`permute_to_contiguous` to each tensor in *kv_caches*.
+
+    Each entry is either a single ``torch.Tensor`` (merged KV) or a tuple of
+    two or more tensors (e.g. K/V, or more parts). The returned list has the
+    same length and
+    structure; tensors are metadata-only permutes where applicable and may
+    share storage with the inputs (see upstream ``permute_to_contiguous``).
+    """
+    results: List[_KVLayer] = []
+    for layer in kv_caches:
+        if isinstance(layer, torch.Tensor):
+            results.append(permute_to_contiguous(layer))
+        elif isinstance(layer, tuple):
+            if len(layer) < 2:
+                raise ValueError(
+                    "Tuple KV entries must contain at least two tensors; "
+                    f"got len={len(layer)}"
+                )
+            permuted: list[torch.Tensor] = []
+            for t in layer:
+                if not isinstance(t, torch.Tensor):
+                    raise ValueError(
+                        f"Expected torch.Tensor inside KV tuple, got {type(t)}"
+                    )
+                permuted.append(permute_to_contiguous(t))
+            results.append(tuple(permuted))
+        else:
+            raise ValueError(
+                f"Unsupported KV cache entry type: {type(layer)} "
+                "(expected Tensor or tuple of Tensors)"
+            )
+    return results

--- a/lmcache_ascend/v1/npu_connector/utils.py
+++ b/lmcache_ascend/v1/npu_connector/utils.py
@@ -31,7 +31,7 @@ def permute_kv_caches_to_contiguous(
                     "Tuple KV entries must contain at least two tensors; "
                     f"got len={len(layer)}"
                 )
-            permuted: list[torch.Tensor] = []
+            permuted: List[torch.Tensor] = []
             for t in layer:
                 if not isinstance(t, torch.Tensor):
                     raise ValueError(

--- a/lmcache_ascend/v1/npu_connector/utils.py
+++ b/lmcache_ascend/v1/npu_connector/utils.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import List, Union
+from typing import List, Tuple, Union
 
 # Third Party
 from lmcache.v1.gpu_connector.utils import permute_to_contiguous

--- a/lmcache_ascend/v1/npu_connector/utils.py
+++ b/lmcache_ascend/v1/npu_connector/utils.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from lmcache.v1.gpu_connector.utils import permute_to_contiguous
 import torch
 
-_KVTupleTwoOrMore = tuple[torch.Tensor, torch.Tensor, *tuple[torch.Tensor, ...]]
+_KVTupleTwoOrMore = Tuple[torch.Tensor, ...]
 _KVLayer = Union[torch.Tensor, _KVTupleTwoOrMore]
 
 

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -4,7 +4,7 @@ from lmcache_tests.v1.utils import *
 import torch
 
 # First Party
-from lmcache_ascend.v1.gpu_connector.npu_connectors import VLLMPagedMemNPUConnectorV2
+from lmcache_ascend.v1.npu_connector.npu_connectors import VLLMPagedMemNPUConnectorV2
 
 
 def create_npu_connector(hidden_dim, num_layers):


### PR DESCRIPTION
# Background
vLLM introduces NHD and HND layouts.
Currently, this PR added the layout hints typing so it work with the upstream LMCache.

# TODO
- We should make the NPUConnector to work with the HND layouts. #214
