### PR TITLE
chore: adapt to upstream LMCache v0.4.4

### DIFF
--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -13,7 +13,7 @@ from lmcache_ascend import _build_info
 
 # NOTE: Must be manually edited per each version and
 # is also used by the test infrastructure.
-LMCACHE_UPSTREAM_TAG = "v0.4.3"
+LMCACHE_UPSTREAM_TAG = "v0.4.4"
 LMCACHE_ASCEND_PATCHED = False
 
 
@@ -190,6 +190,37 @@ def _patch_config():
         "env_converter": int,
         "description": "Maximum number of pending async store tasks in queue. "
         "Set 0 for an unbounded queue; values > 0 enable bounded backpressure.",
+    }
+
+    # v0.4.4: New config fields from upstream
+    lmcache.v1.config._CONFIG_DEFINITIONS["local_disk_path_sharding"] = {
+        "type": str,
+        "default": "by_gpu",
+        "env_converter": str,
+    }
+
+    lmcache.v1.config._CONFIG_DEFINITIONS["pd_skip_proxy_notification"] = {
+        "type": bool,
+        "default": False,
+        "env_converter": _to_bool,
+    }
+
+    lmcache.v1.config._CONFIG_DEFINITIONS["gds_buffer_size"] = {
+        "type": Optional[int],
+        "default": None,
+        "env_converter": int,
+    }
+
+    lmcache.v1.config._CONFIG_DEFINITIONS["use_gds"] = {
+        "type": bool,
+        "default": True,
+        "env_converter": _to_bool,
+    }
+
+    lmcache.v1.config._CONFIG_DEFINITIONS["gds_backend"] = {
+        "type": str,
+        "default": "cufile",
+        "env_converter": str,
     }
 
     namespace_extras = {

--- a/lmcache_ascend/v1/npu_connector/npu_connectors.py
+++ b/lmcache_ascend/v1/npu_connector/npu_connectors.py
@@ -501,7 +501,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
                 "Unable to determine the format of input kv_caches."
             )
 
-        if self.kv_format.is_tuple_format():
+        if self.kv_format.is_separate_format():
             self.kvcaches_device = kv_caches[0][0].device
         else:
             self.kvcaches_device = kv_caches[0].device
@@ -1260,8 +1260,9 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
         if self.use_gpu:
             buffer_shape = self.get_shape(num_tokens)
             assert self.gpu_buffer_allocator is not None
+            mem_fmt = MemoryFormat.KV_MLA_FMT if self.use_mla else MemoryFormat.KV_T2D
             tmp_gpu_buffer_obj = self.gpu_buffer_allocator.allocate(
-                buffer_shape, self.dtype, MemoryFormat.KV_T2D
+                buffer_shape, self.dtype, mem_fmt
             )
             assert tmp_gpu_buffer_obj is not None, (
                 "Failed to allocate NPU buffer in NPUConnector"
@@ -1395,8 +1396,9 @@ class VLLMPagedMemLayerwiseNPUConnector(VLLMPagedMemLayerwiseGPUConnector):
         if self.use_gpu:
             buffer_shape = self.get_shape(num_tokens)
             assert self.gpu_buffer_allocator is not None
+            mem_fmt = MemoryFormat.KV_MLA_FMT if self.use_mla else MemoryFormat.KV_T2D
             tmp_gpu_buffer_obj = self.gpu_buffer_allocator.allocate(
-                buffer_shape, self.dtype, MemoryFormat.KV_T2D
+                buffer_shape, self.dtype, mem_fmt
             )
             assert tmp_gpu_buffer_obj is not None, (
                 "Failed to allocate NPU buffer in NPUConnector"
@@ -1564,7 +1566,7 @@ class SGLangLayerwiseNPUConnector(SGLangLayerwiseGPUConnector):
                 "GPU buffer allocator should be initialized"
             )
             tmp_gpu_buffer_obj = self.gpu_buffer_allocator.allocate(
-                buffer_shape, self.dtype, MemoryFormat.KV_T2D
+                buffer_shape, self.dtype, MemoryFormat.KV_MLA_FMT if self.use_mla else MemoryFormat.KV_T2D
             )
             assert tmp_gpu_buffer_obj is not None, (
                 "Failed to allocate GPU buffer in GPUConnector"
@@ -1679,7 +1681,7 @@ class SGLangLayerwiseNPUConnector(SGLangLayerwiseGPUConnector):
                 "GPU buffer allocator should be initialized"
             )
             tmp_gpu_buffer_obj = self.gpu_buffer_allocator.allocate(
-                buffer_shape, self.dtype, MemoryFormat.KV_T2D
+                buffer_shape, self.dtype, MemoryFormat.KV_MLA_FMT if self.use_mla else MemoryFormat.KV_T2D
             )
             assert tmp_gpu_buffer_obj is not None, (
                 "Failed to allocate GPU buffer in GPUConnector"

--- a/lmcache_ascend/v1/npu_connector/npu_connectors.py
+++ b/lmcache_ascend/v1/npu_connector/npu_connectors.py
@@ -501,7 +501,7 @@ class VLLMPagedMemNPUConnectorV2(VLLMPagedMemGPUConnectorV2):
                 "Unable to determine the format of input kv_caches."
             )
 
-        if self.kv_format.is_separate_format():
+        if self.kv_format.is_tuple_format():
             self.kvcaches_device = kv_caches[0][0].device
         else:
             self.kvcaches_device = kv_caches[0].device


### PR DESCRIPTION
## Upstream Sync: LMCache v0.4.4

Adapt LMCache-Ascend to upstream [v0.4.4](https://github.com/LMCache/LMCache/releases/tag/v0.4.4) release.

### Upstream Changes Affecting Ascend

| Upstream File | Change | Ascend Adaptation |
|---|---|---|
| `gpu_connector/gpu_connectors.py` | Buffer allocation: `MemoryFormat.KV_T2D` → conditional based on `use_mla` | `npu_connectors.py`: 4 buffer allocate sites updated |
| `config.py` | New fields: `local_disk_path_sharding`, `pd_skip_proxy_notification`, `gds_buffer_size`, `use_gds`, `gds_backend` | `__init__.py`: 5 new config fields injected |
| `cache_engine.py` | `retrieve()` bug fix (`<` -> `>`) + ref_count_down cleanup | Ascend does not override `retrieve`, inherits upstream fix automatically |
| `memory_management.py` | c_ops import unguarded + `byte_array` uses `get_size()` | Ascend does not override these methods, inherits upstream fix automatically |
| `storage_backend/__init__.py` | remote_storage_plugins new feature | Ascend has a completely independent implementation, not affected |

### Changes in This PR

**`lmcache_ascend/__init__.py`** (+32 lines):
- Update `LMCACHE_UPSTREAM_TAG` to `"v0.4.4"`
- Inject 5 new upstream config fields into `_CONFIG_DEFINITIONS`

**`lmcache_ascend/v1/npu_connector/npu_connectors.py`** (+5/-2 lines):
- Buffer allocation: `MemoryFormat.KV_T2D` → `MemoryFormat.KV_MLA_FMT if self.use_mla else MemoryFormat.KV_T2D` (4 occurrences in `VLLMPagedMemLayerwiseNPUConnector` and `SGLangLayerwiseNPUConnector`)

### Not Changed (Verified Unnecessary)

- `cache_engine.py`: AscendLMCacheEngine inherits from upstream, `retrieve()` fix applies automatically
- `memory_management.py`: Ascend version only overrides `GPUMemoryAllocator.__init__`
- `storage_backend/__init__.py`: Ascend has completely independent implementation
- `npu_connectors.py`: `is_tuple_format()` method is Ascend-specific (defined in `kv_format.py`), NOT an upstream API — no rename needed

### Testing

- [x] Python syntax check passed (`ast.parse`)
- [ ] Ascend NPU integration test (pending)