### PR TITLE
fix ci certificate verification failed

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,8 @@ jobs:
       # TODO (gingfung): use strategy matrix for version tests
       image: quay.io/ascend/vllm-ascend:v0.18.0rc1
       env:
+        GIT_SSL_CAINFO: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+        PIP_CERT: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         SOC_VERSION: Ascend910B4
         PIP_INDEX_URL: https://mirrors.aliyun.com/pypi/simple
         LMCACHE_TRACK_USAGE: false


### PR DESCRIPTION
When using the standard image, certificate authentication fails during git fetch. It is necessary to use the OpenEuler version certificate from the host machine.