### PR TITLE
Move Ascend P2P by keeping outbound P2P socket operations on the dedicated Ascend P2P event loop.

### DIFF
--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -453,6 +453,16 @@ def _patch_lookup_client():
     )
 
 
+def _patch_cache_controller_worker():
+    # Third Party
+    import lmcache.v1.cache_controller.worker as lmc_worker
+
+    # First Party
+    from lmcache_ascend.v1.cache_controller.worker import async_put_and_wait_msg
+
+    lmc_worker.LMCacheWorker.async_put_and_wait_msg = async_put_and_wait_msg
+
+
 def _patch_sys_detection():
     # Patching this as on some Ascend machines
     # as the kernel can set the NUMA node to -1.
@@ -562,6 +572,7 @@ if not LMCACHE_ASCEND_PATCHED:
         _patch_cacheblend()
         _patch_multi_process()
         _patch_lookup_client()
+        _patch_cache_controller_worker()
         _patch_rpc_utils()
 
     _patch_kv_layer_group()

--- a/lmcache_ascend/v1/cache_controller/__init__.py
+++ b/lmcache_ascend/v1/cache_controller/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache_ascend/v1/cache_controller/worker.py
+++ b/lmcache_ascend/v1/cache_controller/worker.py
@@ -65,6 +65,18 @@ async def _async_put_and_wait_msg_on_worker_loop(
             serialized_ret_msg = frames[-1]
             ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
             return ret_msg
+        except asyncio.CancelledError:
+            # Outer ``asyncio.wait_for`` / task cancellation can interrupt between
+            # send and recv, leaving the DEALER socket in an inconsistent state.
+            # Recreate immediately so the next request does not fail first.
+            logger.warning(
+                "LMCacheWorker controller request cancelled, recreating socket: "
+                "worker_id=%s msg_type=%s",
+                getattr(worker, "worker_id", None),
+                msg_type,
+            )
+            worker._recreate_req_socket()
+            raise
         except (asyncio.TimeoutError, zmq.Again) as e:
             logger.error(
                 "LMCacheWorker controller request timed out, recreating socket: "

--- a/lmcache_ascend/v1/cache_controller/worker.py
+++ b/lmcache_ascend/v1/cache_controller/worker.py
@@ -1,5 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Ascend patches for LMCache controller worker RPCs."""
+"""Ascend replacement for ``LMCacheWorker.async_put_and_wait_msg``.
+
+The upstream worker owns one ``zmq.asyncio`` DEALER (``req_socket``) for
+controller RPCs. The common upstream P2P path usually works even though
+registration runs on ``LMCacheWorker.loop`` and async lookup later calls from
+``StorageManager.loop``: registration has completed, and each lookup owns its
+send/recv pair, so another loop is not normally awaiting the same socket.
+
+Ascend makes that assumption brittle. Peer sockets and transfer-channel work run
+on ``AscendP2PBackend``'s dedicated background loop, and retrieval paths bridge
+between storage-manager, P2P, and worker loops. Since ``zmq.asyncio`` readiness
+is registered with the loop doing the await, this patch pins non-heartbeat
+controller I/O to ``LMCacheWorker.loop``. Cross-loop callers hop there with
+``asyncio.run_coroutine_threadsafe``; send/recv is serialized, and timeout,
+cancellation, or ZMQ errors recreate ``req_socket`` before reuse.
+"""
 
 # Standard
 from concurrent.futures import TimeoutError as FutureTimeoutError
@@ -43,14 +58,7 @@ async def _async_put_and_wait_msg_on_worker_loop(
     worker: Any,
     msg: WorkerReqMsg,
 ) -> WorkerReqRetMsg:
-    """Run controller request/reply I/O on ``worker.loop`` only.
-
-    ``zmq.asyncio.Socket`` instances are event-loop-bound in practice.  The
-    upstream worker creates/uses ``req_socket`` on ``LMCacheWorker.loop`` during
-    registration, but P2P async lookup can call ``async_put_and_wait_msg`` from
-    the storage-manager loop.  Keeping the DEALER socket on one loop avoids late
-    wakeups where a reply is not observed until another request pokes the loop.
-    """
+    """Non-heartbeat DEALER send/recv on ``worker.loop`` (see module docstring)."""
     if isinstance(msg, HeartbeatMsg):
         return await worker._send_heartbeat_msg(msg)
 
@@ -113,12 +121,7 @@ async def async_put_and_wait_msg(
     self: Any,
     msg: WorkerReqMsg,
 ) -> WorkerReqRetMsg:
-    """Patched ``LMCacheWorker.async_put_and_wait_msg``.
-
-    If called from another event loop, marshal the actual socket operation to
-    ``self.loop`` and await the thread-safe future without blocking the caller's
-    loop.  If already on ``self.loop``, execute directly.
-    """
+    """Dispatch controller RPCs onto ``LMCacheWorker.loop`` when needed."""
     worker_loop = getattr(self, "loop", None)
     try:
         running_loop = asyncio.get_running_loop()
@@ -133,6 +136,9 @@ async def async_put_and_wait_msg(
         worker_loop,
     )
     try:
+        # The inner recv timeout owns socket recovery.  The outer timeout gives
+        # that coroutine a little extra time to recreate the socket and return a
+        # typed failure response before the caller stops waiting.
         return await asyncio.wait_for(
             asyncio.wrap_future(future),
             timeout=_outer_timeout_s(self),

--- a/lmcache_ascend/v1/cache_controller/worker.py
+++ b/lmcache_ascend/v1/cache_controller/worker.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ascend patches for LMCache controller worker RPCs."""
+
+# Standard
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from typing import Any
+import asyncio
+
+# Third Party
+from lmcache.logging import init_logger
+from lmcache.v1.cache_controller.message import (
+    HeartbeatMsg,
+    Msg,
+    WorkerReqMsg,
+    WorkerReqRetMsg,
+)
+import msgspec
+import zmq
+
+logger = init_logger(__name__)
+
+
+def _request_timeout_s(worker: Any) -> float:
+    timeout_ms = getattr(worker, "socket_recv_timeout_ms", 30000)
+    return max(float(timeout_ms) / 1000.0, 0.001)
+
+
+def _outer_timeout_s(worker: Any) -> float:
+    # Give the worker-loop coroutine a little room to run its own timeout
+    # handling and recreate the socket before the caller gives up.
+    return _request_timeout_s(worker) + 1.0
+
+
+def _get_req_socket_lock(worker: Any) -> asyncio.Lock:
+    lock = getattr(worker, "_ascend_req_socket_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        worker._ascend_req_socket_lock = lock
+    return lock
+
+
+async def _async_put_and_wait_msg_on_worker_loop(
+    worker: Any,
+    msg: WorkerReqMsg,
+) -> WorkerReqRetMsg:
+    """Run controller request/reply I/O on ``worker.loop`` only.
+
+    ``zmq.asyncio.Socket`` instances are event-loop-bound in practice.  The
+    upstream worker creates/uses ``req_socket`` on ``LMCacheWorker.loop`` during
+    registration, but P2P async lookup can call ``async_put_and_wait_msg`` from
+    the storage-manager loop.  Keeping the DEALER socket on one loop avoids late
+    wakeups where a reply is not observed until another request pokes the loop.
+    """
+    if isinstance(msg, HeartbeatMsg):
+        return await worker._send_heartbeat_msg(msg)
+
+    msg_type = type(msg).__name__
+    async with _get_req_socket_lock(worker):
+        try:
+            await worker.req_socket.send_multipart([b"", msgspec.msgpack.encode(msg)])
+            frames = await asyncio.wait_for(
+                worker.req_socket.recv_multipart(),
+                timeout=_request_timeout_s(worker),
+            )
+            serialized_ret_msg = frames[-1]
+            ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
+            return ret_msg
+        except (asyncio.TimeoutError, zmq.Again) as e:
+            logger.error(
+                "LMCacheWorker controller request timed out, recreating socket: "
+                "worker_id=%s msg_type=%s error=%s",
+                getattr(worker, "worker_id", None),
+                msg_type,
+                e,
+            )
+            worker._recreate_req_socket()
+            return worker._on_request_failure(msg)
+        except zmq.ZMQError as e:
+            logger.error(
+                "LMCacheWorker controller request hit ZMQ error, recreating socket: "
+                "worker_id=%s msg_type=%s error=%s",
+                getattr(worker, "worker_id", None),
+                msg_type,
+                e,
+            )
+            worker._recreate_req_socket()
+            return worker._on_request_failure(msg)
+        except Exception as e:
+            logger.error(
+                "LMCacheWorker controller request failed: worker_id=%s "
+                "msg_type=%s error=%s",
+                getattr(worker, "worker_id", None),
+                msg_type,
+                e,
+                exc_info=True,
+            )
+            return worker._on_request_failure(msg)
+
+
+async def async_put_and_wait_msg(
+    self: Any,
+    msg: WorkerReqMsg,
+) -> WorkerReqRetMsg:
+    """Patched ``LMCacheWorker.async_put_and_wait_msg``.
+
+    If called from another event loop, marshal the actual socket operation to
+    ``self.loop`` and await the thread-safe future without blocking the caller's
+    loop.  If already on ``self.loop``, execute directly.
+    """
+    worker_loop = getattr(self, "loop", None)
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    if worker_loop is None or running_loop is worker_loop:
+        return await _async_put_and_wait_msg_on_worker_loop(self, msg)
+
+    future = asyncio.run_coroutine_threadsafe(
+        _async_put_and_wait_msg_on_worker_loop(self, msg),
+        worker_loop,
+    )
+    try:
+        return await asyncio.wait_for(
+            asyncio.wrap_future(future),
+            timeout=_outer_timeout_s(self),
+        )
+    except (asyncio.TimeoutError, FutureTimeoutError) as e:
+        future.cancel()
+        logger.error(
+            "LMCacheWorker controller request did not finish on worker loop: "
+            "worker_id=%s msg_type=%s timeout_s=%.2f error=%s",
+            getattr(self, "worker_id", None),
+            type(msg).__name__,
+            _outer_timeout_s(self),
+            e,
+        )
+        return self._on_request_failure(msg)

--- a/lmcache_ascend/v1/storage_backend/p2p_backend.py
+++ b/lmcache_ascend/v1/storage_backend/p2p_backend.py
@@ -289,6 +289,7 @@ class AscendP2PBackend(P2PBackend):
         self.async_peer_socket: Optional[zmq.asyncio.Socket] = None
         self.async_done_socket: Optional[zmq.asyncio.Socket] = None
         self.peer_done_url: Optional[str] = None
+        self._async_context_ready = asyncio.Event()
 
         # Per-peer done sockets (client side) keyed by target_peer_url.
         # Each value is (asyncio.Lock, zmq.asyncio.Socket).
@@ -317,9 +318,15 @@ class AscendP2PBackend(P2PBackend):
         future = asyncio.run_coroutine_threadsafe(coro, self.loop)
         return await asyncio.wrap_future(future)
 
+    def _set_async_context_ready(self) -> None:
+        if self._is_on_p2p_loop():
+            self._async_context_ready.set()
+            return
+        self.loop.call_soon_threadsafe(self._async_context_ready.set)
+
     async def _wait_for_async_context(self) -> None:
-        while self.running.is_set() and self.async_context is None:
-            await asyncio.sleep(0.01)
+        if self.async_context is None and self.running.is_set():
+            await self._async_context_ready.wait()
         if self.async_context is None:
             raise RuntimeError("P2P async context is not initialized")
 
@@ -352,6 +359,7 @@ class AscendP2PBackend(P2PBackend):
             "Starting P2P backend batched get handler at %s", self.peer_lookup_url
         )
         self.async_context = get_zmq_context()
+        self._set_async_context_ready()
         self.async_peer_socket = get_zmq_socket_with_timeout(
             self.async_context,
             self.peer_lookup_url,
@@ -402,7 +410,7 @@ class AscendP2PBackend(P2PBackend):
 
         Binds to an OS-assigned port so there are no port collisions.
         """
-        assert self.async_context is not None
+        await self._wait_for_async_context()
         self.async_done_socket = get_zmq_socket_with_timeout(
             self.async_context,
             f"{self.peer_host}:0",
@@ -430,8 +438,12 @@ class AscendP2PBackend(P2PBackend):
         Waits for the main handler to initialise ``async_context`` first,
         then keeps the done-signal handler alive across unexpected errors.
         """
-        while self.running.is_set() and self.async_context is None:
-            await asyncio.sleep(0.05)
+        try:
+            await self._wait_for_async_context()
+        except RuntimeError:
+            if self.running.is_set():
+                raise
+            return
 
         while self.running.is_set():
             try:
@@ -762,7 +774,7 @@ class AscendP2PBackend(P2PBackend):
             )
         done_url = ret_msg.done_url
 
-        assert self.async_context is not None
+        await self._wait_for_async_context()
         ctx = self.async_context
         done_socket = get_zmq_socket_with_timeout(
             ctx,
@@ -1026,6 +1038,8 @@ class AscendP2PBackend(P2PBackend):
 
     def close(self) -> None:
         """Close the Ascend P2P backend, including dedicated done sockets."""
+        self._set_async_context_ready()
+
         for peer_url, (_, sock) in self.done_peer_sockets.items():
             try:
                 sock.close(linger=0)

--- a/lmcache_ascend/v1/storage_backend/p2p_backend.py
+++ b/lmcache_ascend/v1/storage_backend/p2p_backend.py
@@ -268,6 +268,7 @@ class AscendP2PBackend(P2PBackend):
 
         self.chunk_size = config.chunk_size
 
+        # Keep transfer-channel ZMQ I/O on the Ascend P2P backend loop.
         self.transfer_channel = CreateTransferChannel(
             channel_type=config.transfer_channel,
             async_mode=True,
@@ -279,7 +280,7 @@ class AscendP2PBackend(P2PBackend):
             tp_rank=self.tp_rank,
             peer_init_url=self.peer_init_url,
             peer_lookup_url=self.peer_lookup_url,
-            event_loop=loop,
+            event_loop=self.loop,
         )
 
         self.running = asyncio.Event()

--- a/lmcache_ascend/v1/storage_backend/p2p_backend.py
+++ b/lmcache_ascend/v1/storage_backend/p2p_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Coroutine, List, Optional, Sequence, Union
 import asyncio
 import threading
 
@@ -303,6 +303,45 @@ class AscendP2PBackend(P2PBackend):
         asyncio.run_coroutine_threadsafe(
             self._sweep_expired_pending_pull_resources(), self.loop
         )
+
+    def _is_on_p2p_loop(self) -> bool:
+        try:
+            return asyncio.get_running_loop() is self.loop
+        except RuntimeError:
+            return False
+
+    async def _run_on_p2p_loop(self, coro: Coroutine[Any, Any, Any]) -> Any:
+        if self._is_on_p2p_loop():
+            return await coro
+
+        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
+        return await asyncio.wrap_future(future)
+
+    async def _wait_for_async_context(self) -> None:
+        while self.running.is_set() and self.async_context is None:
+            await asyncio.sleep(0.01)
+        if self.async_context is None:
+            raise RuntimeError("P2P async context is not initialized")
+
+    async def _ensure_peer_connection(
+        self,
+        target_peer_init_url: str,
+        force_update: bool = False,
+    ) -> None:
+        await self._run_on_p2p_loop(
+            self._ensure_peer_connection_on_loop(
+                target_peer_init_url,
+                force_update,
+            )
+        )
+
+    async def _ensure_peer_connection_on_loop(
+        self,
+        target_peer_init_url: str,
+        force_update: bool = False,
+    ) -> None:
+        await self._wait_for_async_context()
+        await super()._ensure_peer_connection(target_peer_init_url, force_update)
 
     async def _handle_peer_requests(self):
         """
@@ -722,13 +761,9 @@ class AscendP2PBackend(P2PBackend):
                 f"Unexpected response to AscendQueryDonePortMsg: {type(ret_msg)}"
             )
         done_url = ret_msg.done_url
-        logger.info(
-            "Discovered done port for peer %s: %s",
-            target_peer_url,
-            done_url,
-        )
 
-        ctx = get_zmq_context()
+        assert self.async_context is not None
+        ctx = self.async_context
         done_socket = get_zmq_socket_with_timeout(
             ctx,
             done_url,
@@ -748,6 +783,15 @@ class AscendP2PBackend(P2PBackend):
         await asyncio.sleep(0.05)
 
     async def _send_done_signal(
+        self,
+        lookup_id: str,
+        target_peer_url: str,
+    ) -> None:
+        await self._run_on_p2p_loop(
+            self._send_done_signal_on_loop(lookup_id, target_peer_url)
+        )
+
+    async def _send_done_signal_on_loop(
         self,
         lookup_id: str,
         target_peer_url: str,
@@ -892,8 +936,8 @@ class AscendP2PBackend(P2PBackend):
             pull_mode=self.pull_mode,
         )
 
-        ret_msg = await self._send_lookup_request_with_retry(
-            lookup_id, target_peer_url, msg
+        ret_msg = await self._run_on_p2p_loop(
+            self._send_lookup_request_with_retry(lookup_id, target_peer_url, msg)
         )
         if ret_msg is None or isinstance(ret_msg, P2PErrorMsg):
             if isinstance(ret_msg, P2PErrorMsg):
@@ -956,12 +1000,14 @@ class AscendP2PBackend(P2PBackend):
             hit_mem_obj.pin()
 
         if num_hit_chunks > 0 and self.pull_mode:
-            success = await self._handle_pull_mode_transfer(
-                lookup_id,
-                target_peer_url,
-                hit_mem_objs,
-                ret_msg.remote_buffer_uuids,
-                ret_msg.remote_mem_indexes,
+            success = await self._run_on_p2p_loop(
+                self._handle_pull_mode_transfer(
+                    lookup_id,
+                    target_peer_url,
+                    hit_mem_objs,
+                    ret_msg.remote_buffer_uuids,
+                    ret_msg.remote_mem_indexes,
+                )
             )
             if not success:
                 self._cleanup_memory_objects(mem_objs)

--- a/lmcache_ascend/v1/transfer_channel/hccl_channel.py
+++ b/lmcache_ascend/v1/transfer_channel/hccl_channel.py
@@ -97,6 +97,7 @@ class HcclChannel(BaseMultiBufferChannel):
         self.conn_handles_dict: Dict[str, object] = {}
         self.remote_index_addr_dict: Dict[str, RemotePeerBufferList] = {}
         self._peer_ready_events: Dict[str, threading.Event] = {}
+        self._peer_handshake_locks: Dict[str, asyncio.Lock] = {}
 
         super().__init__(async_mode=async_mode, buffers=buffers, **kwargs)
 
@@ -109,6 +110,13 @@ class HcclChannel(BaseMultiBufferChannel):
 
     def _make_error_response(self) -> HcclErrorResponse:
         return HcclErrorResponse(ok=False)
+
+    def _get_peer_handshake_lock(self, peer_id: str) -> asyncio.Lock:
+        lock = self._peer_handshake_locks.get(peer_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._peer_handshake_locks[peer_id] = lock
+        return lock
 
     def lazy_init_peer_connection(
         self,
@@ -211,6 +219,21 @@ class HcclChannel(BaseMultiBufferChannel):
         return init_ret_msg
 
     async def async_lazy_init_peer_connection(
+        self,
+        local_id: str,
+        peer_id: str,
+        peer_init_url: str,
+        init_side_msg: Optional[InitSideMsgBase] = None,
+    ) -> Optional[InitSideRetMsgBase]:
+        async with self._get_peer_handshake_lock(peer_id):
+            return await self._async_lazy_init_peer_connection_locked(
+                local_id,
+                peer_id,
+                peer_init_url,
+                init_side_msg,
+            )
+
+    async def _async_lazy_init_peer_connection_locked(
         self,
         local_id: str,
         peer_id: str,

--- a/lmcache_ascend/v1/transfer_channel/hccl_channel.py
+++ b/lmcache_ascend/v1/transfer_channel/hccl_channel.py
@@ -247,6 +247,10 @@ class HcclChannel(BaseMultiBufferChannel):
             "connect",
         )
 
+        # The async transfer-channel loop may run on a different thread from the
+        # vLLM worker thread. NPU current device is thread-local.
+        torch.npu.set_device(self.handle_device)
+
         hccl_init_req = HcclInitRequest(
             local_id=local_id,
             client_meta_bytes=pickle.dumps(self.hccl_agent.get_client_meta()),

--- a/tests/v1/storage_backend/test_ascend_p2p_backend.py
+++ b/tests/v1/storage_backend/test_ascend_p2p_backend.py
@@ -74,6 +74,11 @@ def _run_coroutine(loop: asyncio.AbstractEventLoop, coro):
     return future.result(timeout=10)
 
 
+async def _run_on_p2p_loop_inline(coro):
+    """Unit-test stand-in for AscendP2PBackend._run_on_p2p_loop."""
+    return await coro
+
+
 def _make_p2p_backend_stub(
     pull_mode: bool = False,
     delay_pull: bool = False,
@@ -124,6 +129,7 @@ def _make_p2p_backend_stub(
     backend.full_size_shapes = kv_shapes
     backend.dtypes = kv_dtypes
     backend.fmt = fmt
+    backend._run_on_p2p_loop = AsyncMock(side_effect=_run_on_p2p_loop_inline)
 
     backend._allocate_memory_for_keys = lambda keys, cum_chunk_lengths: (
         AscendP2PBackend._allocate_memory_for_keys(backend, keys, cum_chunk_lengths)
@@ -557,6 +563,7 @@ class TestAscendP2PBackendUnit:
         backend.memory_allocator = MagicMock()
         backend.lookup_id_to_peer_mapping = {"lu_delay": ("target_peer_url", "npu")}
         backend.transfer_channel = MagicMock()
+        backend._run_on_p2p_loop = AsyncMock(side_effect=_run_on_p2p_loop_inline)
 
         ret_msg = AscendBatchedLookupAndGetRetMsg(
             num_hit_chunks=2,


### PR DESCRIPTION
### Changes
- Made all P2P lookup, connection , pull and signals through the P2P loop instead of the storage manager loop to avoid blocking from storage manager operation and avoid sit ready while the wrong loop were delayed.
- Ensure Done-signal uses the backend's async ZMQ context instead of creating sockets on a different loop.
- Serialize async HCCL peer handshakes to avoid concurrent setup.

```mermaid
flowchart LR
  subgraph ownership["Socket / I/O ownership"]
    A["req_socket"] --> B["must run on worker.loop"]
    C["P2P peer + transfer ZMQ"] --> D["must run on AscendP2PBackend.loop"]
    E["prefetch orchestration"] --> F["runs on StorageManager.loop"]
  end
```

```mermaid
sequenceDiagram
  participant SL as StorageManager.loop
  participant BE as Backend coroutine<br/>(e.g. AscendP2PBackend)
  participant PL as AscendP2PBackend.loop
  participant WL as worker.loop

  SL->>BE: await batched_async_contains / batched_get_non_blocking
  alt Ascend P2P needs P2P-only I/O
    BE->>PL: run_coroutine_threadsafe(_run_on_p2p_loop coro)
    PL-->>BE: result via Future → wrap_future
  end
  opt Needs controller via worker req_socket
    BE->>WL: async_put_and_wait_msg → run_coroutine_threadsafe(...)
    WL-->>BE: result via wrap_future + wait_for
  end
  BE-->>SL: return to prefetch task

```


### Why
- By creating and using the dedicated sockets on p2p loop, the lookup replies should have no risk of being delayed, and no longer depend on storagemanager and worker loop.
