### PR TITLE
Adapter Agentos:Add chunk_hash return and expose evict/prefetch APIs

### DIFF
--- a/docs/internal_api_server/prefetch_evict_apis.md
+++ b/docs/internal_api_server/prefetch_evict_apis.md
@@ -1,0 +1,241 @@
+# Prefetch & Evict APIs
+
+LMCache-Ascend exposes two internal REST endpoints to control KV cache data placement
+across storage tiers:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/memory/prefetch` | POST | Pre-load KV chunks from slow tiers (SSD / P2P) into DDR |
+| `/memory/evict` | POST | Remove KV chunks from a specified storage tier |
+
+These APIs require several configuration options to be enabled. This document
+explains each option and how to use the endpoints.
+
+---
+
+## Required Configuration
+
+All of the following must be enabled for the APIs to work:
+
+### 1. `internal_api_server_enabled: true`
+
+**What it does**: Starts LMCache's built-in HTTP server on each worker / scheduler.
+Without it, no internal API endpoints exist at all.
+
+**YAML**:
+```yaml
+internal_api_server_enabled: true
+```
+
+**Env**: `LMCACHE_INTERNAL_API_SERVER_ENABLED=true`
+
+This is an upstream LMCache config. Default port start is `6999` (scheduler),
+then `7000`, `7001`, ... for workers.
+
+---
+
+### 2. `enable_chunk_hashes_return: true`
+
+**What it does**: Two-fold:
+
+- Includes `chunk_hashes` in the `kv_transfer_params` of each response, so that
+  callers can know which chunks were looked up for a request.
+- Registers the `/memory/prefetch` and `/memory/evict` routes on the internal
+  API server.
+
+**YAML**:
+```yaml
+enable_chunk_hashes_return: true
+```
+
+**Env**: `LMCACHE_ENABLE_CHUNK_HASHES_RETURN=true`
+
+**Default**: `false` (no impact on existing functionality)
+
+---
+
+### 3. `enable_async_loading: true`
+
+**What it does**: Enables the asynchronous lookup-and-prefetch pipeline. The
+`/memory/prefetch` endpoint calls `async_lookup_and_prefetch` internally, which
+requires the async loading infrastructure (async serializer, event loop, etc.).
+
+**YAML**:
+```yaml
+enable_async_loading: true
+```
+
+**Env**: `LMCACHE_ENABLE_ASYNC_LOADING=true`
+
+This is an upstream LMCache config.
+
+---
+
+### 4. `lookup_hashes_cache_size` (recommended)
+
+**What it does**: Controls the in-memory cache of `chunk_hashes` per request.
+Each call to `lookup()` records the computed chunk hashes keyed by `lookup_id`.
+When `request_finished` fires, the cached hashes are popped and returned via
+`kv_transfer_params.chunk_hashes`.
+
+Without a size limit, this cache would grow unboundedly if the upper layer
+never calls `get_cached_hashes`.
+
+**YAML**:
+```yaml
+lookup_hashes_cache_size: 1024
+```
+
+**Env**: `LMCACHE_LOOKUP_HASHES_CACHE_SIZE=1024`
+
+**Default**: `0` (unlimited -- use `> 0` for production)
+
+FIFO eviction: when the cache reaches the limit, the oldest entry is removed
+before inserting a new one.
+
+---
+
+## Configuration Summary
+
+Minimal YAML snippet:
+
+```yaml
+# Required
+internal_api_server_enabled: true
+enable_async_loading: true
+enable_chunk_hashes_return: true
+
+# Recommended
+lookup_hashes_cache_size: 1024
+```
+
+---
+
+## Usage
+
+All endpoints are served on the internal API server (default scheduler port `6999`).
+
+### Prefetch (SSD / P2P -> DDR)
+
+Load KV chunks from slower storage tiers into CPU DDR so that subsequent
+requests hit the hot cache.
+
+**Endpoint**: `POST http://<host>:6999/memory/prefetch`
+
+**Headers**: `Content-Type: application/json`
+
+**Body**:
+```json
+{
+  "chunk_hashes": ["abc123", "def456"],
+  "lookup_id": "prefetch_test_001"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `chunk_hashes` | `string[]` | Hex-encoded chunk hashes (from `kv_transfer_params.chunk_hashes`) |
+| `lookup_id` | `string` | A unique identifier for this prefetch session |
+
+**Success response** (200):
+```json
+{
+  "status": "prefetch_started",
+  "lookup_id": "prefetch_test_001",
+  "num_chunks": 2
+}
+```
+
+**Notes**:
+- The prefetch runs asynchronously. The response returns immediately after
+  scheduling; actual disk reads happen in the background.
+- Use the `lookup_id` to track completion (future enhancement).
+- When called on the scheduler, the request is forwarded to all workers.
+
+---
+
+### Evict
+
+Remove KV chunks from a specific storage tier.
+
+**Endpoint**: `POST http://<host>:6999/memory/evict`
+
+**Headers**: `Content-Type: application/json`
+
+**Body**:
+```json
+{
+  "chunk_hashes": ["abc123", "def456"],
+  "locations": ["LocalCPUBackend"]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `chunk_hashes` | `string[]` | Hex-encoded chunk hashes to evict |
+| `locations` | `string[]` (optional) | Storage tier name. `null` to evict from all tiers. Common value: `"LocalCPUBackend"` |
+
+**Success response** (200):
+```json
+{
+  "status": "success",
+  "num_evicted": 2
+}
+```
+
+**Notes**:
+- Eviction is synchronous and blocks until complete.
+- When called on the scheduler, the request is forwarded to all workers.
+
+---
+
+## Streaming Response Support
+
+The `chunk_hashes` are delivered via `kv_transfer_params` in the final (finish)
+chunk of the streaming response. This requires modifications to the vllm /
+vllm-ascend serving layer.
+
+### Data Flow
+
+```
+LMCache-Ascend vllm_v1_adapter.py
+  request_finished() -> return_params = {"chunk_hashes": [...]}
+
+    v
+vllm scheduler.py
+  _free_request() -> _connector_finished()
+  -> kv_transfer_params = return value (dict)
+
+    v
+EngineCoreOutput.kv_transfer_params
+
+    v
+output_processor.py -> RequestOutput.kv_transfer_params
+
+    v
+Serving layer -> ChatCompletionStreamResponse / CompletionStreamResponse
+```
+
+### Required Modifications
+
+vllm-ascend: `patch_glm_tool_call_parser.py` (already applied)
+
+In the streaming loop, pass `kv_transfer_params` to the final chunk:
+
+```python
+# File: vllm-ascend/vllm_ascend/patch/platform/patch_glm_tool_call_parser.py
+
+chunk = ChatCompletionStreamResponse(
+    id=request_id,
+    object=chunk_object_type,
+    created=created_time,
+    choices=[choice_data],
+    model=model_name,
+    kv_transfer_params=res.kv_transfer_params if finish_reason_ is not None else None,
+)
+```
+
+**Note**: Only the last chunk (where `finish_reason_` is set) carries the
+`kv_transfer_params`, avoiding unnecessary data in intermediate chunks.
+
+

--- a/examples/memory_apis/prefetch_evict.yaml
+++ b/examples/memory_apis/prefetch_evict.yaml
@@ -1,0 +1,30 @@
+# LMCache-Ascend configuration for memory prefetch / evict API usage.
+#
+# Required parameters to enable the /memory/prefetch and /memory/evict
+# REST endpoints on the internal API server.
+
+# ── General cache settings ──────────────────────────────────────
+chunk_size: 256
+local_cpu: True
+max_local_cpu_size: 100
+
+# ── Async loading (required by /memory/prefetch) ─────────────────
+enable_async_loading: True
+
+# ── Disk storage (optional, provides SSD tier for prefetch target) ──
+local_disk: "file:///home/"
+max_local_disk_size: 1000
+
+# ── Lookup timeout ───────────────────────────────────────────────
+lookup_timeout_ms: 300000
+
+# ── Internal API server (required) ───────────────────────────────
+internal_api_server_enabled: True
+internal_api_server_host: "0.0.0.0"
+internal_api_server_port_start: 6999
+
+# ── Chunk hash tracking & return (required) ──────────────────────
+enable_chunk_hashes_return: True
+
+# ── Lookup hashes cache size (recommended, prevents memory leak) ──
+lookup_hashes_cache_size: 2048

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -192,6 +192,27 @@ def _patch_config():
         "Set 0 for an unbounded queue; values > 0 enable bounded backpressure.",
     }
 
+    # Add enable_chunk_hashes_return config
+    lmcache.v1.config._CONFIG_DEFINITIONS["enable_chunk_hashes_return"] = {
+        "type": bool,
+        "default": False,
+        "env_converter": _to_bool,
+        "description": "Whether to track chunk hashes during lookup and "
+        "include them in request_finished return params. "
+        "If True, chunk_hashes will be available in return_params. "
+        "Default is False (disabled, no impact on original functionality).",
+    }
+
+    # Add lookup_hashes_cache_size config
+    lmcache.v1.config._CONFIG_DEFINITIONS["lookup_hashes_cache_size"] = {
+        "type": int,
+        "default": 0,
+        "env_converter": int,
+        "description": "Maximum number of cached chunk hash entries. "
+        "When exceeded, the oldest entry is evicted to prevent unbounded "
+        "memory growth. Default is 0 (unlimited).",
+    }
+
     namespace_extras = {
         "validate": lmcache.v1.config._validate_config,
         "log_config": lmcache.v1.config._log_config,
@@ -530,6 +551,49 @@ def _patch_rpc_utils():
         _factory_mod.get_zmq_rpc_path_lmcache = get_zmq_rpc_path_lmcache
 
 
+def _patch_storage_manager():
+    # Prefetch all done callback: write loaded data back to hot cache
+    # so subsequent requests hit DDR instead of SSD/P2P.
+    # Third Party
+    from lmcache.v1.storage_backend.storage_manager import StorageManager
+
+    # First Party
+    from lmcache_ascend.v1.storage_backend.storage_manager import (
+        patched_prefetch_all_done_callback,
+    )
+
+    StorageManager.prefetch_all_done_callback = patched_prefetch_all_done_callback
+
+
+def _patch_lookup_client_factory():
+    # Replace LMCacheAsyncLookupClient with Ascend subclass that caches
+    # chunk_hashes during lookup and exposes them via get_cached_hashes().
+    # Third Party
+    import lmcache.v1.lookup_client.lmcache_async_lookup_client as lmc_async
+
+    # First Party
+    from lmcache_ascend.v1.lookup_client.lmcache_async_lookup_client import (
+        LMCacheAsyncLookupClient,
+    )
+
+    lmc_async.LMCacheAsyncLookupClient = LMCacheAsyncLookupClient
+
+
+def _patch_api_server():
+    # Register /memory/prefetch and /memory/evict REST endpoints.
+    # Third Party
+    from lmcache.v1.internal_api_server.api_server import InternalAPIServer
+
+    # First Party
+    from lmcache_ascend.v1.internal_api_server import (
+        InternalAPIServer__init__,
+        _capture_original_init,
+    )
+
+    _capture_original_init(InternalAPIServer.__init__)
+    InternalAPIServer.__init__ = InternalAPIServer__init__
+
+
 # Check if we've already patched to avoid redundant work
 if not LMCACHE_ASCEND_PATCHED:
     # Standard
@@ -572,9 +636,13 @@ if not LMCACHE_ASCEND_PATCHED:
         if _build_info.__framework_name__ == "pytorch":
             _patch_sys_detection()
 
+        _patch_lookup_client_factory()
         _patch_vllm_v1_adapter()
 
         _patch_cache_engine()
+
+        _patch_storage_manager()
+        _patch_api_server()
 
     if _build_info.__framework_name__ == "mindspore":
         # First Party

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -263,6 +263,16 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
     ) -> tuple[bool, Optional[dict[str, Any]]]:
         _, return_params = super().request_finished(request, block_ids)
 
+        # chunk_hashes return start ---------------------
+        if getattr(self.config, "enable_chunk_hashes_return", False):
+            inner = self.lookup_client
+            while hasattr(inner, "actual_lookup_client"):
+                inner = inner.actual_lookup_client
+            new_hashes = inner.get_cached_hashes(request.request_id)
+            return_params = return_params or {}
+            return_params["chunk_hashes"] = new_hashes
+        # chunk_hashes return end ---------------------
+
         if (
             request.status == RequestStatus.FINISHED_ABORTED
             and self.lmcache_engine is not None

--- a/lmcache_ascend/v1/internal_api_server/__init__.py
+++ b/lmcache_ascend/v1/internal_api_server/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# First Party
+from lmcache_ascend.v1.internal_api_server.memory.memory_api import (
+    router as memory_router,
+)
+
+_original_init = None
+
+
+def _capture_original_init(original):
+    global _original_init
+    _original_init = original
+
+
+def InternalAPIServer__init__(self, lmcache_manager):
+    # Third Party
+    from lmcache.v1.internal_api_server.api_server import app
+
+    _original_init(self, lmcache_manager)
+
+    config = lmcache_manager.config
+    if getattr(config, "enable_chunk_hashes_return", False):
+        app.include_router(memory_router)

--- a/lmcache_ascend/v1/internal_api_server/memory/__init__.py
+++ b/lmcache_ascend/v1/internal_api_server/memory/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache_ascend/v1/internal_api_server/memory/memory_api.py
+++ b/lmcache_ascend/v1/internal_api_server/memory/memory_api.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Memory system REST API: /memory/prefetch, /memory/evict."""
+
+# Standard
+from typing import List
+import asyncio
+import json
+import urllib.request
+
+# Third Party
+from fastapi import APIRouter
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.cache_engine import LMCacheEngine
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+def _hashes_to_keys(
+    engine: LMCacheEngine, chunk_hashes: List[str]
+) -> List[CacheEngineKey]:
+    world_size = 1 if engine.save_only_first_rank else engine.metadata.world_size
+    return [
+        CacheEngineKey(
+            model_name=engine.metadata.model_name,
+            world_size=world_size,
+            worker_id=engine.metadata.worker_id,
+            chunk_hash=int(h, 16),
+            dtype=engine.metadata.kv_dtype,
+        )
+        for h in chunk_hashes
+    ]
+
+
+async def _forward_to_all_workers(request: Request, path: str) -> PlainTextResponse:
+    adapter = request.app.state.lmcache_adapter
+    port_start = adapter.config.internal_api_server_port_start
+    metadata = getattr(adapter, "lmcache_engine_metadata", None)
+    world_size = metadata.world_size if metadata else 1
+    worker_ports = [port_start + 1 + i for i in range(world_size)]
+
+    body = await request.body()
+
+    def _do_request(port: int):
+        try:
+            req = urllib.request.Request(
+                f"http://localhost:{port}{path}",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.status, json.loads(resp.read())
+        except Exception as e:
+            return 503, {"error": str(e)}
+
+    tasks = [
+        asyncio.get_event_loop().run_in_executor(None, _do_request, port)
+        for port in worker_ports
+    ]
+    results = await asyncio.gather(*tasks)
+
+    failures = [(i, r) for i, (s, r) in enumerate(results) if s != 200]
+    if not failures:
+        return PlainTextResponse(
+            content=json.dumps(results[0][1]),
+            media_type="application/json",
+            status_code=200,
+        )
+
+    failure_map = {worker_ports[i]: r for i, r in failures}
+    logger.error(
+        "Forward %s: %d/%d workers failed: %s",
+        path,
+        len(failures),
+        len(worker_ports),
+        failure_map,
+    )
+    return PlainTextResponse(
+        content=json.dumps(
+            {
+                "error": "Some workers failed to process request",
+                "failures": {str(k): v for k, v in failure_map.items()},
+            }
+        ),
+        media_type="application/json",
+        status_code=500,
+    )
+
+
+@router.post("/memory/prefetch")
+async def prefetch(request: Request):
+    adapter = request.app.state.lmcache_adapter
+    if not adapter.lmcache_engine:
+        return await _forward_to_all_workers(request, "/memory/prefetch")
+
+    engine: LMCacheEngine = adapter.lmcache_engine
+    try:
+        body = await request.json()
+        chunk_hashes = body.get("chunk_hashes", [])
+        lookup_id = body.get("lookup_id")
+
+        if not chunk_hashes or not lookup_id:
+            return PlainTextResponse(
+                content=json.dumps(
+                    {"error": "chunk_hashes and lookup_id are required"}
+                ),
+                media_type="application/json",
+                status_code=400,
+            )
+
+        keys = _hashes_to_keys(engine, chunk_hashes)
+        chunk_size = engine.config.chunk_size
+        cum_chunk_lengths = [i * chunk_size for i in range(len(keys) + 1)]
+
+        asyncio.run_coroutine_threadsafe(
+            engine.storage_manager.async_lookup_and_prefetch(
+                lookup_id=lookup_id,
+                keys=keys,
+                cum_chunk_lengths=cum_chunk_lengths,
+                search_range=engine.retrieve_locations,
+                pin=False,
+            ),
+            engine.storage_manager.loop,
+        )
+
+        return PlainTextResponse(
+            content=json.dumps(
+                {
+                    "status": "prefetch_started",
+                    "lookup_id": lookup_id,
+                    "num_chunks": len(keys),
+                }
+            ),
+            media_type="application/json",
+        )
+
+    except Exception as e:
+        logger.error("prefetch failed: %s", e)
+        return PlainTextResponse(
+            content=json.dumps({"error": str(e)}),
+            media_type="application/json",
+            status_code=500,
+        )
+
+
+@router.post("/memory/evict")
+async def evict(request: Request):
+    adapter = request.app.state.lmcache_adapter
+    if not adapter.lmcache_engine:
+        return await _forward_to_all_workers(request, "/memory/evict")
+
+    engine: LMCacheEngine = adapter.lmcache_engine
+    try:
+        body = await request.json()
+        chunk_hashes = body.get("chunk_hashes", [])
+        locations = body.get("locations")
+
+        if not chunk_hashes:
+            return PlainTextResponse(
+                content=json.dumps({"error": "chunk_hashes is required"}),
+                media_type="application/json",
+                status_code=400,
+            )
+
+        keys = _hashes_to_keys(engine, chunk_hashes)
+        num_evicted = engine.storage_manager.batched_remove(keys, locations=locations)
+
+        return PlainTextResponse(
+            content=json.dumps(
+                {
+                    "status": "success",
+                    "num_evicted": num_evicted,
+                }
+            ),
+            media_type="application/json",
+        )
+
+    except Exception as e:
+        logger.error("evict failed: %s", e)
+        return PlainTextResponse(
+            content=json.dumps({"error": str(e)}),
+            media_type="application/json",
+            status_code=500,
+        )

--- a/lmcache_ascend/v1/lookup_client/__init__.py
+++ b/lmcache_ascend/v1/lookup_client/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache_ascend/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache_ascend/v1/lookup_client/lmcache_async_lookup_client.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Optional, Union
+import time
+
+# Third Party
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.lookup_client.async_lookup_message import (
+    LookupRequestMsg,
+)
+from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
+    LMCacheAsyncLookupClient as _BaseLMCacheAsyncLookupClient,
+)
+from lmcache.v1.metadata import LMCacheMetadata
+import msgspec
+import torch
+
+
+class LMCacheAsyncLookupClient(_BaseLMCacheAsyncLookupClient):
+    def __init__(
+        self,
+        config: LMCacheEngineConfig,
+        metadata: LMCacheMetadata,
+    ):
+        super().__init__(config, metadata)
+        # lookup_hashes_cache init start---------------------
+        self._lookup_hashes_cache = {}
+        self._max_cache_size = int(getattr(config, "lookup_hashes_cache_size", 0))
+        # lookup_hashes_cache init end ---------------------
+
+    def lookup(
+        self,
+        token_ids: Union[torch.Tensor, list[int]],
+        lookup_id: str,
+        request_configs: Optional[dict] = None,
+    ) -> Optional[int]:
+        hashes: list[int] = []
+        offsets = []
+        for start, end, hash_val in self.token_database.process_tokens(
+            token_ids, make_key=False
+        ):
+            hashes.append(hash_val)
+            offsets.append(end - start)
+
+        # lookup_hashes_cache fill start ---------------------
+        if (
+            self._max_cache_size > 0
+            and len(self._lookup_hashes_cache) >= self._max_cache_size
+        ):
+            oldest_key = next(iter(self._lookup_hashes_cache))
+            del self._lookup_hashes_cache[oldest_key]
+
+        self._lookup_hashes_cache[lookup_id] = [f"{h:x}" for h in hashes]
+        # lookup_hashes_cache fill end ---------------------
+
+        msg = LookupRequestMsg(
+            lookup_id=lookup_id,
+            hashes=hashes,
+            offsets=offsets,
+            request_configs=request_configs,
+        )
+        msg_buf = msgspec.msgpack.encode(msg)
+        for i in range(self.world_size):
+            self.push_sockets[i].send(msg_buf, copy=False)
+        time.sleep(self.lookup_backoff_time)
+        return None
+
+    # get_cached_hashes start ---------------------
+    def get_cached_hashes(self, lookup_id: str) -> Optional[list[str]]:
+        return self._lookup_hashes_cache.pop(lookup_id, None)
+
+    # get_cached_hashes end ---------------------

--- a/lmcache_ascend/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/v1/storage_backend/storage_manager.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+from lmcache.logging import init_logger
+from lmcache.v1.event_manager import EventStatus, EventType
+
+logger = init_logger(__name__)
+
+
+def patched_prefetch_all_done_callback(
+    self,
+    task,
+    lookup_id,
+    cum_chunk_lengths_total,
+    tier_expected_chunks,
+):
+    assert self.async_lookup_server is not None
+    self.event_manager.update_event_status(
+        EventType.LOADING, lookup_id, status=EventStatus.DONE
+    )
+
+    res = task.result()
+
+    total_retrieved_chunks = 0
+    for tier_idx, tier_result in enumerate(res):
+        actual_chunks = len(tier_result)
+        total_retrieved_chunks += actual_chunks
+        if actual_chunks < tier_expected_chunks[tier_idx]:
+            for subsequent_tier in res[tier_idx + 1 :]:
+                for mem_obj in subsequent_tier:
+                    mem_obj.ref_count_down()
+            break
+
+    # inject hotcache start ---------------------
+    if (
+        self.local_cpu_backend is not None
+        and self.local_cpu_backend.use_hot
+        and total_retrieved_chunks > 0
+    ):
+        chunk_count = 0
+        for tier_idx, tier_result in enumerate(res):
+            tier_keys = []
+            tier_objs = []
+            for key, mem_obj in tier_result:
+                if chunk_count >= total_retrieved_chunks:
+                    break
+                tier_keys.append(key)
+                tier_objs.append(mem_obj)
+                chunk_count += 1
+            if tier_keys:
+                self.local_cpu_backend.batched_submit_put_task(tier_keys, tier_objs)
+            if chunk_count >= total_retrieved_chunks:
+                break
+    # inject hotcache end ---------------------
+
+    retrieved_length = cum_chunk_lengths_total[total_retrieved_chunks]
+    logger.info(
+        f"Responding to scheduler for lookup id {lookup_id}"
+        f" with retrieved length {retrieved_length}"
+    )
+    self.async_lookup_server.send_response_to_scheduler(lookup_id, retrieved_length)

--- a/tests/integration/vllm/test_request_finished_chunk_hashes.py
+++ b/tests/integration/vllm/test_request_finished_chunk_hashes.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pytest
+
+_patched = False
+
+
+def _import_adapter():
+    global _patched
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    if not _patched:
+        lmcache_ascend = pytest.importorskip("lmcache_ascend")
+        lmcache_ascend._patch_vllm_v1_adapter()
+        _patched = True
+    return pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+
+def _make_adapter(adapter_mod, *, lookup_client):
+    adapter = object.__new__(adapter_mod.LMCacheAscendConnectorV1Impl)
+    adapter.store_async = False
+    adapter.kv_role = "kv_both"
+    adapter.lmcache_engine = None
+    adapter.lookup_client = lookup_client
+    return adapter
+
+
+class TestRequestFinished:
+    def test_returns_chunk_hashes_in_response(self):
+        adapter_mod = _import_adapter()
+
+        inner = MagicMock()
+        inner.get_cached_hashes.return_value = ["abc", "def"]
+
+        adapter = _make_adapter(adapter_mod, lookup_client=inner)
+        request = SimpleNamespace(request_id="req-001")
+
+        with patch.object(
+            adapter_mod.LMCacheConnectorV1Impl,
+            "request_finished",
+            return_value=(False, None),
+        ):
+            impl = adapter_mod.LMCacheAscendConnectorV1Impl
+            _, return_params = impl.request_finished(adapter, request, [])
+
+        assert return_params == {"chunk_hashes": ["abc", "def"]}

--- a/tests/v1/internal_api_server/test_memory_api.py
+++ b/tests/v1/internal_api_server/test_memory_api.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for /memory/prefetch and /memory/evict endpoints."""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pytest
+import torch
+
+starlette_testclient = pytest.importorskip(
+    "starlette.testclient", reason="starlette not installed"
+)
+fastapi_mod = pytest.importorskip("fastapi", reason="fastapi not installed")
+TestClient = starlette_testclient.TestClient
+FastAPI = fastapi_mod.FastAPI
+
+
+def _make_app(engine):
+    # First Party
+    from lmcache_ascend.v1.internal_api_server.memory.memory_api import (
+        router,
+    )
+
+    config = SimpleNamespace(internal_api_server_port_start=9000)
+    adapter = SimpleNamespace(
+        lmcache_engine=engine,
+        config=config,
+    )
+    app = FastAPI()
+    app.state.lmcache_adapter = adapter
+    app.include_router(router)
+    return app
+
+
+def _make_engine(*, backend_state=None):
+    metadata = SimpleNamespace(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        kv_dtype=torch.float16,
+    )
+    config = SimpleNamespace(chunk_size=256)
+
+    engine = SimpleNamespace(
+        save_only_first_rank=False,
+        metadata=metadata,
+        config=config,
+        retrieve_locations=None,
+    )
+
+    sm = MagicMock()
+    sm.loop = MagicMock()
+    sm.async_lookup_and_prefetch = MagicMock()
+
+    if backend_state is not None:
+        sm.batched_remove = MagicMock(
+            side_effect=lambda keys, locations=None: sum(
+                1 for k in keys if backend_state.pop(k.chunk_hash, None) is not None
+            )
+        )
+    else:
+        sm.batched_remove = MagicMock(return_value=0)
+
+    engine.storage_manager = sm
+    return engine
+
+
+class TestPrefetchEndpoint:
+    @patch(
+        "lmcache_ascend.v1.internal_api_server.memory.memory_api."
+        "_forward_to_all_workers"
+    )
+    def test_scheduler_forwards_to_workers(self, mock_forward):
+        mock_forward.return_value = MagicMock(status_code=200)
+        app = _make_app(engine=None)
+        client = TestClient(app)
+        client.post(
+            "/memory/prefetch",
+            json={"chunk_hashes": ["abc"], "lookup_id": "req-001"},
+        )
+        mock_forward.assert_called_once()
+
+    def test_worker_prefetches_correct_keys(self):
+        engine = _make_engine()
+        app = _make_app(engine=engine)
+        client = TestClient(app)
+
+        with patch("asyncio.run_coroutine_threadsafe"):
+            resp = client.post(
+                "/memory/prefetch",
+                json={
+                    "chunk_hashes": ["abc123", "def456"],
+                    "lookup_id": "req-001",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "prefetch_started"
+
+        sm = engine.storage_manager
+        sm.async_lookup_and_prefetch.assert_called_once()
+        kwargs = sm.async_lookup_and_prefetch.call_args.kwargs
+        assert kwargs["lookup_id"] == "req-001"
+        assert kwargs["pin"] is False
+
+        keys = kwargs["keys"]
+        assert len(keys) == 2
+        assert keys[0].chunk_hash == int("abc123", 16)
+        assert keys[0].model_name == "test-model"
+        assert keys[0].world_size == 1
+        assert keys[0].worker_id == 0
+        assert keys[1].chunk_hash == int("def456", 16)
+        assert kwargs["cum_chunk_lengths"] == [0, 256, 512]
+
+    def test_prefetch_missing_fields(self):
+        engine = _make_engine()
+        app = _make_app(engine=engine)
+        client = TestClient(app)
+        resp = client.post("/memory/prefetch", json={})
+        assert resp.status_code == 400
+
+
+class TestEvictEndpoint:
+    @patch(
+        "lmcache_ascend.v1.internal_api_server.memory.memory_api."
+        "_forward_to_all_workers"
+    )
+    def test_scheduler_forwards_to_workers(self, mock_forward):
+        mock_forward.return_value = MagicMock(status_code=200)
+        app = _make_app(engine=None)
+        client = TestClient(app)
+        client.post("/memory/evict", json={"chunk_hashes": ["abc"]})
+        mock_forward.assert_called_once()
+
+    def test_worker_evicts_and_clears_backend(self):
+        chunk_hashes = ["abc123", "def456", "789abc"]
+        backend_state = {int(h, 16): f"data-for-{h}" for h in chunk_hashes}
+
+        engine = _make_engine(backend_state=backend_state)
+        app = _make_app(engine=engine)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/memory/evict",
+            json={"chunk_hashes": chunk_hashes},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["num_evicted"] == 3
+
+        sm = engine.storage_manager
+        sm.batched_remove.assert_called_once()
+        (keys,) = sm.batched_remove.call_args[0]
+        assert len(keys) == 3
+        assert sm.batched_remove.call_args.kwargs == {"locations": None}
+        assert backend_state == {}
+
+    def test_evict_reports_zero_when_nothing_to_evict(self):
+        engine = _make_engine(backend_state={})
+        app = _make_app(engine=engine)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/memory/evict",
+            json={"chunk_hashes": ["abc123"]},
+        )
+
+        assert resp.json()["num_evicted"] == 0
+        assert resp.json()["status"] == "success"
+
+    def test_evict_missing_fields(self):
+        engine = _make_engine()
+        app = _make_app(engine=engine)
+        client = TestClient(app)
+        resp = client.post("/memory/evict", json={})
+        assert resp.status_code == 400

--- a/tests/v1/lookup_client/test_lmcache_ascend_async_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_ascend_async_lookup_client.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import MagicMock, patch
+
+
+class TestLMCacheAsyncLookupClient:
+    @staticmethod
+    def _make_client(**attrs):
+        # First Party
+        from lmcache_ascend.v1.lookup_client.lmcache_async_lookup_client import (
+            LMCacheAsyncLookupClient,
+        )
+
+        client = LMCacheAsyncLookupClient.__new__(LMCacheAsyncLookupClient)
+        client._lookup_hashes_cache = {}
+        client._max_cache_size = 0
+        for k, v in attrs.items():
+            setattr(client, k, v)
+        return client
+
+    def test_lookup_caches_hex_hashes(self):
+        client = self._make_client(
+            world_size=1,
+            push_sockets=[MagicMock()],
+            lookup_backoff_time=0.001,
+            token_database=MagicMock(),
+        )
+        client._max_cache_size = 8
+        client.token_database.process_tokens.return_value = [
+            (0, 256, 0xABC123),
+            (256, 512, 0xDEF456),
+        ]
+        with patch("msgspec.msgpack.encode", return_value=b"mock"):
+            with patch("time.sleep", return_value=None):
+                client.lookup([1, 2, 3], "req-001")
+
+        assert client._lookup_hashes_cache == {
+            "req-001": [f"{0xABC123:x}", f"{0xDEF456:x}"]
+        }
+
+    def test_get_cached_hashes_pops(self):
+        client = self._make_client()
+        client._lookup_hashes_cache = {"req-001": ["abc", "def"]}
+        assert client.get_cached_hashes("req-001") == ["abc", "def"]
+        assert "req-001" not in client._lookup_hashes_cache
+        assert client.get_cached_hashes("req-missing") is None


### PR DESCRIPTION
To interface with the upper-layer AgentOS, each KV Cache needs a unique identifier. Therefore, a chunk_hash field is added to the response returned by the request.