### PR TITLE
fix: handle kv_events as list in synchronous store mode

### DIFF
--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -416,7 +416,11 @@ class AscendLMCacheEngine(LMCacheEngine):
 
     def get_kv_events(self) -> Iterable[CacheStoreEvent]:
         if self.kv_events_enabled and self.kv_events:
-            return self.kv_events.drain()
+            if self.is_store_async:
+                return self.kv_events.drain()
+            events = list(self.kv_events)
+            self.kv_events.clear()
+            return events
         return []
 
     def lookup(


### PR DESCRIPTION
When store_async is False, self.kv_events remains a plain list (initialized by upstream LMCacheEngine), which does not have a drain() method. Calling drain() unconditionally causes an AttributeError crash on the first inference request.

Use list snapshot-and-clear for synchronous mode and reserve ThreadSafeEventList.drain() for the async path only.