### PR TITLE
fix ci git fetch tiomeout

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,11 +61,13 @@ jobs:
     steps:
       - name: 🔧 Fix Proxy Configuration
         run: |
-          echo "Overwriting Runner Proxy Settings..."
-          echo "http_proxy=http://host.docker.internal:3128" >> $GITHUB_ENV
-          echo "https_proxy=http://host.docker.internal:3128" >> $GITHUB_ENV
-          echo "HTTP_PROXY=http://host.docker.internal:3128" >> $GITHUB_ENV
-          echo "HTTPS_PROXY=http://host.docker.internal:3128" >> $GITHUB_ENV
+          git config --global http.version HTTP/1.1
+          if getent hosts proxyhk.huawei.com >/dev/null 2>&1; then
+            echo "http_proxy=http://host.docker.internal:3128" >> $GITHUB_ENV
+            echo "https_proxy=http://host.docker.internal:3128" >> $GITHUB_ENV
+            echo "HTTP_PROXY=http://host.docker.internal:3128" >> $GITHUB_ENV
+            echo "HTTPS_PROXY=http://host.docker.internal:3128" >> $GITHUB_ENV
+          fi
 
       - name: Checkout (Workflow Run)
         if: github.event_name == 'workflow_run'
@@ -264,6 +266,16 @@ jobs:
 
       
     steps:
+      - name: 🔧 Fix Proxy Configuration
+        run: |
+          git config --global http.version HTTP/1.1
+          if getent hosts proxyhk.huawei.com >/dev/null 2>&1; then
+            echo "http_proxy=http://host.docker.internal:3128" >> $GITHUB_ENV
+            echo "https_proxy=http://host.docker.internal:3128" >> $GITHUB_ENV
+            echo "HTTP_PROXY=http://host.docker.internal:3128" >> $GITHUB_ENV
+            echo "HTTPS_PROXY=http://host.docker.internal:3128" >> $GITHUB_ENV
+          fi
+
       - name: Checkout (Workflow Run)
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v4


### PR DESCRIPTION
1. the container needs to enable privileged mode to access the NPU in some environment
2. fix the proxy issue
3. by default, git uses the HTTP/2 protocol. However it may randomly result in issues such as the HTTP/2 layer being lost or connection timeout. switching to HTTP/1.1 resolves these issues 