### PR TITLE
Support dynamic shard_size when save_only_first_rank = true

### DIFF
--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -11,6 +11,7 @@ import threading
 import time
 
 # Third Party
+from lmcache.integration.vllm.utils import get_size_bytes
 from lmcache.logging import init_logger
 from lmcache.utils import (
     CacheEngineKey,
@@ -113,9 +114,6 @@ class AscendLMCacheEngine(LMCacheEngine):
         self._broadcast_shard_size = self.config.get_extra_config_value(
             "broadcast_shard_size", None
         )
-        self._preallocate_broadcast_pool = self.config.get_extra_config_value(
-            "preallocate_broadcast_pool", True
-        )
 
         if self.kv_events_enabled and self.is_store_async:
             self.kv_events = ThreadSafeEventList()
@@ -145,7 +143,12 @@ class AscendLMCacheEngine(LMCacheEngine):
 
         # Override upstream broadcast_stream with a dedicated NPU stream
         # so broadcast and to_gpu can execute on separate streams.
-        if self.save_only_first_rank and hasattr(self.gpu_connector, "load_stream"):
+        if self.save_only_first_rank:
+            if not hasattr(self.gpu_connector, "load_stream"):
+                raise RuntimeError(
+                    "gpu_connector must have 'load_stream' when "
+                    "save_only_first_rank is True"
+                )
             # Auto-estimate or validate shard_size now that model weights
             # are loaded and NPU memory state is stable.
             if self._broadcast_shard_size is None:
@@ -159,16 +162,17 @@ class AscendLMCacheEngine(LMCacheEngine):
                         "(1) reduce broadcast_shard_size to <= %d; "
                         "(2) or increase --gpu-memory-utilization appropriately "
                         "(note: KV cache also uses free memory, do not set too high)",
-                        self._broadcast_shard_size, estimated, estimated,
+                        self._broadcast_shard_size,
+                        estimated,
+                        estimated,
                     )
+                    self._broadcast_shard_size = estimated
 
             self.broadcast_stream = torch.npu.Stream()
             logger.info(
                 "Ascend broadcast stream initialized: shard_size=%d",
                 self._broadcast_shard_size,
             )
-            if self._preallocate_broadcast_pool:
-                self._preallocate_merged_pool()
 
     def _estimate_shard_size(self) -> int:
         """Estimate a safe ``broadcast_shard_size`` from available NPU memory.
@@ -181,8 +185,6 @@ class AscendLMCacheEngine(LMCacheEngine):
         chunk_size = self.metadata.chunk_size
         shapes = self.metadata.get_shapes(chunk_size)
         dtypes = self.metadata.get_dtypes()
-
-        from lmcache.integration.vllm.utils import get_size_bytes
         per_chunk_bytes = get_size_bytes(shapes, dtypes)
 
         device = self.metadata.worker_id
@@ -200,9 +202,9 @@ class AscendLMCacheEngine(LMCacheEngine):
             "(per_chunk=%.1f MB, available=%.2f GB, "
             "pool_budget=%.2f GB)",
             recommended,
-            per_chunk_bytes / 1024 ** 2,
-            available / 1024 ** 3,
-            pool_budget / 1024 ** 3,
+            per_chunk_bytes / 1024**2,
+            available / 1024**3,
+            pool_budget / 1024**3,
         )
         return recommended
 
@@ -267,85 +269,12 @@ class AscendLMCacheEngine(LMCacheEngine):
             len(objs),
         )
 
-    def _sync_pipeline_streams_to_current(
-        self,
-        load_stream: "torch.npu.Stream",
-    ) -> None:
-        """Fence pipeline streams before returning to model execution.
-
-        In graph mode / cross-machine scenarios, host synchronization alone
-        (``load_stream.synchronize()``) does not establish a device-side
-        dependency that the ACL graph replay can see.  We explicitly make
-        the current (model/graph) stream wait on both pipeline streams so
-        that subsequent model ops see the broadcast+scatter results.
-        """
-        current_stream = torch.npu.current_stream()
-        for stream in (self.broadcast_stream, load_stream):
-            if stream is not current_stream:
-                current_stream.wait_stream(stream)
-
     # Ping-pong merged-buffer pool for batched broadcast.  Two slots
     # suffice: while slot A's to_gpu runs on load_stream, slot B
     # receives the next shard's broadcast on broadcast_stream.
     _merged_pool: List["torch.Tensor"] = []
     _pool_scatter_ev: List["torch.npu.Event"] = []
     _pool_bytes: int = 0
-
-    def _broadcast_pool_device(self) -> str:
-        return f"npu:{self.metadata.worker_id}"
-
-    @staticmethod
-    def _dtype_nbytes(dtype: torch.dtype) -> int:
-        if dtype is torch.bool:
-            return 1
-        itemsize = getattr(dtype, "itemsize", None)
-        if itemsize is not None:
-            return int(itemsize)
-        try:
-            return int(torch.finfo(dtype).bits // 8)
-        except TypeError:
-            return int(torch.iinfo(dtype).bits // 8)
-
-    def _broadcast_pool_chunk_bytes(self) -> int:
-        """Estimate the byte size of a full chunk for preallocating buffers."""
-        chunk_size = getattr(self.config, "chunk_size", None)
-        if chunk_size is None:
-            chunk_size = self.metadata.kv_shape[2]
-        chunk_size = int(chunk_size)
-        kv_shapes = self.metadata.get_shapes(chunk_size)
-        kv_dtypes = self.metadata.get_dtypes()
-
-        total = 0
-        for shape, dtype in zip(kv_shapes, kv_dtypes, strict=False):
-            total += int(torch.Size(shape).numel()) * self._dtype_nbytes(dtype)
-        return total
-
-    def _preallocate_merged_pool(self) -> None:
-        if self._broadcast_shard_size <= 0:
-            return
-
-        try:
-            chunk_bytes = self._broadcast_pool_chunk_bytes()
-        except Exception as e:
-            logger.warning(
-                "rank=%d unable to preallocate broadcast merged-buffer pool; "
-                "will allocate on first use: %s",
-                self.metadata.worker_id,
-                e,
-            )
-            return
-        max_bytes = chunk_bytes * self._broadcast_shard_size
-        if max_bytes <= 0:
-            return
-
-        if self._ensure_merged_pool(max_bytes, self._broadcast_pool_device()):
-            logger.info(
-                "Ascend broadcast merged-buffer pool preallocated: "
-                "chunk_bytes=%d shard_size=%d bytes_per_slot=%d",
-                chunk_bytes,
-                self._broadcast_shard_size,
-                max_bytes,
-            )
 
     def _ensure_merged_pool(self, max_bytes: int, device: str) -> bool:
         """Allocate the 2-slot ping-pong pool if not yet created or if a
@@ -573,11 +502,12 @@ class AscendLMCacheEngine(LMCacheEngine):
         meta_table = plan["meta"]
         shard_plan = plan["shard_plan"]
         shard_layouts = plan["shard_layouts"]
-        device = self._broadcast_pool_device()
+        device = f"npu:{self.metadata.worker_id}"
         if not self._ensure_merged_pool(plan["max_shard_bytes"], device):
             raise RuntimeError(
-                "Unable to allocate Ascend broadcast merged-buffer pool "
-                f"({plan['max_shard_bytes']} bytes/slot) on {device}"
+                f"Failed to allocate merged broadcast pool on {device} "
+                f"({plan['max_shard_bytes']} bytes/slot). "
+                "Consider reducing broadcast_shard_size."
             )
 
         pending: List[Tuple[List[MemoryObj], torch.npu.Event]] = []
@@ -631,12 +561,6 @@ class AscendLMCacheEngine(LMCacheEngine):
 
         finally:
             load_stream.synchronize()
-            # Keep the model/graph stream ordered after all broadcast
-            # H2D copies and KV scatters. Host synchronization alone
-            # does not create a stream dependency visible to ACL graph
-            # replay, which can cause hangs on the first request in
-            # graph mode / cross-machine scenarios.
-            self._sync_pipeline_streams_to_current(load_stream)
             for objs, _ in pending:
                 for obj in objs:
                     try:

--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -194,8 +194,24 @@ class AscendLMCacheEngine(LMCacheEngine):
         available = total_mem - allocated
         pool_budget = available // 4
 
+        if per_chunk_bytes <= 0:
+            raise RuntimeError(
+                f"Invalid per-chunk size {per_chunk_bytes} bytes; "
+                "cannot estimate broadcast_shard_size. "
+                "Check model config (shapes/dtypes)."
+            )
         max_shard = int(pool_budget // (2 * per_chunk_bytes))
-        recommended = max(1, min(max_shard, 16))
+        if max_shard <= 0:
+            raise RuntimeError(
+                f"NPU free memory insufficient for broadcast pool "
+                f"(available={available / 1024**3:.2f} GB, "
+                f"pool_budget={pool_budget / 1024**3:.2f} GB, "
+                f"per_chunk={per_chunk_bytes / 1024**2:.1f} MB; "
+                f"need at least {2 * per_chunk_bytes / 1024**2:.1f} MB "
+                f"pool budget for shard_size=1). "
+                "Consider reducing --gpu-memory-utilization or chunk_size."
+            )
+        recommended = min(max_shard, 16)
 
         logger.info(
             "Estimated broadcast_shard_size=%d "

--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -109,8 +109,12 @@ class AscendLMCacheEngine(LMCacheEngine):
 
         self._device_id: Optional[int] = None
 
+        # None means auto-estimate in post_init based on available NPU memory.
         self._broadcast_shard_size = self.config.get_extra_config_value(
-            "broadcast_shard_size", 16
+            "broadcast_shard_size", None
+        )
+        self._preallocate_broadcast_pool = self.config.get_extra_config_value(
+            "preallocate_broadcast_pool", True
         )
 
         if self.kv_events_enabled and self.is_store_async:
@@ -142,11 +146,65 @@ class AscendLMCacheEngine(LMCacheEngine):
         # Override upstream broadcast_stream with a dedicated NPU stream
         # so broadcast and to_gpu can execute on separate streams.
         if self.save_only_first_rank and hasattr(self.gpu_connector, "load_stream"):
+            # Auto-estimate or validate shard_size now that model weights
+            # are loaded and NPU memory state is stable.
+            if self._broadcast_shard_size is None:
+                self._broadcast_shard_size = self._estimate_shard_size()
+            else:
+                estimated = self._estimate_shard_size()
+                if self._broadcast_shard_size > estimated:
+                    logger.warning(
+                        "broadcast_shard_size=%d (user-set) may cause NPU OOM "
+                        "(estimated safe max=%d). Suggestions: "
+                        "(1) reduce broadcast_shard_size to <= %d; "
+                        "(2) or increase --gpu-memory-utilization appropriately "
+                        "(note: KV cache also uses free memory, do not set too high)",
+                        self._broadcast_shard_size, estimated, estimated,
+                    )
+
             self.broadcast_stream = torch.npu.Stream()
             logger.info(
                 "Ascend broadcast stream initialized: shard_size=%d",
                 self._broadcast_shard_size,
             )
+            if self._preallocate_broadcast_pool:
+                self._preallocate_merged_pool()
+
+    def _estimate_shard_size(self) -> int:
+        """Estimate a safe ``broadcast_shard_size`` from available NPU memory.
+
+        Uses 1/4 of the free memory as the pool budget so the remainder
+        is reserved for KV-cache growth and temporary buffers.
+
+        Returns the estimated shard size, clamped to [1, 16].
+        """
+        chunk_size = self.metadata.chunk_size
+        shapes = self.metadata.get_shapes(chunk_size)
+        dtypes = self.metadata.get_dtypes()
+
+        from lmcache.integration.vllm.utils import get_size_bytes
+        per_chunk_bytes = get_size_bytes(shapes, dtypes)
+
+        device = self.metadata.worker_id
+        props = torch.npu.get_device_properties(device)
+        total_mem = props.total_memory
+        allocated = torch.npu.memory_allocated(device)
+        available = total_mem - allocated
+        pool_budget = available // 4
+
+        max_shard = int(pool_budget // (2 * per_chunk_bytes))
+        recommended = max(1, min(max_shard, 16))
+
+        logger.info(
+            "Estimated broadcast_shard_size=%d "
+            "(per_chunk=%.1f MB, available=%.2f GB, "
+            "pool_budget=%.2f GB)",
+            recommended,
+            per_chunk_bytes / 1024 ** 2,
+            available / 1024 ** 3,
+            pool_budget / 1024 ** 3,
+        )
+        return recommended
 
     def _build_shard_plan(
         self,
@@ -199,8 +257,6 @@ class AscendLMCacheEngine(LMCacheEngine):
                 self.gpu_connector.to_gpu(obj, s, e, **kwargs)
             ev_togpu = torch.npu.Event()
             ev_togpu.record()
-        # Record scatter completion so the next broadcast reusing
-        # this slot waits for it.
         self._pool_scatter_ev[slot].record(load_stream)
         pending.append((objs, ev_togpu))
         self._try_release_pending(pending)
@@ -211,12 +267,85 @@ class AscendLMCacheEngine(LMCacheEngine):
             len(objs),
         )
 
+    def _sync_pipeline_streams_to_current(
+        self,
+        load_stream: "torch.npu.Stream",
+    ) -> None:
+        """Fence pipeline streams before returning to model execution.
+
+        In graph mode / cross-machine scenarios, host synchronization alone
+        (``load_stream.synchronize()``) does not establish a device-side
+        dependency that the ACL graph replay can see.  We explicitly make
+        the current (model/graph) stream wait on both pipeline streams so
+        that subsequent model ops see the broadcast+scatter results.
+        """
+        current_stream = torch.npu.current_stream()
+        for stream in (self.broadcast_stream, load_stream):
+            if stream is not current_stream:
+                current_stream.wait_stream(stream)
+
     # Ping-pong merged-buffer pool for batched broadcast.  Two slots
     # suffice: while slot A's to_gpu runs on load_stream, slot B
     # receives the next shard's broadcast on broadcast_stream.
     _merged_pool: List["torch.Tensor"] = []
     _pool_scatter_ev: List["torch.npu.Event"] = []
     _pool_bytes: int = 0
+
+    def _broadcast_pool_device(self) -> str:
+        return f"npu:{self.metadata.worker_id}"
+
+    @staticmethod
+    def _dtype_nbytes(dtype: torch.dtype) -> int:
+        if dtype is torch.bool:
+            return 1
+        itemsize = getattr(dtype, "itemsize", None)
+        if itemsize is not None:
+            return int(itemsize)
+        try:
+            return int(torch.finfo(dtype).bits // 8)
+        except TypeError:
+            return int(torch.iinfo(dtype).bits // 8)
+
+    def _broadcast_pool_chunk_bytes(self) -> int:
+        """Estimate the byte size of a full chunk for preallocating buffers."""
+        chunk_size = getattr(self.config, "chunk_size", None)
+        if chunk_size is None:
+            chunk_size = self.metadata.kv_shape[2]
+        chunk_size = int(chunk_size)
+        kv_shapes = self.metadata.get_shapes(chunk_size)
+        kv_dtypes = self.metadata.get_dtypes()
+
+        total = 0
+        for shape, dtype in zip(kv_shapes, kv_dtypes, strict=False):
+            total += int(torch.Size(shape).numel()) * self._dtype_nbytes(dtype)
+        return total
+
+    def _preallocate_merged_pool(self) -> None:
+        if self._broadcast_shard_size <= 0:
+            return
+
+        try:
+            chunk_bytes = self._broadcast_pool_chunk_bytes()
+        except Exception as e:
+            logger.warning(
+                "rank=%d unable to preallocate broadcast merged-buffer pool; "
+                "will allocate on first use: %s",
+                self.metadata.worker_id,
+                e,
+            )
+            return
+        max_bytes = chunk_bytes * self._broadcast_shard_size
+        if max_bytes <= 0:
+            return
+
+        if self._ensure_merged_pool(max_bytes, self._broadcast_pool_device()):
+            logger.info(
+                "Ascend broadcast merged-buffer pool preallocated: "
+                "chunk_bytes=%d shard_size=%d bytes_per_slot=%d",
+                chunk_bytes,
+                self._broadcast_shard_size,
+                max_bytes,
+            )
 
     def _ensure_merged_pool(self, max_bytes: int, device: str) -> bool:
         """Allocate the 2-slot ping-pong pool if not yet created or if a
@@ -444,8 +573,12 @@ class AscendLMCacheEngine(LMCacheEngine):
         meta_table = plan["meta"]
         shard_plan = plan["shard_plan"]
         shard_layouts = plan["shard_layouts"]
-        device = f"npu:{self.metadata.worker_id}"
-        self._ensure_merged_pool(plan["max_shard_bytes"], device)
+        device = self._broadcast_pool_device()
+        if not self._ensure_merged_pool(plan["max_shard_bytes"], device):
+            raise RuntimeError(
+                "Unable to allocate Ascend broadcast merged-buffer pool "
+                f"({plan['max_shard_bytes']} bytes/slot) on {device}"
+            )
 
         pending: List[Tuple[List[MemoryObj], torch.npu.Event]] = []
 
@@ -498,6 +631,12 @@ class AscendLMCacheEngine(LMCacheEngine):
 
         finally:
             load_stream.synchronize()
+            # Keep the model/graph stream ordered after all broadcast
+            # H2D copies and KV scatters. Host synchronization alone
+            # does not create a stream dependency visible to ACL graph
+            # replay, which can cause hangs on the first request in
+            # graph mode / cross-machine scenarios.
+            self._sync_pipeline_streams_to_current(load_stream)
             for objs, _ in pending:
                 for obj in objs:
                     try:

--- a/tests/v1/test_estimate_shard_size.py
+++ b/tests/v1/test_estimate_shard_size.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for ``AscendLMCacheEngine._estimate_shard_size`` ,
+when save_only_first_rank is True in MLA scenario.
+"""
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+GB = 1024**3
+MB = 1024**2
+
+
+def _make_engine(monkeypatch, *, total_mem, allocated, per_chunk_bytes):
+    """Mock NPU state."""
+    # First Party
+    from lmcache_ascend.v1 import cache_engine as ce_mod
+
+    engine = object.__new__(ce_mod.AscendLMCacheEngine)
+
+    # Fake metadata consumed by _estimate_shard_size
+    engine.metadata = SimpleNamespace(
+        chunk_size=256,
+        worker_id=0,
+        get_shapes=lambda _cs: ("unused",),  # bypassed by get_size_bytes patch
+        get_dtypes=lambda: ("unused",),
+    )
+
+    # --- Patch module-level get_size_bytes ---
+    monkeypatch.setattr(
+        ce_mod,
+        "get_size_bytes",
+        lambda _shapes, _dtypes: per_chunk_bytes,
+    )
+
+    # --- Patch torch.npu device APIs ---
+    fake_props = SimpleNamespace(total_memory=total_mem)
+    monkeypatch.setattr(
+        ce_mod.torch.npu,
+        "get_device_properties",
+        lambda _device: fake_props,
+    )
+    monkeypatch.setattr(
+        ce_mod.torch.npu,
+        "memory_allocated",
+        lambda _device: allocated,
+    )
+
+    return engine
+
+
+class TestEstimateShardSize:
+    """Verify ``_estimate_shard_size`` under different NPU memory states."""
+
+    def test_normal_case(self, monkeypatch):
+        """Abundant free memory → clamp at upper bound 16."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=80 * GB,
+            allocated=30 * GB,  # 50 GB free
+            per_chunk_bytes=10 * MB,  # budget = 12.5 GB → max_shard=640
+        )
+        assert engine._estimate_shard_size() == 16
+
+    def test_moderate_memory(self, monkeypatch):
+        """Limited free memory → value within (1, 16)."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=40 * GB,
+            allocated=30 * GB,  # 10 GB free, budget = 2.5 GB
+            per_chunk_bytes=100 * MB,  # max_shard = 2.5GB / 200MB = 12
+        )
+        assert engine._estimate_shard_size() == 12
+
+    def test_zero_free_memory(self, monkeypatch):
+        """No free memory at all → RuntimeError (fail-fast)."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=10 * GB,
+            allocated=10 * GB,  # available = 0
+            per_chunk_bytes=10 * MB,
+        )
+        with pytest.raises(RuntimeError, match="insufficient"):
+            engine._estimate_shard_size()
+
+    def test_tiny_free_memory(self, monkeypatch):
+        """Free memory too small to hold one shard → RuntimeError."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=10 * GB,
+            allocated=10 * GB - 1 * MB,  # only 1 MB free
+            per_chunk_bytes=10 * MB,
+        )
+        with pytest.raises(RuntimeError, match="insufficient"):
+            engine._estimate_shard_size()
+
+    def test_huge_chunk_size(self, monkeypatch):
+        """per-chunk bytes larger than pool budget → RuntimeError."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=10 * GB,
+            allocated=0,  # 10 GB free, budget = 2.5 GB
+            per_chunk_bytes=5 * GB,  # max_shard = 2.5GB / 10GB = 0
+        )
+        with pytest.raises(RuntimeError, match="insufficient"):
+            engine._estimate_shard_size()
+
+    def test_per_chunk_larger_than_available(self, monkeypatch):
+        """per-chunk bytes larger than total free memory → RuntimeError."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=1 * GB,
+            allocated=900 * MB,  # 100 MB free
+            per_chunk_bytes=1 * GB,  # one chunk > available
+        )
+        with pytest.raises(RuntimeError, match="insufficient"):
+            engine._estimate_shard_size()
+
+    def test_per_chunk_zero_raises(self, monkeypatch):
+        """per_chunk_bytes == 0 → RuntimeError (no ZeroDivisionError)."""
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=80 * GB,
+            allocated=0,
+            per_chunk_bytes=0,
+        )
+        with pytest.raises(RuntimeError, match="Invalid per-chunk size"):
+            engine._estimate_shard_size()
+
+    @pytest.mark.parametrize(
+        "total,alloc,per_chunk,expected",
+        [
+            # budget = 40GB/4 = 10GB, divisor = 2GB, max_shard = 5
+            (40 * GB, 0, 1 * GB, 5),
+            # budget = 24GB/4 = 6GB, divisor = 2GB, max_shard = 3
+            (24 * GB, 0, 1 * GB, 3),
+            # budget = 32GB/4 = 8GB, divisor = 0.5GB, max_shard = 16 → clamp at 16
+            (32 * GB, 0, 256 * MB, 16),
+            # max_shard exactly 16, no clamping needed
+            (132 * GB, 4 * GB, 1 * GB, 16),
+        ],
+    )
+    def test_boundary_values(self, monkeypatch, total, alloc, per_chunk, expected):
+        engine = _make_engine(
+            monkeypatch,
+            total_mem=total,
+            allocated=alloc,
+            per_chunk_bytes=per_chunk,
+        )
+        assert engine._estimate_shard_size() == expected


### PR DESCRIPTION
1. Support dynamic shard_size when save_only_first_rank = true

```
python -m pytest tests/v1/test_estimate_shard_size.py -v
=============================================================== test session starts ================================================================
platform linux -- Python 3.11.14, pytest-9.1.1, pluggy-1.6.0 -- /usr/local/python3.11.14/bin/python
cachedir: .pytest_cache
rootdir: /home/xnm/vl/LMCache-Ascend/tests
configfile: pytest.ini
plugins: anyio-4.13.0
collected 11 items                                                                                                                                 

tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_normal_case PASSED                                                         [  9%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_moderate_memory PASSED                                                     [ 18%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_zero_free_memory PASSED                                                    [ 27%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_tiny_free_memory PASSED                                                    [ 36%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_huge_chunk_size PASSED                                                     [ 45%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_per_chunk_larger_than_available PASSED                                     [ 54%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_per_chunk_zero_raises PASSED                                               [ 63%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_boundary_values[42949672960-0-1073741824-5] PASSED                         [ 72%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_boundary_values[25769803776-0-1073741824-3] PASSED                         [ 81%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_boundary_values[34359738368-0-268435456-16] PASSED                         [ 90%]
tests/v1/test_estimate_shard_size.py::TestEstimateShardSize::test_boundary_values[141733920768-4294967296-1073741824-16] PASSED              [100%]

================================================================= warnings summary =================================================================
../../../../usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531
../../../../usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531
../../../../usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531
../../../../usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531
../../../../usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531
../../../../usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531
v1/test_estimate_shard_size.py::TestEstimateShardSize::test_normal_case
  /usr/local/python3.11.14/lib/python3.11/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py:531: DeprecationWarning: `LoggingHandler` in `opentelemetry-sdk` is deprecated. Use the handler from `opentelemetry-instrumentation-logging` instead.
    warnings.warn(

../../../../usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py:347
  /usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py:347: ImportWarning: 
      *************************************************************************************************************
      The torch.Tensor.cuda and torch.nn.Module.cuda are replaced with torch.Tensor.npu and torch.nn.Module.npu now..
      The torch.cuda.DoubleTensor is replaced with torch.npu.FloatTensor cause the double type is not supported now..
      The backend in torch.distributed.init_process_group set to hccl now..
      The torch.cuda.* and torch.cuda.amp.* are replaced with torch.npu.* and torch.npu.amp.* now..
      The device parameters have been replaced with npu in the function below:
      torch.logspace, torch.randint, torch.hann_window, torch.rand, torch.full_like, torch.ones_like, torch.rand_like, torch.randperm, torch.arange, torch.frombuffer, torch.normal, torch._empty_per_channel_affine_quantized, torch.empty_strided, torch.empty_like, torch.scalar_tensor, torch.tril_indices, torch.bartlett_window, torch.ones, torch.sparse_coo_tensor, torch.randn, torch.kaiser_window, torch.tensor, torch.triu_indices, torch.as_tensor, torch.zeros, torch.randint_like, torch.full, torch.eye, torch._sparse_csr_tensor_unsafe, torch.empty, torch._sparse_coo_tensor_unsafe, torch.blackman_window, torch.zeros_like, torch.range, torch.sparse_csr_tensor, torch.randn_like, torch.from_file, torch._cudnn_init_dropout_state, torch._empty_affine_quantized, torch.linspace, torch.hamming_window, torch.empty_quantized, torch._pin_memory, torch.load, torch.set_default_device, torch.get_device_module, torch.sparse_compressed_tensor, torch.Tensor.new_empty, torch.Tensor.new_empty_strided, torch.Tensor.new_full, torch.Tensor.new_ones, torch.Tensor.new_tensor, torch.Tensor.new_zeros, torch.Tensor.to, torch.Tensor.pin_memory, torch.nn.Module.to, torch.nn.Module.to_empty
      *************************************************************************************************************
      
    warnings.warn(msg, ImportWarning)

../../../../usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py:276
  /usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py:276: RuntimeWarning: torch.jit.script and torch.jit.script_method will be disabled by transfer_to_npu, which currently does not support them, if you need to enable them, please do not use transfer_to_npu.
    warnings.warn(msg, RuntimeWarning)

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 11 passed, 11 warnings in 2.02s ==========================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
root@liteserver-hps-805f-00002:/home/xnm/vl/LMCache-Ascend# 
```