### PR TITLE
[Bug] Restore normal-mode KV cache loading during retrieval

### DIFF
--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -681,6 +681,12 @@ class AscendLMCacheEngine(LMCacheEngine):
                 self._pipelined_sharded_broadcast_and_load(
                     reordered_chunks, ret_mask, **kwargs
                 )
+        elif len(reordered_chunks) > 0:
+            with retrieve_stats.profile_to_gpu():
+                _, memory_objs, starts, ends = zip(*reordered_chunks, strict=False)
+                self.gpu_connector.batched_to_gpu(
+                    list(memory_objs), list(starts), list(ends), **kwargs
+                )
 
         # --- Cleanup ---
         # When save_only_first_rank is set, the sharded-broadcast pipeline

--- a/tests/v1/test_cache_engine_retrieve.py
+++ b/tests/v1/test_cache_engine_retrieve.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for Ascend LMCache retrieval."""
+
+# Standard
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+# Third Party
+import torch
+
+# First Party
+from lmcache_ascend.v1.cache_engine import AscendLMCacheEngine
+
+
+class _RetrieveStats:
+    def profile_process_tokens(self):
+        return nullcontext()
+
+    def profile_to_gpu(self):
+        return nullcontext()
+
+    def time_to_retrieve(self):
+        return 0.001
+
+
+def test_retrieve_loads_cache_to_gpu_in_normal_mode():
+    """A cache hit must copy the retrieved CPU KV into the serving KV cache."""
+    engine = object.__new__(AscendLMCacheEngine)
+    stats = _RetrieveStats()
+    memory_obj_0 = SimpleNamespace(ref_count_down=Mock())
+    memory_obj_1 = SimpleNamespace(ref_count_down=Mock())
+    chunks = [
+        (object(), memory_obj_0, 0, 256),
+        (object(), memory_obj_1, 256, 512),
+    ]
+
+    engine.gpu_connector = SimpleNamespace(batched_to_gpu=Mock())
+    engine.is_healthy = lambda: True
+    engine._get_req_id = lambda _kwargs: "test-request"
+    engine._log_kvcache_for_check = lambda **_kwargs: None
+    engine.stats_monitor = SimpleNamespace(
+        on_retrieve_request=lambda _num_tokens: stats,
+        on_retrieve_finished=Mock(),
+    )
+    engine._is_passive = lambda: False
+    engine.async_loading = False
+    engine.save_only_first_rank = False
+    engine.remove_after_retrieve = False
+
+    def process_tokens(tokens, mask, ret_mask, **kwargs):
+        ret_mask[:] = True
+        return chunks, 1024
+
+    engine._process_tokens_internal = process_tokens
+
+    slot_mapping = object()
+    result = engine.retrieve(
+        list(range(512)),
+        slot_mapping=slot_mapping,
+    )
+
+    engine.gpu_connector.batched_to_gpu.assert_called_once_with(
+        [memory_obj_0, memory_obj_1],
+        [0, 256],
+        [256, 512],
+        slot_mapping=slot_mapping,
+    )
+    assert torch.all(result)
+    memory_obj_0.ref_count_down.assert_called_once_with()
+    memory_obj_1.ref_count_down.assert_called_once_with()


### PR DESCRIPTION
## Summary

Restore KV cache loading in the normal retrieval path when
`save_only_first_rank` is disabled.

## Root cause

The Ascend `retrieve()` override handled KV loading inside the sharded
broadcast path, but omitted the normal-mode call to
`gpu_connector.batched_to_gpu()`.

As a result, LMCache reported the prefix as retrieved and returned a hit mask,
but the retrieved KV data was never loaded into vLLM's NPU KV cache. The model
then consumed stale or invalid KV data and generated corrupted output.

## Fix

Call `batched_to_gpu()` for retrieved chunks when
`save_only_first_rank` is disabled, while preserving the existing
sharded-broadcast behavior.

A regression test verifies that:

- retrieved memory objects are passed to `batched_to_gpu()`;
- chunk offsets and connector arguments are preserved;
- retrieved memory objects are released afterward.

## Validation

### Unit test

```bash
python -m pytest tests/v1/test_cache_engine_retrieve.py -q
```
Result:

```text
1 passed
```
