### PR TITLE
[BUG][AscendP2P][InProcess] Fix Host-Staging H2H Copy non-draining when cancelled

### DIFF
--- a/lmcache_ascend/v1/transfer_channel/hccl_channel.py
+++ b/lmcache_ascend/v1/transfer_channel/hccl_channel.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, Optional, Union
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Dict, List, Optional, Union
 import asyncio
 import pickle
 import threading
@@ -39,6 +39,31 @@ from .transfer_spec import TS_RECEIVER_ID
 logger = init_logger(__name__)
 
 _DEFAULT_STAGING_BYTES = 10 * 1024 * 1024 * 1024
+
+
+async def _await_settled(fut: "asyncio.Future") -> Any:
+    """Await ``fut`` without letting cancellation resume the caller early.
+
+    ``asyncio.shield`` keeps *fut* running across a cancel, but the awaiting
+    coroutine still resumes immediately, and ``Future.cancel()`` cannot stop
+    executor work that already started. A single shielded await therefore
+    still lets a caller reclaim buffers while worker threads write into them.
+    Re-await until *fut* actually settles, then re-raise the cancellation.
+    """
+    cancelled: Optional[asyncio.CancelledError] = None
+    while not fut.done():
+        try:
+            await asyncio.shield(fut)
+        except asyncio.CancelledError as exc:
+            cancelled = exc
+    if cancelled is not None:
+        if not fut.cancelled() and fut.exception() is not None:
+            logger.warning(
+                "Shielded operation failed while its caller was cancelled: %s",
+                fut.exception(),
+            )
+        raise cancelled
+    return fut.result()
 
 
 class HcclMsgBase(msgspec.Struct, tag=True):
@@ -222,7 +247,15 @@ class HcclChannel(BaseMultiBufferChannel):
         src_tensors: list[torch.Tensor],
         dst_tensors: list[torch.Tensor],
     ) -> None:
-        """Copy host tensors off the event loop with a bounded copy pool."""
+        """Copy host tensors off the event loop with a bounded copy pool.
+
+        The await is cancellation-safe: ThreadPoolExecutor workers are drained
+        before this coroutine returns or raises. Callers such as
+        ``copy_receiver_staging_to`` / ``stage`` may ``release_staged()`` as
+        soon as the await completes; abandoning in-flight H2H workers would
+        UAF the staging arena on reuse (e.g. sync-get timeout cancel during
+        the post-DMA H2H copy).
+        """
         if len(src_tensors) != len(dst_tensors):
             raise ValueError(
                 "src_tensors and dst_tensors must have the same length, "
@@ -243,24 +276,42 @@ class HcclChannel(BaseMultiBufferChannel):
             else 1
         )
 
+        if executor is None:
+            await _await_settled(
+                loop.run_in_executor(None, _copy_slice, dst_tensors, src_tensors)
+            )
+            return
+
+        # Submit directly to the pool: the returned handles are owned here and
+        # cannot be detached by task cancellation, unlike ``run_in_executor``.
+        cf_futures: List[Future] = []
         if n_slices > 1:
             base, rem = divmod(num_tensors, n_slices)
-            tasks = []
             start = 0
             for i in range(n_slices):
                 end = start + base + (1 if i < rem else 0)
-                tasks.append(
-                    loop.run_in_executor(
-                        executor,
+                cf_futures.append(
+                    executor.submit(
                         _copy_slice,
                         dst_tensors[start:end],
                         src_tensors[start:end],
                     )
                 )
                 start = end
-            await asyncio.gather(*tasks)
         else:
-            await loop.run_in_executor(executor, _copy_slice, dst_tensors, src_tensors)
+            cf_futures.append(executor.submit(_copy_slice, dst_tensors, src_tensors))
+
+        # ``return_exceptions`` so a failing slice cannot resume the caller
+        # while sibling threads are still writing into the same pages.
+        results = await _await_settled(
+            asyncio.gather(
+                *(asyncio.wrap_future(cf, loop=loop) for cf in cf_futures),
+                return_exceptions=True,
+            )
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
 
     async def stage(
         self, mem_objs: list[MemoryObj]
@@ -289,7 +340,10 @@ class HcclChannel(BaseMultiBufferChannel):
                 src_tensors=[mem_objs[i].tensor for i in range(num_staged)],
                 dst_tensors=[a.tensor for a in arena_objs],
             )
-        except Exception:
+        except (Exception, asyncio.CancelledError):
+            # Safe to freelist: ``_async_h2h_copy`` drains workers first.
+            # Include CancelledError (BaseException) so sync-get timeout
+            # cannot leak arena pages until channel teardown.
             self.release_staged(arena_objs)
             raise
 

--- a/tests/v1/transfer_channel/test_staging_h2h_copy.py
+++ b/tests/v1/transfer_channel/test_staging_h2h_copy.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
+"""Unit tests for host-staging H2H copy cancellation safety.
+
+These tests exercise ``HcclChannel._async_h2h_copy`` on a minimally
+constructed instance (no live HCCL/NPU traffic). Import still requires
+the extension module to be present.
+"""
+
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+import asyncio
+import threading
+import time
+
+# First Party
+from tests.bootstrap import prepare_environment
+
+prepare_environment()
+
+# Third Party
+import pytest
+import torch
+
+try:
+    # First Party
+    from lmcache_ascend.v1.transfer_channel.hccl_channel import HcclChannel
+
+    _hccl_channel_available = True
+except ImportError:
+    _hccl_channel_available = False
+    HcclChannel = None  # type: ignore[misc, assignment]
+
+pytestmark = pytest.mark.skipif(
+    not _hccl_channel_available,
+    reason="hccl channel extension not built (set HCOMM_SRC_PATH at build time)",
+)
+
+# How long a parked fake copy waits to be released. Only a safety net so a
+# broken test cannot hang the suite; the test always releases explicitly.
+_HOLD_TIMEOUT_S = 10.0
+# How long we keep asserting the caller stays blocked while workers are live.
+_OBSERVE_S = 0.5
+# Duration of the slow sibling slice in the failing-slice test.
+_SIBLING_COPY_S = 0.5
+
+
+class _ParkedCopy:
+    """Fake ``torch._foreach_copy_`` that parks *inside* the copy body.
+
+    Makes worker liveness directly observable instead of assumed:
+    ``live_workers`` counts threads currently inside the copy, and no worker
+    can leave until :meth:`release` is called. A test can therefore assert
+    "N threads are still writing" at the same moment it asserts the caller
+    has not been resumed.
+    """
+
+    def __init__(self, num_workers: int):
+        self.num_workers = num_workers
+        self._all_inside = threading.Barrier(num_workers + 1)
+        self._gate = threading.Event()
+        self._lock = threading.Lock()
+        self._live = 0
+        self.finished: list[str] = []
+
+    def __call__(self, dst_slice, src_slice) -> None:
+        with self._lock:
+            self._live += 1
+        try:
+            self._all_inside.wait(timeout=_HOLD_TIMEOUT_S)
+            if not self._gate.wait(timeout=_HOLD_TIMEOUT_S):
+                raise AssertionError("copy gate was never released by the test")
+            with self._lock:
+                self.finished.append(threading.current_thread().name)
+        finally:
+            with self._lock:
+                self._live -= 1
+
+    @property
+    def live_workers(self) -> int:
+        with self._lock:
+            return self._live
+
+    def wait_until_all_inside(self) -> None:
+        """Block until every worker has entered the copy body."""
+        self._all_inside.wait(timeout=_HOLD_TIMEOUT_S)
+
+    def release(self) -> None:
+        self._gate.set()
+
+
+def _make_channel(*, copy_threads: int = 2) -> HcclChannel:
+    channel = object.__new__(HcclChannel)
+    channel._os_staging_copy_threads = copy_threads
+    channel._staging_copy_pool = ThreadPoolExecutor(
+        max_workers=copy_threads,
+        thread_name_prefix="test-staging-copy",
+    )
+    return channel
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _assert_blocked_while_workers_live(task, copy: _ParkedCopy, seconds: float):
+    """Assert the caller stays blocked for *seconds* while workers are live.
+
+    Both halves matter: ``live_workers`` proves the copy threads really are
+    still inside the copy, and ``task.done()`` proves the caller has not been
+    resumed (which is what would let it hand the staging page back).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + seconds
+    while loop.time() < deadline:
+        live = copy.live_workers
+        assert live == copy.num_workers, (
+            f"expected {copy.num_workers} copy threads still inside the copy, "
+            f"saw {live} (gate has not been released yet)"
+        )
+        assert not task.done(), (
+            f"caller resumed while {live} copy thread(s) were still writing"
+        )
+        await asyncio.sleep(0.02)
+
+
+class TestAsyncH2HCopyDrain:
+    def test_cancel_waits_for_executor_workers(self, monkeypatch):
+        """Cancelled await must not return while H2H workers still write.
+
+        Sync-get timeout cancels ``_handle_pull_mode_transfer`` during
+        ``copy_receiver_staging_to``. Callers then ``release_staged()``.
+        If ThreadPoolExecutor workers are orphaned, arena freelist reuse
+        UAFs the pages under in-flight ``torch._foreach_copy_``.
+        """
+        channel = _make_channel(copy_threads=2)
+        copy = _ParkedCopy(num_workers=2)
+        monkeypatch.setattr(torch, "_foreach_copy_", copy)
+
+        src = [torch.ones(8), torch.ones(8)]
+        dst = [torch.zeros(8), torch.zeros(8)]
+
+        async def _cancel_mid_copy():
+            loop = asyncio.get_running_loop()
+            task = asyncio.create_task(channel._async_h2h_copy(src, dst))
+            await loop.run_in_executor(None, copy.wait_until_all_inside)
+
+            # Release inside the coroutine even on failure: parked workers
+            # would otherwise stall asyncio.run()'s executor shutdown until
+            # the _HOLD_TIMEOUT_S safety net fires.
+            try:
+                task.cancel()
+                await _assert_blocked_while_workers_live(task, copy, _OBSERVE_S)
+            finally:
+                copy.release()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # Every worker ran to completion before the await returned.
+            assert len(copy.finished) == 2
+            assert copy.live_workers == 0
+
+        try:
+            _run(_cancel_mid_copy())
+        finally:
+            copy.release()
+            channel._staging_copy_pool.shutdown(wait=True)
+
+    def test_repeated_cancel_still_drains(self, monkeypatch):
+        """Repeated cancels must not resume the caller before workers finish.
+
+        A sync-get timeout can be followed by a second cancel (e.g. loop
+        teardown cancelling pending tasks). A single shielded await would
+        resume on the second cancel, freeing pages under live writers.
+        """
+        channel = _make_channel(copy_threads=2)
+        copy = _ParkedCopy(num_workers=2)
+        monkeypatch.setattr(torch, "_foreach_copy_", copy)
+
+        src = [torch.ones(8), torch.ones(8)]
+        dst = [torch.zeros(8), torch.zeros(8)]
+
+        async def _cancel_repeatedly():
+            loop = asyncio.get_running_loop()
+            task = asyncio.create_task(channel._async_h2h_copy(src, dst))
+            await loop.run_in_executor(None, copy.wait_until_all_inside)
+
+            # Cancel repeatedly, and keep checking across the whole window.
+            try:
+                for _ in range(3):
+                    task.cancel()
+                    await _assert_blocked_while_workers_live(task, copy, _OBSERVE_S / 3)
+            finally:
+                copy.release()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert len(copy.finished) == 2
+            assert copy.live_workers == 0
+
+        try:
+            _run(_cancel_repeatedly())
+        finally:
+            copy.release()
+            channel._staging_copy_pool.shutdown(wait=True)
+
+    def test_exception_in_one_slice_drains_siblings(self, monkeypatch):
+        """A failing slice must not freelist while sibling workers still run."""
+        channel = _make_channel(copy_threads=2)
+        sibling_started = threading.Event()
+        sibling_done = threading.Event()
+        call_count = {"n": 0}
+        lock = threading.Lock()
+
+        def flaky_foreach(dst_slice, src_slice):
+            with lock:
+                call_count["n"] += 1
+                idx = call_count["n"]
+            if idx == 1:
+                sibling_started.set()
+                # Slow sibling — must finish before _async_h2h_copy raises.
+                time.sleep(_SIBLING_COPY_S)
+                sibling_done.set()
+                return
+            # Fast failing slice: wait until sibling has started, then raise.
+            assert sibling_started.wait(timeout=_HOLD_TIMEOUT_S)
+            raise RuntimeError("boom-slice")
+
+        monkeypatch.setattr(torch, "_foreach_copy_", flaky_foreach)
+
+        src = [torch.ones(4), torch.ones(4)]
+        dst = [torch.zeros(4), torch.zeros(4)]
+
+        async def _run_copy():
+            with pytest.raises(RuntimeError, match="boom-slice"):
+                await channel._async_h2h_copy(src, dst)
+            assert sibling_done.is_set(), (
+                "error surfaced while the sibling slice was still copying"
+            )
+
+        try:
+            _run(_run_copy())
+        finally:
+            channel._staging_copy_pool.shutdown(wait=True)
+
+
+class TestStageCancelReleasesArena:
+    def test_stage_cancelled_error_releases_staged(self, monkeypatch):
+        """Cancelled stage() must return arena pages (after H2H drain)."""
+        channel = _make_channel(copy_threads=1)
+        channel._use_host_staging = True
+        channel._staging_arena = MagicMock()
+        channel._staging_lock = threading.Lock()
+
+        slot = MagicMock()
+        slot.tensor = torch.zeros(4)
+        slot.meta = MagicMock(shape=(4,), dtype=torch.float32, fmt=MagicMock())
+        channel._staging_arena.allocate.return_value = slot
+
+        released = []
+
+        def _release(objs):
+            released.extend(objs)
+
+        channel.release_staged = _release  # type: ignore[method-assign]
+        channel.get_local_buffer_refs = MagicMock(return_value=([], []))
+
+        async def cancel_copy(*_args, **_kwargs):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(channel, "_async_h2h_copy", cancel_copy)
+
+        src_obj = MagicMock()
+        src_obj.tensor = torch.ones(4)
+        src_obj.meta = slot.meta
+
+        async def _run_stage():
+            with pytest.raises(asyncio.CancelledError):
+                await channel.stage([src_obj])
+
+        try:
+            _run(_run_stage())
+            assert released == [slot]
+        finally:
+            channel._staging_copy_pool.shutdown(wait=True)


### PR DESCRIPTION
## Overview

The AscendP2P host-staging path can cancel the H2H copy coroutine, but the underlying
thread pool keeps executing. Cancelling an asyncio future does not stop a
`ThreadPoolExecutor` worker that has already started — `concurrent.futures.Future.cancel()`
returns `False` once the work is running.

The awaiting coroutine therefore resumed immediately while copy threads were still
touching the staging pages, and the caller went on to `release_staged()` them. This is now
fixed: we drain the copy first, then re-raise the cancellation.

Introduced with H2H host staging (#259).

## Impact

`release_staged()` returns pages to the staging arena free list, so a page could be handed
to another in-flight transfer while a copy thread was still using it. Both peers are
affected, because both funnel through the same helper:

- Consumer (`copy_receiver_staging_to`): the page is freed while threads still **read** it,
  so a concurrent transfer can allocate it and DMA new data in — the final KV buffer ends
  up holding another request's bytes.
- Producer (`stage`): the page is freed while threads still **write** into it, so the next
  `stage()` can take the page and have it overwritten underneath. `stage()` also caught only
  `Exception`, so a `CancelledError` skipped the release entirely and leaked the page until
  channel teardown.

Trigger: `use_host_staging` with `p2p_delay_pull: False` and `p2p_use_npu: False`, when a
sync-get timeout (`p2p_sync_get_timeout_s`) cancels the pull during the post-DMA host copy.

## What changed

All in `_async_h2h_copy` / `stage` in `hccl_channel.py`:

- Submit slices with `executor.submit` and keep the `concurrent.futures` handles locally, so
  task cancellation cannot detach the handle from work that is still running.
  `run_in_executor` marks its future cancelled even when the thread cannot be stopped.
- New `_await_settled` helper: re-await under `asyncio.shield` until the work actually
  settles, then re-raise the cancellation. A single shielded await is not enough — `shield`
  keeps the inner operation alive but still resumes the caller immediately, so repeated
  cancels (e.g. loop teardown after a timeout) would still free pages under live writers.
- `gather(..., return_exceptions=True)` so a failing slice cannot resume the caller while
  sibling threads are still writing.
- `asyncio.wrap_future` to observe thread completion on the event loop instead of blocking an
  extra executor thread per in-flight copy.
- `stage()` releases arena pages on `CancelledError` as well as `Exception`, which is safe
  now that the drain is guaranteed.

## Implications

We wait slightly longer on the abort path for the in-flight copy to finish. That is one
chunk-sized host memcpy — sub-millisecond to a couple of milliseconds in practice. It is
also off the request critical path: the blocking sync-get has already returned
`TimeoutError` to the worker by then, so the only thing deferred is reuse of the staging
page.

The copies themselves still run off the event loop; only the completion notification touches
it. At teardown `close()` already does `_staging_copy_pool.shutdown(wait=True)` before
closing the arena, so threads are joined before the arena memory goes away.

## Tests

`tests/v1/transfer_channel/test_staging_h2h_copy.py` replaces `torch._foreach_copy_` with a
fake that parks inside the copy body and counts the threads currently in it, so each test
asserts both "N threads are still writing" and "the caller has not resumed" at the same
instant, across a 500 ms window.

| test | guards against |
| --- | --- |
| `test_cancel_waits_for_executor_workers` | a single cancel freeing the page under a live copy |
| `test_repeated_cancel_still_drains` | a second or third cancel doing the same |
| `test_exception_in_one_slice_drains_siblings` | one slice's error resuming the caller while siblings write |
| `test_stage_cancelled_error_releases_staged` | producer `stage()` leaking its arena page on cancel |

All four fail against the pre-fix code (`caller resumed while 2 copy thread(s) were still
writing`) and pass with the fix. They need no NPU device and no peers, but are skipped when
the HCCL extension is not built.

## Scope note

This addresses the host-side copy pool only. Draining the HCCL transport stream before
releasing buffers on an aborted transfer is a separate concern and is not part of this PR.