### PR TITLE
[PD][P2P] Allow PD and P2P to be used together on Ascend

### DIFF
--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -228,6 +228,7 @@ def _patch_config():
         "When exceeded, the oldest entry is evicted to prevent unbounded "
         "memory growth. Default is 0 (unlimited).",
     }
+
     def _ascend_validate_config(self):
         if not (self.enable_pd and self.enable_p2p):
             return lmcache.v1.config._validate_config(self)
@@ -235,7 +236,7 @@ def _patch_config():
         if self.pd_role != "sender":
             raise ValueError(
                 "Invalid LMCache-Ascend config: `enable_pd=true` and "
-                "`enable_p2p=true` are only supported for `pd_role=\"sender\"` "
+                '`enable_p2p=true` are only supported for `pd_role="sender"` '
                 f"in Phase 1, got pd_role={self.pd_role!r}."
             )
 
@@ -390,10 +391,10 @@ def _patch_storage_manager():
         allocate_and_copy_objects as ascend_allocate_and_copy_objects,
     )
     from lmcache_ascend.v1.storage_backend.storage_manager import (
-        batched_get as ascend_batched_get,
+        batched_contains as ascend_batched_contains,
     )
     from lmcache_ascend.v1.storage_backend.storage_manager import (
-        batched_contains as ascend_batched_contains,
+        batched_get as ascend_batched_get,
     )
     from lmcache_ascend.v1.storage_backend.storage_manager import get as ascend_get
     from lmcache_ascend.v1.storage_backend.storage_manager import (

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -228,9 +228,83 @@ def _patch_config():
         "When exceeded, the oldest entry is evicted to prevent unbounded "
         "memory growth. Default is 0 (unlimited).",
     }
+    def _ascend_validate_config(self):
+        if not (self.enable_pd and self.enable_p2p):
+            return lmcache.v1.config._validate_config(self)
+
+        if self.pd_role != "sender":
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_pd=true` and "
+                "`enable_p2p=true` are only supported for `pd_role=\"sender\"` "
+                f"in Phase 1, got pd_role={self.pd_role!r}."
+            )
+
+        if self.enable_async_loading:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_async_loading=true` is "
+                "not supported when `enable_pd=true` and `enable_p2p=true` in "
+                "Phase 1. Use blocking retrieve with enable_async_loading=false."
+            )
+
+        if not self.enable_controller:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_controller=true` is "
+                "required when `enable_p2p=true`."
+            )
+        if self.controller_pull_url is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `controller_pull_url` is "
+                "required when `enable_p2p=true`."
+            )
+        if self.controller_reply_url is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `controller_reply_url` is "
+                "required when `enable_p2p=true`."
+            )
+        if not self.lmcache_worker_ports:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `lmcache_worker_ports` is "
+                "required and cannot be empty when `enable_p2p=true`."
+            )
+        if self.p2p_host is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `p2p_host` is required when "
+                "`enable_p2p=true`."
+            )
+        if self.p2p_init_ports is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `p2p_init_ports` is required "
+                "when `enable_p2p=true`."
+            )
+        if self.p2p_lookup_ports is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `p2p_lookup_ports` is required "
+                "when `enable_p2p=true`."
+            )
+        if self.transfer_channel is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `transfer_channel` is required "
+                "when `enable_p2p=true`."
+            )
+
+        original_enable_p2p = self.enable_p2p
+        # Temporarily disable p2p to bypass upstream's
+        # `assert self.enable_p2p is False` (config.py:599) while still running
+        # upstream's PD field validation (pd_role/pd_buffer_size/save_unfull_chunk
+        # auto-fix, etc.). The 8 p2p field checks above replicate upstream's p2p
+        # validation block (config.py:582-590), which is otherwise skipped when
+        # enable_p2p is flipped to False.
+        # Safe as long as upstream's PD validation block has no side-effect that
+        # branches on enable_p2p (currently true: save_unfull_chunk assignment at
+        # config.py:611 only depends on enable_pd).
+        try:
+            self.enable_p2p = False
+            return lmcache.v1.config._validate_config(self)
+        finally:
+            self.enable_p2p = original_enable_p2p
 
     namespace_extras = {
-        "validate": lmcache.v1.config._validate_config,
+        "validate": _ascend_validate_config,
         "log_config": lmcache.v1.config._log_config,
         "get_extra_config_value": lmcache.v1.config._get_extra_config_value,
         "get_lmcache_worker_ids": lmcache.v1.config._get_lmcache_worker_ids,

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -600,7 +600,19 @@ def _patch_vllm_v1_adapter():
 
     lmc_vllm_v1_adapter.LMCacheConnectorV1Impl = ascend_LMCacheAscendConnectorV1Impl
 
-    def handle_preemptions(self, preempted_req_ids):
+    def handle_preemptions(self, preemption_payload):
+        # vLLM 0.18 passes request IDs directly, while vLLM 0.23 carries
+        # them in connector metadata built by the scheduler-side adapter.
+        if isinstance(preemption_payload, set):
+            preempted_req_ids = set(preemption_payload)
+        else:
+            preempted_req_ids = set(
+                getattr(preemption_payload, "preempted_req_ids", None) or ()
+            )
+
+        if not preempted_req_ids:
+            return
+
         method = getattr(self._lmcache_engine, "handle_preemptions", None)
         if callable(method):
             method(preempted_req_ids)

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -387,6 +387,9 @@ def _patch_storage_manager():
 
     # First Party
     from lmcache_ascend.v1.storage_backend.storage_manager import (
+        allocate_and_copy_objects as ascend_allocate_and_copy_objects,
+    )
+    from lmcache_ascend.v1.storage_backend.storage_manager import (
         batched_get as ascend_batched_get,
     )
     from lmcache_ascend.v1.storage_backend.storage_manager import get as ascend_get
@@ -396,6 +399,7 @@ def _patch_storage_manager():
         patched_prefetch_all_done_callback,
     )
 
+    lm_storage_manager.allocate_and_copy_objects = ascend_allocate_and_copy_objects
     lm_storage_manager.StorageManager.get = ascend_get
     lm_storage_manager.StorageManager.batched_get = ascend_batched_get
     lm_storage_manager.StorageManager.prefetch_all_done_callback = (

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -392,6 +392,9 @@ def _patch_storage_manager():
     from lmcache_ascend.v1.storage_backend.storage_manager import (
         batched_get as ascend_batched_get,
     )
+    from lmcache_ascend.v1.storage_backend.storage_manager import (
+        batched_contains as ascend_batched_contains,
+    )
     from lmcache_ascend.v1.storage_backend.storage_manager import get as ascend_get
     from lmcache_ascend.v1.storage_backend.storage_manager import (
         local_cpu_touch_cache,
@@ -401,6 +404,7 @@ def _patch_storage_manager():
 
     lm_storage_manager.allocate_and_copy_objects = ascend_allocate_and_copy_objects
     lm_storage_manager.StorageManager.get = ascend_get
+    lm_storage_manager.StorageManager.batched_contains = ascend_batched_contains
     lm_storage_manager.StorageManager.batched_get = ascend_batched_get
     lm_storage_manager.StorageManager.prefetch_all_done_callback = (
         patched_prefetch_all_done_callback

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
 # Third Party
@@ -14,6 +15,7 @@ from vllm.config import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVConnectorMetadata,
     KVConnectorRole,
 )
 from vllm.distributed.parallel_state import get_pp_group
@@ -23,9 +25,17 @@ import torch
 if TYPE_CHECKING:
     # Third Party
     from vllm.forward_context import ForwardContext
+    from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class LMCacheAscendConnectorMetadata(LMCacheConnectorMetadata):
+    """LMCache request metadata plus vLLM scheduler preemption hints."""
+
+    preempted_req_ids: set[str] = field(default_factory=set)
 
 
 class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
@@ -42,6 +52,21 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
         self._finished_req_ids_waiting_for_save: set[str] = set()
         self._late_finished_sending: set[str] = set()
         logger.debug("store_async: %s", self.store_async)
+
+    @_lmcache_nvtx_annotate
+    def build_connector_meta(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> KVConnectorMetadata:
+        """Build per-step metadata and carry preempted request IDs to workers."""
+        metadata = super().build_connector_meta(scheduler_output)
+        assert isinstance(metadata, LMCacheConnectorMetadata)
+
+        return LMCacheAscendConnectorMetadata(
+            requests=metadata.requests,
+            preempted_req_ids=set(
+                getattr(scheduler_output, "preempted_req_ids", None) or ()
+            ),
+        )
 
     @_lmcache_nvtx_annotate
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
@@ -264,7 +289,9 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
         self._wait_for_save_done = True
         self._replay_finished_stores_after_save()
 
-    def _pd_producer_skip_leading_tokens(self, skip_leading_tokens: int, request) -> int:
+    def _pd_producer_skip_leading_tokens(
+        self, skip_leading_tokens: int, request
+    ) -> int:
         """Clamp producer store skip to tokens already transferred to D.
 
         ``skip_leading_tokens`` may come from local/P2P cache hits, but PD
@@ -386,7 +413,7 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
         )
 
     def handle_preemptions(self, preempted_req_ids: set[str]) -> None:
-        if self.lmcache_engine is None:
+        if self.lmcache_engine is None or not preempted_req_ids:
             return
 
         logger.debug(

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -195,6 +195,10 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
                     skip_leading_tokens = save_spec.skip_leading_tokens
                 else:
                     skip_leading_tokens = 0
+                
+                skip_leading_tokens = self._pd_producer_skip_leading_tokens(
+                    skip_leading_tokens, request
+                )
 
                 if skip_leading_tokens == len(token_ids):
                     continue
@@ -259,6 +263,21 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
 
         self._wait_for_save_done = True
         self._replay_finished_stores_after_save()
+
+    def _pd_producer_skip_leading_tokens(self, skip_leading_tokens: int, request) -> int:
+        """Clamp producer store skip to tokens already transferred to D.
+
+        ``skip_leading_tokens`` may come from local/P2P cache hits, but PD
+        handoff can only skip tokens that the paired decoder has already
+        received for this request. This preserves the upstream LMCache producer
+        guard while keeping Ascend's LocalCPU backfill skip calculation.
+        """
+        if self.kv_role == "kv_producer" and request.disagg_spec:
+            return min(
+                skip_leading_tokens,
+                request.disagg_spec.num_transferred_tokens,
+            )
+        return skip_leading_tokens
 
     def _local_persist_skip(self, request, token_ids) -> Optional[int]:
         """Decide whether a remote-loaded prefix must be persisted locally.

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -220,7 +220,7 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
                     skip_leading_tokens = save_spec.skip_leading_tokens
                 else:
                     skip_leading_tokens = 0
-                
+
                 skip_leading_tokens = self._pd_producer_skip_leading_tokens(
                     skip_leading_tokens, request
                 )

--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -119,15 +119,21 @@ class AscendLMCacheEngine(LMCacheEngine):
             self.kv_events = ThreadSafeEventList()
 
     def _is_pd_receiver(self) -> bool:
-        return self.config.enable_pd and self.config.pd_role == "receiver"
+        config = getattr(self, "config", None)
+        return bool(
+            getattr(config, "enable_pd", False)
+            and getattr(config, "pd_role", None) == "receiver"
+        )
 
     def _release_pd_request_lease(self, request_id: Optional[str]) -> None:
         if not request_id or request_id == "unspecified":
             return
-        if not self._is_pd_receiver() or self.storage_manager is None:
+
+        storage_manager = getattr(self, "storage_manager", None)
+        if not self._is_pd_receiver() or storage_manager is None:
             return
 
-        pd_backend = self.storage_manager.storage_backends.get("PDBackend")
+        pd_backend = storage_manager.storage_backends.get("PDBackend")
         release_request_lease = getattr(pd_backend, "release_request_lease", None)
         if callable(release_request_lease):
             release_request_lease(request_id)

--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -118,6 +118,20 @@ class AscendLMCacheEngine(LMCacheEngine):
         if self.kv_events_enabled and self.is_store_async:
             self.kv_events = ThreadSafeEventList()
 
+    def _is_pd_receiver(self) -> bool:
+        return self.config.enable_pd and self.config.pd_role == "receiver"
+
+    def _release_pd_request_lease(self, request_id: Optional[str]) -> None:
+        if not request_id or request_id == "unspecified":
+            return
+        if not self._is_pd_receiver() or self.storage_manager is None:
+            return
+
+        pd_backend = self.storage_manager.storage_backends.get("PDBackend")
+        release_request_lease = getattr(pd_backend, "release_request_lease", None)
+        if callable(release_request_lease):
+            release_request_lease(request_id)
+
     def _ensure_store_worker(self) -> None:
         if self._store_queue is not None:
             return
@@ -1038,19 +1052,64 @@ class AscendLMCacheEngine(LMCacheEngine):
     ) -> int:
         # Serialize against the store-worker thread's
         with self._engine_state_lock:
-            return super().lookup(
-                tokens=tokens,
-                hashes=hashes,
-                offsets=offsets,
-                search_range=search_range,
-                lookup_id=lookup_id,
-                pin=pin,
-                request_configs=request_configs,
-            )
+            token = None
+            if self._is_pd_receiver() and pin and lookup_id is not None:
+                from lmcache_ascend.v1.storage_backend.storage_manager import (
+                    set_current_pd_lookup_id,
+                )
+
+                token = set_current_pd_lookup_id(lookup_id)
+            try:
+                return super().lookup(
+                    tokens=tokens,
+                    hashes=hashes,
+                    offsets=offsets,
+                    search_range=search_range,
+                    lookup_id=lookup_id,
+                    pin=pin,
+                    request_configs=request_configs,
+                )
+            finally:
+                if token is not None:
+                    from lmcache_ascend.v1.storage_backend.storage_manager import (
+                        reset_current_pd_lookup_id,
+                    )
+
+                    reset_current_pd_lookup_id(token)
 
     def lookup_unpin(self, lookup_id: str) -> None:
         with self._engine_state_lock:
-            super().lookup_unpin(lookup_id)
+            try:
+                super().lookup_unpin(lookup_id)
+            finally:
+                self._release_pd_request_lease(lookup_id)
+
+    @torch.inference_mode()
+    def retrieve(
+        self,
+        tokens: Union[torch.Tensor, list[int]],
+        mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        req_id = self._get_req_id(kwargs)
+        token = None
+        if self._is_pd_receiver():
+            from lmcache_ascend.v1.storage_backend.storage_manager import (
+                set_current_pd_retrieve_id,
+            )
+
+            token = set_current_pd_retrieve_id(req_id)
+
+        try:
+            return super().retrieve(tokens, mask=mask, **kwargs)
+        finally:
+            if token is not None:
+                from lmcache_ascend.v1.storage_backend.storage_manager import (
+                    reset_current_pd_retrieve_id,
+                )
+
+                reset_current_pd_retrieve_id(token)
+            self._release_pd_request_lease(req_id)
 
     @torch.inference_mode()
     def store(

--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -609,7 +609,7 @@ class AscendLMCacheEngine(LMCacheEngine):
                         pass
 
     @torch.inference_mode()
-    def retrieve(
+    def _retrieve_impl(
         self,
         tokens: Union[torch.Tensor, list[int]],
         mask: Optional[torch.Tensor] = None,
@@ -1054,6 +1054,7 @@ class AscendLMCacheEngine(LMCacheEngine):
         with self._engine_state_lock:
             token = None
             if self._is_pd_receiver() and pin and lookup_id is not None:
+                # First Party
                 from lmcache_ascend.v1.storage_backend.storage_manager import (
                     set_current_pd_lookup_id,
                 )
@@ -1071,6 +1072,7 @@ class AscendLMCacheEngine(LMCacheEngine):
                 )
             finally:
                 if token is not None:
+                    # First Party
                     from lmcache_ascend.v1.storage_backend.storage_manager import (
                         reset_current_pd_lookup_id,
                     )
@@ -1094,6 +1096,7 @@ class AscendLMCacheEngine(LMCacheEngine):
         req_id = self._get_req_id(kwargs)
         token = None
         if self._is_pd_receiver():
+            # First Party
             from lmcache_ascend.v1.storage_backend.storage_manager import (
                 set_current_pd_retrieve_id,
             )
@@ -1101,9 +1104,10 @@ class AscendLMCacheEngine(LMCacheEngine):
             token = set_current_pd_retrieve_id(req_id)
 
         try:
-            return super().retrieve(tokens, mask=mask, **kwargs)
+            return self._retrieve_impl(tokens, mask=mask, **kwargs)
         finally:
             if token is not None:
+                # First Party
                 from lmcache_ascend.v1.storage_backend.storage_manager import (
                     reset_current_pd_retrieve_id,
                 )

--- a/lmcache_ascend/v1/proxy_memory_obj.py
+++ b/lmcache_ascend/v1/proxy_memory_obj.py
@@ -94,6 +94,7 @@ class ProxyMemoryObj(MemoryObj):
         # Temporary lookup pins increment this count but must not consume the
         # base owner when they are released.
         self._ref_count = 1
+        self._lease_request_id: Optional[str] = None
 
         # Store allocation metadata for deferred buffer operations
         if backing_obj is not None:
@@ -143,6 +144,28 @@ class ProxyMemoryObj(MemoryObj):
             self._consumed = True
             self._released = True
             self._ref_count = 0
+
+    def clone_for_request(self, request_id: str) -> "ProxyMemoryObj":
+        """Create a request-local proxy over the same remote buffer reference.
+
+        The backend keeps an unconsumed prototype so other requests can still
+        declare hits for the same PD key.  The connector consumes only this
+        clone, making ``mark_consumed()`` request-local.
+        """
+        proxy = ProxyMemoryObj(
+            backing_obj=None,
+            transfer_channel=self._transfer_channel,
+            target_peer_url=self._target_peer_url,
+            remote_buffer_uuid=self._remote_buffer_uuid,
+            remote_mem_index=self._remote_mem_index,
+            transfer_context=self._transfer_context,
+            chunk_index=self._chunk_index,
+            shapes=self._shapes,
+            dtypes=self._dtypes,
+            fmt=self._fmt,
+        )
+        proxy._lease_request_id = request_id
+        return proxy
 
     @property
     def backing_obj(self) -> Optional[MemoryObj]:

--- a/lmcache_ascend/v1/storage_backend/__init__.py
+++ b/lmcache_ascend/v1/storage_backend/__init__.py
@@ -80,6 +80,9 @@ def CreateStorageBackends(
     # Reuse existing LocalCPUBackend when available so that
     # dependent backends (disk, remote, p2p, …) keep working.
     local_cpu_backend: Optional[LocalCPUBackend] = None
+    needs_local_cpu_backend = (
+        not config.enable_pd or config.local_cpu or config.enable_p2p
+    )
     if existing_backends and "LocalCPUBackend" in existing_backends:
         _existing_cpu = existing_backends["LocalCPUBackend"]
         if isinstance(_existing_cpu, LocalCPUBackend):
@@ -88,7 +91,7 @@ def CreateStorageBackends(
     if metadata.role == "scheduler":
         # For scheduler role, local_cpu_backend is None
         pass
-    elif not config.enable_pd or config.local_cpu:
+    elif needs_local_cpu_backend:
         if "LocalCPUBackend" in _skip:
             pass  # Skipped — already exists
         elif config.max_local_cpu_size > 0:
@@ -110,7 +113,11 @@ def CreateStorageBackends(
                 "with `use_layerwise=true`. The Ascend P2P backend does not support "
                 "layerwise mode in current implementation. Disable one of them."
             )
-        assert local_cpu_backend is not None
+        if local_cpu_backend is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_p2p=true` requires "
+                "`max_local_cpu_size > 0` or an existing `LocalCPUBackend`."
+            )
         assert lmcache_worker is not None
         p2p_backend = AscendP2PBackend(
             config,

--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -46,7 +46,8 @@ class PDEntry:
 
     base_obj: MemoryObj
     owners: set[str] = field(default_factory=set)
-    proxy_leases: dict[str, ProxyMemoryObj] = field(default_factory=dict) # used for delay-pull mode
+    # Request-local proxy clones used for delay-pull mode.
+    proxy_leases: dict[str, ProxyMemoryObj] = field(default_factory=dict)
     pending_delete: bool = False
 
 

--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -8,6 +8,7 @@ allocation, and key lookup/partitioning.
 """
 
 # Standard
+from dataclasses import dataclass, field
 from typing import Optional, Union
 import threading
 
@@ -37,6 +38,16 @@ from lmcache_ascend.v1.storage_backend.utils import resolve_memory_format
 from lmcache_ascend.v1.transfer_channel import CreateTransferChannel, get_correct_device
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class PDEntry:
+    """Receiver-side PD object plus request ownership metadata."""
+
+    base_obj: MemoryObj
+    owners: set[str] = field(default_factory=set)
+    proxy_leases: dict[str, ProxyMemoryObj] = field(default_factory=dict) # used for delay-pull mode
+    pending_delete: bool = False
 
 
 class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
@@ -73,6 +84,8 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
 
         # Receiver-side KV store
         self.data: dict[CacheEngineKey, MemoryObj] = {}
+        self._pd_entries: dict[CacheEngineKey, PDEntry] = {}
+        self._pd_request_keys: dict[str, set[CacheEngineKey]] = {}
         self.data_lock = threading.Lock()
 
         self.memory_allocator = self.initialize_allocator(config, metadata)
@@ -271,12 +284,13 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         object when *pin* is ``True`` once the pin is no longer needed.
         """
         with self.data_lock:
-            mem_obj = self.data.get(key, None)
-            if mem_obj is None:
+            entry = self._pd_entries.get(key)
+            if entry is None:
                 return None
 
+            mem_obj = entry.base_obj
             if isinstance(mem_obj, ProxyMemoryObj) and mem_obj.consumed:
-                del self.data[key]
+                self._delete_pd_entry_locked(key, entry, release_obj=False)
                 return None
 
             if pin:
@@ -303,6 +317,188 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         Returns ``None`` when the key is absent or is a consumed proxy.
         """
         return self._lookup(key, pin=True)
+
+    def put(
+        self,
+        key: CacheEngineKey,
+        mem_obj: MemoryObj,
+    ):
+        with self.data_lock:
+            old_entry = self._pd_entries.get(key)
+            if old_entry is not None and old_entry.owners:
+                logger.warning(
+                    "PD receiver overwriting key %s with active owners: %s",
+                    key,
+                    sorted(old_entry.owners),
+                )
+            self.data[key] = mem_obj
+            self._pd_entries[key] = PDEntry(base_obj=mem_obj)
+
+    def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        with self.data_lock:
+            entry = self._pd_entries.get(key)
+            assert entry is not None, f"Key {key} not found in local data."
+            return entry.base_obj
+
+    def batched_get_blocking_for_request(
+        self,
+        keys: list[CacheEngineKey],
+        request_id: str,
+    ) -> list[Optional[MemoryObj]]:
+        memory_objs: list[Optional[MemoryObj]] = []
+        with self.data_lock:
+            for key in keys:
+                entry = self._pd_entries.get(key)
+                if entry is None:
+                    logger.warning(
+                        "PD request %s declared hit for missing key %s.",
+                        request_id,
+                        key,
+                    )
+                    memory_objs.append(None)
+                    continue
+
+                if request_id not in entry.owners:
+                    logger.debug(
+                        "PD request %s retrieves key %s without a prior lease; "
+                        "registering a lazy lease.",
+                        request_id,
+                        key,
+                    )
+                    self._ensure_request_lease_locked(key, entry, request_id)
+
+                base_obj = entry.base_obj
+                if isinstance(base_obj, ProxyMemoryObj):
+                    proxy = entry.proxy_leases.get(request_id)
+                    if proxy is None or proxy.consumed:
+                        logger.warning(
+                            "PD request %s has no usable proxy lease for key %s.",
+                            request_id,
+                            key,
+                        )
+                        memory_objs.append(None)
+                    else:
+                        memory_objs.append(proxy)
+                    continue
+
+                base_obj.ref_count_up()
+                memory_objs.append(base_obj)
+        return memory_objs
+
+    def batched_contains_and_lease(
+        self,
+        keys: list[CacheEngineKey],
+        request_id: str,
+    ) -> int:
+        hit_chunks = 0
+        with self.data_lock:
+            for key in keys:
+                entry = self._pd_entries.get(key)
+                if entry is None:
+                    break
+
+                base_obj = entry.base_obj
+                if isinstance(base_obj, ProxyMemoryObj) and base_obj.consumed:
+                    self._delete_pd_entry_locked(key, entry, release_obj=False)
+                    break
+
+                self._ensure_request_lease_locked(key, entry, request_id)
+
+                hit_chunks += 1
+        return hit_chunks
+
+    def _ensure_request_lease_locked(
+        self,
+        key: CacheEngineKey,
+        entry: PDEntry,
+        request_id: str,
+    ) -> None:
+        entry.owners.add(request_id)
+        self._pd_request_keys.setdefault(request_id, set()).add(key)
+
+        base_obj = entry.base_obj
+        if not isinstance(base_obj, ProxyMemoryObj):
+            return
+
+        if request_id in entry.proxy_leases:
+            return
+
+        entry.proxy_leases[request_id] = base_obj.clone_for_request(request_id)
+        transfer_context = base_obj.transfer_context
+        acquire_request = getattr(
+            transfer_context,
+            "acquire_request",
+            None,
+        )
+        if callable(acquire_request):
+            acquire_request(request_id)
+
+    def release_request_lease(self, request_id: str) -> None:
+        proxy_contexts = []
+        with self.data_lock:
+            keys = self._pd_request_keys.pop(request_id, set())
+            for key in list(keys):
+                entry = self._pd_entries.get(key)
+                if entry is None:
+                    continue
+
+                entry.owners.discard(request_id)
+                proxy = entry.proxy_leases.pop(request_id, None)
+                if proxy is not None:
+                    proxy_contexts.append(proxy.transfer_context)
+
+                entry.pending_delete = True
+                if not entry.owners:
+                    self._delete_pd_entry_locked(key, entry, release_obj=True)
+
+        for transfer_context in proxy_contexts:
+            release_request = getattr(
+                transfer_context,
+                "release_request",
+                None,
+            )
+            if callable(release_request):
+                release_request(request_id)
+
+    def remove(
+        self,
+        key: CacheEngineKey,
+        force: bool = True,
+    ) -> bool:
+        with self.data_lock:
+            entry = self._pd_entries.get(key)
+            if entry is None:
+                return False
+
+            entry.pending_delete = True
+            if entry.owners:
+                return True
+
+            self._delete_pd_entry_locked(key, entry, release_obj=True)
+            return True
+
+    def _delete_pd_entry_locked(
+        self,
+        key: CacheEngineKey,
+        entry: PDEntry,
+        release_obj: bool,
+    ) -> None:
+        self.data.pop(key, None)
+        self._pd_entries.pop(key, None)
+        for owner in list(entry.owners):
+            owned_keys = self._pd_request_keys.get(owner)
+            if owned_keys is not None:
+                owned_keys.discard(key)
+                if not owned_keys:
+                    self._pd_request_keys.pop(owner, None)
+        entry.owners.clear()
+        entry.proxy_leases.clear()
+
+        if release_obj:
+            try:
+                entry.base_obj.ref_count_down()
+            except Exception as e:
+                logger.warning("Failed to release PD entry for key %s: %s", key, e)
 
     def _partition_keys(
         self,

--- a/lmcache_ascend/v1/storage_backend/pd/receiver_mixin.py
+++ b/lmcache_ascend/v1/storage_backend/pd/receiver_mixin.py
@@ -108,7 +108,11 @@ class AscendPDReceiverMixin:
                 )
                 with self.data_lock:
                     for k in allocated_keys:
-                        self.data.pop(k, None)
+                        entry = self._pd_entries.get(k)
+                        if entry is not None:
+                            self._delete_pd_entry_locked(k, entry, release_obj=False)
+                        else:
+                            self.data.pop(k, None)
                 release_memory_objects(allocated_objs + already_sent_objs)
                 return AscendAllocResponse(
                     already_sent_indexes=already_sent_indexes,

--- a/lmcache_ascend/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/v1/storage_backend/storage_manager.py
@@ -61,16 +61,65 @@ no-op for missing keys instead of aborting the lookup.
 """
 
 # Standard
-from typing import List, Optional, cast
+from typing import List, Optional, Sequence, cast
 
 # Third Party
+import torch
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.event_manager import EventStatus, EventType
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
+
+
+def allocate_and_copy_objects(
+    allocator_backend: AllocatorBackendInterface,
+    keys: Sequence[CacheEngineKey],
+    src_memory_objs: list[MemoryObj],
+    stream: torch.cuda.Stream,
+) -> tuple[Sequence[CacheEngineKey], list[MemoryObj]]:
+    """Allocate/copy objects while preserving key-object alignment.
+
+    Upstream LMCache returns ``keys[:len(allocated_objects)]`` after skipping
+    keys that already exist in the target allocator. That can pair newly copied
+    suffix objects with already-skipped prefix keys. Keep the allocated keys
+    alongside the objects so StorageManager fan-out submits aligned pairs.
+    """
+    allocated_keys = []
+    allocated_objects = []
+    for key, src_memory_obj in zip(keys, src_memory_objs, strict=False):
+        if allocator_backend.contains(key):
+            continue
+        memory_obj = allocator_backend.allocate(
+            src_memory_obj.get_shape(),
+            src_memory_obj.get_dtype(),
+            fmt=src_memory_obj.meta.fmt,
+            eviction=True,
+            busy_loop=False,
+        )
+
+        if memory_obj is None:
+            break
+
+        if memory_obj.tensor is None:
+            logger.warning(
+                "Allocated MemoryObj has None tensor, this is unexpected. "
+                "Releasing the memory object."
+            )
+            memory_obj.ref_count_down()
+            break
+
+        with torch.cuda.stream(stream):
+            memory_obj.tensor.copy_(src_memory_obj.tensor, non_blocking=True)
+        allocated_keys.append(key)
+        allocated_objects.append(memory_obj)
+
+    if stream is not None:
+        stream.synchronize()
+    return allocated_keys, allocated_objects
 
 
 def get(

--- a/lmcache_ascend/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/v1/storage_backend/storage_manager.py
@@ -65,21 +65,21 @@ from typing import List, Optional, Sequence, cast
 import contextvars
 
 # Third Party
-import torch
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.event_manager import EventStatus, EventType
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+import torch
 
 logger = init_logger(__name__)
 
-_current_pd_lookup_id: contextvars.ContextVar[Optional[str]] = (
-    contextvars.ContextVar("current_pd_lookup_id", default=None)
+_current_pd_lookup_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "current_pd_lookup_id", default=None
 )
-_current_pd_retrieve_id: contextvars.ContextVar[Optional[str]] = (
-    contextvars.ContextVar("current_pd_retrieve_id", default=None)
+_current_pd_retrieve_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "current_pd_retrieve_id", default=None
 )
 
 
@@ -193,7 +193,7 @@ def batched_get(
             )
         else:
             memory_objs = storage_backend.batched_get_blocking(keys)
-            
+
         if memory_objs and any(m is not None for m in memory_objs):
             # Align with single-key `get()` logic:
             # auto-write remote data to local CPU cache, but skip deferred-fetch

--- a/lmcache_ascend/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/v1/storage_backend/storage_manager.py
@@ -62,6 +62,7 @@ no-op for missing keys instead of aborting the lookup.
 
 # Standard
 from typing import List, Optional, Sequence, cast
+import contextvars
 
 # Third Party
 import torch
@@ -73,6 +74,29 @@ from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterfac
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
+
+_current_pd_lookup_id: contextvars.ContextVar[Optional[str]] = (
+    contextvars.ContextVar("current_pd_lookup_id", default=None)
+)
+_current_pd_retrieve_id: contextvars.ContextVar[Optional[str]] = (
+    contextvars.ContextVar("current_pd_retrieve_id", default=None)
+)
+
+
+def set_current_pd_lookup_id(request_id: str) -> contextvars.Token:
+    return _current_pd_lookup_id.set(request_id)
+
+
+def reset_current_pd_lookup_id(token: contextvars.Token) -> None:
+    _current_pd_lookup_id.reset(token)
+
+
+def set_current_pd_retrieve_id(request_id: str) -> contextvars.Token:
+    return _current_pd_retrieve_id.set(request_id)
+
+
+def reset_current_pd_retrieve_id(token: contextvars.Token) -> None:
+    _current_pd_retrieve_id.reset(token)
 
 
 def allocate_and_copy_objects(
@@ -157,7 +181,19 @@ def batched_get(
     """Blocking batched get with a delay-pull proxy guard on local write-back."""
     # TODO (ApostaC): remove the nested optional here
     for backend_name, storage_backend in self.get_active_storage_backends(location):
-        memory_objs = storage_backend.batched_get_blocking(keys)
+        request_id = _current_pd_retrieve_id.get()
+        if (
+            backend_name == "PDBackend"
+            and request_id is not None
+            and hasattr(storage_backend, "batched_get_blocking_for_request")
+        ):
+            memory_objs = storage_backend.batched_get_blocking_for_request(
+                keys,
+                request_id,
+            )
+        else:
+            memory_objs = storage_backend.batched_get_blocking(keys)
+            
         if memory_objs and any(m is not None for m in memory_objs):
             # Align with single-key `get()` logic:
             # auto-write remote data to local CPU cache, but skip deferred-fetch
@@ -181,6 +217,44 @@ def batched_get(
                 local_cpu_backend.batched_submit_put_task(keys, memory_objs_no_none)
             return memory_objs
     return [None] * len(keys)
+
+
+def batched_contains(
+    self,
+    keys: List[CacheEngineKey],
+    search_range: Optional[List[str]] = None,
+    pin: bool = False,
+) -> tuple[int, dict]:
+    """Prefix lookup with PD receiver request-lease registration."""
+    total_keys = len(keys)
+    total_hit_chunks = 0
+    block_mapping = {}
+    for backend_name, backend in self.get_active_storage_backends(
+        search_range=search_range
+    ):
+        request_id = _current_pd_lookup_id.get()
+        if (
+            backend_name == "PDBackend"
+            and pin
+            and request_id is not None
+            and hasattr(backend, "batched_contains_and_lease")
+        ):
+            hit_chunks = backend.batched_contains_and_lease(keys, request_id)
+        else:
+            # Preserve upstream semantics: PDBackend is not pinned by the
+            # generic pin path. Ascend PD leases are handled above.
+            pin_in_backend = pin if backend_name != "PDBackend" else False
+            hit_chunks = backend.batched_contains(keys, pin_in_backend)
+
+        if hit_chunks == 0:
+            continue
+        block_mapping[backend_name] = keys[:hit_chunks]
+        total_hit_chunks += hit_chunks
+        if total_hit_chunks == total_keys:
+            break
+        keys = keys[hit_chunks:]
+
+    return total_hit_chunks, block_mapping
 
 
 def _best_effort_touch_cache(self, cache_dict) -> None:

--- a/lmcache_ascend/v1/transfer_context.py
+++ b/lmcache_ascend/v1/transfer_context.py
@@ -354,6 +354,8 @@ class PDTransferContext(AscendBaseTransferContext):
         self._sender_id = sender_id
         self._done_callback = done_callback
         self._loop = None
+        self._active_request_counts: dict[str, int] = {}
+        self._active_lease_count = 0
 
         logger.debug(
             "PDTransferContext: sender_id=%s, num_proxies=%d, "
@@ -364,6 +366,64 @@ class PDTransferContext(AscendBaseTransferContext):
             dtypes,
             fmt,
         )
+
+    def acquire_request(self, request_id: str) -> None:
+        """Register one request-level lease on this PD pull context."""
+        with self._lock:
+            if self._done_sent:
+                raise RuntimeError(
+                    "Cannot acquire PD request lease after Done was sent "
+                    f"for sender {self._sender_id}, request {request_id}"
+                )
+            self._active_request_counts[request_id] = (
+                self._active_request_counts.get(request_id, 0) + 1
+            )
+            self._active_lease_count += 1
+
+    def release_request(self, request_id: str) -> None:
+        """Release one request-level lease and send Done after the last lease."""
+        send_done = False
+        with self._lock:
+            count = self._active_request_counts.get(request_id, 0)
+            if count <= 0:
+                return
+
+            if count == 1:
+                self._active_request_counts.pop(request_id, None)
+            else:
+                self._active_request_counts[request_id] = count - 1
+
+            self._active_lease_count -= 1
+            if self._active_lease_count <= 0 and not self._done_sent:
+                self._done_sent = True
+                send_done = True
+
+        if send_done:
+            self._send_done()
+
+    def decref(self) -> None:
+        """Ignore generic proxy refcounting for PD delay-pull.
+
+        PD receiver proxies are shared prototypes in the backend store plus
+        per-request clones handed to the connector.  The sender-side resources
+        must be released by request leases, not by incidental pins from
+        receiver control-plane deduplication.
+        """
+        return None
+
+    def send_done_now(self) -> None:
+        """Send Done only when no request-level leases are active."""
+        send_done = False
+        with self._lock:
+            if self._done_sent:
+                return
+            if self._active_lease_count > 0:
+                return
+            self._done_sent = True
+            send_done = True
+
+        if send_done:
+            self._send_done()
 
     def _send_done(self) -> None:
         """Invoke the done callback to signal the sender."""

--- a/tests/integration/vllm/test_handle_preemptions.py
+++ b/tests/integration/vllm/test_handle_preemptions.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-import pickle
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
+import pickle
 
 # Third Party
 import pytest
@@ -30,8 +30,7 @@ def _make_adapter(adapter_mod, *, store_async, kv_role, lmcache_engine):
     return adapter
 
 
-@pytest.mark.parametrize("preempted_req_ids", [{"req-1", "req-2"}, None])
-def test_build_connector_meta_carries_preempted_request_ids(preempted_req_ids):
+def test_build_connector_meta_carries_preempted_request_ids():
     """Scheduler metadata preserves LMCache requests and preemption hints."""
     pytest.importorskip("lmcache")
     pytest.importorskip("vllm")
@@ -40,6 +39,7 @@ def test_build_connector_meta_carries_preempted_request_ids(preempted_req_ids):
     adapter = object.__new__(adapter_mod.LMCacheAscendConnectorV1Impl)
     request_metadata = object()
     base_metadata = adapter_mod.LMCacheConnectorMetadata(requests=[request_metadata])
+    preempted_req_ids = {"req-1", "req-2"}
     scheduler_output = SimpleNamespace(preempted_req_ids=preempted_req_ids)
 
     with patch.object(
@@ -51,11 +51,10 @@ def test_build_connector_meta_carries_preempted_request_ids(preempted_req_ids):
 
     assert isinstance(metadata, adapter_mod.LMCacheAscendConnectorMetadata)
     assert metadata.requests == [request_metadata]
-    assert metadata.preempted_req_ids == set(preempted_req_ids or ())
+    assert metadata.preempted_req_ids == preempted_req_ids
 
-    if preempted_req_ids is not None:
-        preempted_req_ids.add("req-added-after-build")
-        assert "req-added-after-build" not in metadata.preempted_req_ids
+    preempted_req_ids.add("req-added-after-build")
+    assert "req-added-after-build" not in metadata.preempted_req_ids
 
 
 def test_ascend_connector_metadata_is_pickleable():
@@ -73,61 +72,45 @@ def test_ascend_connector_metadata_is_pickleable():
     assert restored.preempted_req_ids == {"req-1", "req-2"}
 
 
-def test_lmcache_connector_extracts_preemptions_from_v023_metadata():
-    """The vLLM 0.23 metadata payload is normalized to request IDs."""
+@pytest.mark.parametrize("payload_kind", ["v023_metadata", "legacy_set"])
+def test_lmcache_connector_normalizes_preemption_payload(payload_kind):
+    """The patched connector accepts both vLLM 0.23 and legacy payloads."""
     LMCacheConnectorV1 = _import_and_patch_vllm_connector()
     adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
 
     connector = object.__new__(LMCacheConnectorV1)
     connector._lmcache_engine = MagicMock()
 
-    metadata = adapter_mod.LMCacheAscendConnectorMetadata(
-        preempted_req_ids={"req-1", "req-2"}
-    )
-    connector.handle_preemptions(metadata)
+    expected_req_ids = {"req-1", "req-2"}
+    if payload_kind == "v023_metadata":
+        payload = adapter_mod.LMCacheAscendConnectorMetadata(
+            preempted_req_ids=expected_req_ids
+        )
+    else:
+        payload = set(expected_req_ids)
+
+    connector.handle_preemptions(payload)
 
     connector._lmcache_engine.handle_preemptions.assert_called_once_with(
-        {"req-1", "req-2"}
+        expected_req_ids
     )
 
 
-def test_lmcache_connector_accepts_legacy_preemption_set():
-    """The patched connector remains compatible with the vLLM 0.18 API."""
-    LMCacheConnectorV1 = _import_and_patch_vllm_connector()
-
-    connector = object.__new__(LMCacheConnectorV1)
-    connector._lmcache_engine = MagicMock()
-
-    preempted_req_ids = {"req-1", "req-2"}
-    connector.handle_preemptions(preempted_req_ids)
-
-    connector._lmcache_engine.handle_preemptions.assert_called_once_with(
-        preempted_req_ids
-    )
-
-
-def test_lmcache_connector_skips_empty_v023_metadata():
-    """vLLM 0.23 calls the hook every step; empty metadata must be a no-op."""
+@pytest.mark.parametrize("payload_kind", ["empty_metadata", "base_metadata"])
+def test_lmcache_connector_skips_payloads_without_preemptions(payload_kind):
+    """Payloads with no preempted request ids must be no-ops."""
     LMCacheConnectorV1 = _import_and_patch_vllm_connector()
     adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
 
     connector = object.__new__(LMCacheConnectorV1)
     connector._lmcache_engine = MagicMock()
 
-    connector.handle_preemptions(adapter_mod.LMCacheAscendConnectorMetadata())
+    if payload_kind == "empty_metadata":
+        payload = adapter_mod.LMCacheAscendConnectorMetadata()
+    else:
+        payload = adapter_mod.LMCacheConnectorMetadata()
 
-    connector._lmcache_engine.handle_preemptions.assert_not_called()
-
-
-def test_lmcache_connector_skips_metadata_without_preemption_field():
-    """A mixed-version base LMCache metadata payload must not be iterated."""
-    LMCacheConnectorV1 = _import_and_patch_vllm_connector()
-    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
-
-    connector = object.__new__(LMCacheConnectorV1)
-    connector._lmcache_engine = MagicMock()
-
-    connector.handle_preemptions(adapter_mod.LMCacheConnectorMetadata())
+    connector.handle_preemptions(payload)
 
     connector._lmcache_engine.handle_preemptions.assert_not_called()
 
@@ -194,23 +177,3 @@ def test_ascend_adapter_skips_preemption_drain_when_not_required(
     if has_engine:
         lmcache_engine.lookup_unpin.assert_called_once_with("req-1")
         lmcache_engine.wait_for_pending_stores.assert_not_called()
-
-
-def test_ascend_adapter_skips_empty_preemption_ids():
-    """An ordinary vLLM 0.23 step must not touch the cache engine."""
-    pytest.importorskip("lmcache")
-    pytest.importorskip("vllm")
-    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
-
-    lmcache_engine = MagicMock()
-    adapter = _make_adapter(
-        adapter_mod,
-        store_async=True,
-        kv_role="kv_both",
-        lmcache_engine=lmcache_engine,
-    )
-
-    adapter.handle_preemptions(set())
-
-    lmcache_engine.lookup_unpin.assert_not_called()
-    lmcache_engine.wait_for_pending_stores.assert_not_called()

--- a/tests/integration/vllm/test_handle_preemptions.py
+++ b/tests/integration/vllm/test_handle_preemptions.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import pickle
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call, patch
 
 # Third Party
 import pytest
@@ -29,8 +30,69 @@ def _make_adapter(adapter_mod, *, store_async, kv_role, lmcache_engine):
     return adapter
 
 
-def test_lmcache_connector_delegates_preemptions_after_ascend_patch():
-    """Ascend patches the outer vLLM connector to delegate preemptions."""
+@pytest.mark.parametrize("preempted_req_ids", [{"req-1", "req-2"}, None])
+def test_build_connector_meta_carries_preempted_request_ids(preempted_req_ids):
+    """Scheduler metadata preserves LMCache requests and preemption hints."""
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    adapter = object.__new__(adapter_mod.LMCacheAscendConnectorV1Impl)
+    request_metadata = object()
+    base_metadata = adapter_mod.LMCacheConnectorMetadata(requests=[request_metadata])
+    scheduler_output = SimpleNamespace(preempted_req_ids=preempted_req_ids)
+
+    with patch.object(
+        adapter_mod.LMCacheConnectorV1Impl,
+        "build_connector_meta",
+        return_value=base_metadata,
+    ):
+        metadata = adapter.build_connector_meta(scheduler_output)
+
+    assert isinstance(metadata, adapter_mod.LMCacheAscendConnectorMetadata)
+    assert metadata.requests == [request_metadata]
+    assert metadata.preempted_req_ids == set(preempted_req_ids or ())
+
+    if preempted_req_ids is not None:
+        preempted_req_ids.add("req-added-after-build")
+        assert "req-added-after-build" not in metadata.preempted_req_ids
+
+
+def test_ascend_connector_metadata_is_pickleable():
+    """Custom metadata survives scheduler-to-worker style serialization."""
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    metadata = adapter_mod.LMCacheAscendConnectorMetadata(
+        preempted_req_ids={"req-1", "req-2"}
+    )
+    restored = pickle.loads(pickle.dumps(metadata))
+
+    assert isinstance(restored, adapter_mod.LMCacheAscendConnectorMetadata)
+    assert restored.preempted_req_ids == {"req-1", "req-2"}
+
+
+def test_lmcache_connector_extracts_preemptions_from_v023_metadata():
+    """The vLLM 0.23 metadata payload is normalized to request IDs."""
+    LMCacheConnectorV1 = _import_and_patch_vllm_connector()
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    connector = object.__new__(LMCacheConnectorV1)
+    connector._lmcache_engine = MagicMock()
+
+    metadata = adapter_mod.LMCacheAscendConnectorMetadata(
+        preempted_req_ids={"req-1", "req-2"}
+    )
+    connector.handle_preemptions(metadata)
+
+    connector._lmcache_engine.handle_preemptions.assert_called_once_with(
+        {"req-1", "req-2"}
+    )
+
+
+def test_lmcache_connector_accepts_legacy_preemption_set():
+    """The patched connector remains compatible with the vLLM 0.18 API."""
     LMCacheConnectorV1 = _import_and_patch_vllm_connector()
 
     connector = object.__new__(LMCacheConnectorV1)
@@ -42,6 +104,32 @@ def test_lmcache_connector_delegates_preemptions_after_ascend_patch():
     connector._lmcache_engine.handle_preemptions.assert_called_once_with(
         preempted_req_ids
     )
+
+
+def test_lmcache_connector_skips_empty_v023_metadata():
+    """vLLM 0.23 calls the hook every step; empty metadata must be a no-op."""
+    LMCacheConnectorV1 = _import_and_patch_vllm_connector()
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    connector = object.__new__(LMCacheConnectorV1)
+    connector._lmcache_engine = MagicMock()
+
+    connector.handle_preemptions(adapter_mod.LMCacheAscendConnectorMetadata())
+
+    connector._lmcache_engine.handle_preemptions.assert_not_called()
+
+
+def test_lmcache_connector_skips_metadata_without_preemption_field():
+    """A mixed-version base LMCache metadata payload must not be iterated."""
+    LMCacheConnectorV1 = _import_and_patch_vllm_connector()
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    connector = object.__new__(LMCacheConnectorV1)
+    connector._lmcache_engine = MagicMock()
+
+    connector.handle_preemptions(adapter_mod.LMCacheConnectorMetadata())
+
+    connector._lmcache_engine.handle_preemptions.assert_not_called()
 
 
 def test_lmcache_connector_preemption_patch_handles_no_inner_impl():
@@ -72,6 +160,9 @@ def test_ascend_adapter_drains_pending_stores_for_async_producer():
     preempted_req_ids = {"req-1", "req-2"}
     adapter.handle_preemptions(preempted_req_ids)
 
+    lmcache_engine.lookup_unpin.assert_has_calls(
+        [call("req-1"), call("req-2")], any_order=True
+    )
     lmcache_engine.wait_for_pending_stores.assert_called_once_with(preempted_req_ids)
 
 
@@ -101,4 +192,25 @@ def test_ascend_adapter_skips_preemption_drain_when_not_required(
     adapter.handle_preemptions({"req-1"})
 
     if has_engine:
+        lmcache_engine.lookup_unpin.assert_called_once_with("req-1")
         lmcache_engine.wait_for_pending_stores.assert_not_called()
+
+
+def test_ascend_adapter_skips_empty_preemption_ids():
+    """An ordinary vLLM 0.23 step must not touch the cache engine."""
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    lmcache_engine = MagicMock()
+    adapter = _make_adapter(
+        adapter_mod,
+        store_async=True,
+        kv_role="kv_both",
+        lmcache_engine=lmcache_engine,
+    )
+
+    adapter.handle_preemptions(set())
+
+    lmcache_engine.lookup_unpin.assert_not_called()
+    lmcache_engine.wait_for_pending_stores.assert_not_called()

--- a/tests/integration/vllm/test_local_persist_skip.py
+++ b/tests/integration/vllm/test_local_persist_skip.py
@@ -133,3 +133,22 @@ def test_missing_save_spec_skips_without_lookup():
 
     assert adapter._local_persist_skip(request, request.token_ids) is None
     engine.lookup.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("kv_role", "disagg_spec", "expected_skip"),
+    [
+        ("kv_producer", SimpleNamespace(num_transferred_tokens=2 * CHUNK), 2 * CHUNK),
+        ("kv_both", SimpleNamespace(num_transferred_tokens=2 * CHUNK), 4 * CHUNK),
+        ("kv_producer", None, 4 * CHUNK),
+    ],
+)
+def test_pd_producer_skip_is_clamped_to_transferred_tokens(
+    kv_role,
+    disagg_spec,
+    expected_skip,
+):
+    adapter, _ = _make_adapter(kv_role=kv_role)
+    request = SimpleNamespace(disagg_spec=disagg_spec)
+
+    assert adapter._pd_producer_skip_leading_tokens(4 * CHUNK, request) == expected_skip

--- a/tests/v1/storage_backend/test_ascend_pd_backend.py
+++ b/tests/v1/storage_backend/test_ascend_pd_backend.py
@@ -66,20 +66,30 @@ def _make_mock_mem_obj(
     return mock
 
 
-def _make_consumed_proxy() -> ProxyMemoryObj:
-    """Create a ProxyMemoryObj that is already consumed."""
+def _make_proxy(
+    context: MagicMock | None = None,
+    chunk_index: int = 0,
+) -> ProxyMemoryObj:
+    if context is None:
+        context = MagicMock()
     proxy = ProxyMemoryObj(
         backing_obj=None,
         transfer_channel=MagicMock(),
         target_peer_url="fake_url",
-        remote_buffer_uuid="fake_uuid",
-        remote_mem_index=0,
-        transfer_context=MagicMock(),
-        chunk_index=0,
+        remote_buffer_uuid=f"fake_uuid_{chunk_index}",
+        remote_mem_index=chunk_index,
+        transfer_context=context,
+        chunk_index=chunk_index,
         shapes=[DEFAULT_SHAPE],
         dtypes=[DEFAULT_DTYPE],
         fmt=MemoryFormat.KV_2LTD,
     )
+    return proxy
+
+
+def _make_consumed_proxy() -> ProxyMemoryObj:
+    """Create a ProxyMemoryObj that is already consumed."""
+    proxy = _make_proxy()
     proxy.mark_consumed()
     return proxy
 
@@ -96,10 +106,22 @@ def _make_pd_backend_stub(
 ):
     """Create a mock object with the minimal attributes needed by PD backend methods."""
     # First Party
-    from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+    from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend, PDEntry
 
     backend = MagicMock()
-    backend.data = {}
+    backend._pd_entries = {}
+    backend._pd_request_keys = {}
+
+    class _PDDataDict(dict):
+        def __setitem__(self, key, value):
+            super().__setitem__(key, value)
+            backend._pd_entries[key] = PDEntry(base_obj=value)
+
+        def pop(self, key, default=None):
+            backend._pd_entries.pop(key, None)
+            return super().pop(key, default)
+
+    backend.data = _PDDataDict()
     backend.data_lock = threading.Lock()
     backend.pd_config = MagicMock()
     backend.pd_config.role = role
@@ -126,6 +148,22 @@ def _make_pd_backend_stub(
     )
     backend._partition_keys = lambda keys: AscendPDBackend._partition_keys(
         backend, keys
+    )
+    backend._ensure_request_lease_locked = (
+        lambda key, entry, request_id: AscendPDBackend._ensure_request_lease_locked(
+            backend,
+            key,
+            entry,
+            request_id,
+        )
+    )
+    backend._delete_pd_entry_locked = (
+        lambda key, entry, release_obj: AscendPDBackend._delete_pd_entry_locked(
+            backend,
+            key,
+            entry,
+            release_obj,
+        )
     )
 
     return backend
@@ -342,6 +380,68 @@ class TestAscendPDBackend:
 
         proxy.ref_count_down()
         context.decref.assert_called_once()
+
+    def test_pd_backend_keeps_shared_entry_until_last_request_lease_released(self):
+        """A shared PD hit is deleted only after every request lease is released."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+
+        backend = _make_pd_backend_stub()
+        key = _make_key("shared_lease")
+        mem_obj = _make_mock_mem_obj()
+        AscendPDBackend.put(backend, key, mem_obj)
+
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-1") == 1
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-2") == 1
+
+        AscendPDBackend.release_request_lease(backend, "req-1")
+
+        assert key in backend.data
+        assert key in backend._pd_entries
+        assert backend._pd_entries[key].owners == {"req-2"}
+        mem_obj.ref_count_down.assert_not_called()
+
+        AscendPDBackend.release_request_lease(backend, "req-2")
+
+        assert key not in backend.data
+        assert key not in backend._pd_entries
+        assert backend._pd_request_keys == {}
+        mem_obj.ref_count_down.assert_called_once()
+
+    def test_pd_backend_proxy_leases_are_request_local(self):
+        """Consuming one request's proxy clone must not poison shared PD hits."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+
+        backend = _make_pd_backend_stub()
+        key = _make_key("shared_proxy")
+        transfer_context = MagicMock()
+        base_proxy = _make_proxy(transfer_context)
+        AscendPDBackend.put(backend, key, base_proxy)
+
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-1") == 1
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-2") == 1
+
+        entry = backend._pd_entries[key]
+        req1_proxy = entry.proxy_leases["req-1"]
+        req2_proxy = entry.proxy_leases["req-2"]
+
+        assert req1_proxy is not base_proxy
+        assert req2_proxy is not base_proxy
+        assert req1_proxy is not req2_proxy
+        transfer_context.acquire_request.assert_any_call("req-1")
+        transfer_context.acquire_request.assert_any_call("req-2")
+
+        req1_proxy.mark_consumed()
+
+        assert req1_proxy.consumed is True
+        assert base_proxy.consumed is False
+        assert req2_proxy.consumed is False
+        assert AscendPDBackend.batched_get_blocking_for_request(
+            backend,
+            [key],
+            "req-2",
+        ) == [req2_proxy]
 
     def test_push_mode_allocate_and_put(self):
         """Push-mode allocate_and_put returns UUID-based refs."""

--- a/tests/v1/storage_backend/test_ascend_pd_backend.py
+++ b/tests/v1/storage_backend/test_ascend_pd_backend.py
@@ -505,6 +505,48 @@ class TestAscendPDBackend:
         assert resp.alloc_failed is True
         backend.put.assert_not_called()
 
+    def test_push_mode_partial_alloc_failure_cleans_pd_entries(self):
+        """Partial push allocation rollback removes both receiver indexes."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+        from lmcache_ascend.v1.storage_backend.pd.receiver_mixin import (
+            AscendPDReceiverMixin,
+        )
+
+        backend = _make_pd_backend_stub()
+        backend.data = {}
+        backend._pd_entries = {}
+        backend.put = lambda key, mem_obj: AscendPDBackend.put(backend, key, mem_obj)
+        allocated_obj = _make_mock_mem_obj()
+        backend.transfer_channel.get_local_buffer_refs.return_value = (
+            ["uuid-alloc"],
+            [42],
+        )
+        key0 = _make_key("partial-alloc-0")
+        key1 = _make_key("partial-alloc-1")
+
+        alloc_req = AllocRequest(
+            keys=[key0.to_string(), key1.to_string()],
+            fmt=MemoryFormat.KV_2LTD.value,
+            shape=list(DEFAULT_SHAPE),
+            dtype="bfloat16",
+            last_chunk_toks=256,
+        )
+
+        with patch(
+            "lmcache_ascend.v1.storage_backend.pd.receiver_mixin.allocate_with_retry",
+            side_effect=[allocated_obj, None],
+        ):
+            resp = AscendPDReceiverMixin._allocate_and_put(backend, alloc_req)
+
+        assert isinstance(resp, AscendAllocResponse)
+        assert resp.alloc_failed is True
+        assert key0 not in backend.data
+        assert key0 not in backend._pd_entries
+        assert key1 not in backend.data
+        assert key1 not in backend._pd_entries
+        allocated_obj.ref_count_down.assert_called_once()
+
     def test_pull_eager_flow(self):
         """Pull-eager: allocates, reads from sender, returns ack + callback."""
         # First Party

--- a/tests/v1/storage_backend/test_proxy_memory_obj.py
+++ b/tests/v1/storage_backend/test_proxy_memory_obj.py
@@ -93,3 +93,37 @@ def test_proxy_shared_context_sends_done_after_all_discards():
 
     proxy_1.ref_count_down()
     context.send_done.assert_called_once()
+
+
+def test_pd_transfer_context_sends_done_after_last_request_lease():
+    """PD delay-pull Done is gated by request leases, not proxy refcounts."""
+    # First Party
+    from lmcache_ascend.v1.transfer_context import PDTransferContext
+
+    done_callback = MagicMock()
+    context = PDTransferContext(
+        sender_id="sender-1",
+        done_callback=done_callback,
+        num_proxies=2,
+        memory_allocator=MagicMock(),
+        shapes=[DEFAULT_SHAPE],
+        dtypes=[DEFAULT_DTYPE],
+        fmt=MemoryFormat.KV_2LTD,
+    )
+
+    context.acquire_request("req-1")
+    context.acquire_request("req-2")
+
+    context.decref()
+    context.send_done_now()
+    done_callback.assert_not_called()
+
+    context.release_request("req-1")
+    done_callback.assert_not_called()
+
+    context.release_request("req-2")
+    done_callback.assert_called_once()
+
+    context.release_request("req-2")
+    context.send_done_now()
+    done_callback.assert_called_once()

--- a/tests/v1/storage_backend/test_storage_backend_init.py
+++ b/tests/v1/storage_backend/test_storage_backend_init.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+
+def _mixed_sender_config(max_local_cpu_size: int = 16):
+    return SimpleNamespace(
+        enable_pd=True,
+        enable_p2p=True,
+        pd_role="sender",
+        enable_async_loading=False,
+        local_cpu=False,
+        local_disk=False,
+        max_local_cpu_size=max_local_cpu_size,
+        max_local_disk_size=0,
+        enable_controller=True,
+        controller_pull_url="localhost:9800",
+        controller_reply_url="localhost:9900",
+        lmcache_worker_ports=[9950],
+        p2p_host="localhost",
+        p2p_init_ports=[9960],
+        p2p_lookup_ports=[9962],
+        transfer_channel="hccl",
+        remote_storage_plugins=None,
+        remote_url=None,
+        use_layerwise=False,
+        extra_config=None,
+    )
+
+
+def _worker_metadata():
+    return SimpleNamespace(role="worker", worker_id=0)
+
+
+def _patch_backend_constructors(monkeypatch):
+    # First Party
+    import lmcache_ascend.v1.storage_backend as storage_backend_module
+    import lmcache_ascend.v1.storage_backend.pd as pd_module
+
+    class _FakeLocalCPUBackend:
+        def __init__(self, config, metadata, dst_device, lmcache_worker):
+            self.config = config
+            self.metadata = metadata
+            self.dst_device = dst_device
+            self.lmcache_worker = lmcache_worker
+
+        def __str__(self):
+            return "LocalCPUBackend"
+
+    class _FakePDBackend:
+        def __init__(self, config, metadata):
+            self.config = config
+            self.metadata = metadata
+
+    class _FakeP2PBackend:
+        def __init__(self, config, metadata, loop, local_cpu_backend, lmcache_worker):
+            self.config = config
+            self.metadata = metadata
+            self.loop = loop
+            self.local_cpu_backend = local_cpu_backend
+            self.lmcache_worker = lmcache_worker
+
+        def __str__(self):
+            return "P2PBackend"
+
+    monkeypatch.setattr(storage_backend_module, "is_npu_worker", lambda metadata: False)
+    monkeypatch.setattr(storage_backend_module, "LocalCPUBackend", _FakeLocalCPUBackend)
+    monkeypatch.setattr(storage_backend_module, "AscendP2PBackend", _FakeP2PBackend)
+    monkeypatch.setattr(pd_module, "AscendPDBackend", _FakePDBackend)
+    monkeypatch.setattr(storage_backend_module, "storage_plugin_launcher", MagicMock())
+
+    return storage_backend_module
+
+
+def test_mixed_pd_p2p_sender_provisions_local_cpu_backend(monkeypatch):
+    """P2P construction gets a LocalCPUBackend even when local_cpu is disabled."""
+    storage_backend_module = _patch_backend_constructors(monkeypatch)
+    config = _mixed_sender_config(max_local_cpu_size=16)
+
+    backends = storage_backend_module.CreateStorageBackends(
+        config,
+        _worker_metadata(),
+        MagicMock(),
+        lmcache_worker=MagicMock(),
+    )
+
+    assert list(backends.keys()) == ["PDBackend", "LocalCPUBackend", "P2PBackend"]
+    assert backends["P2PBackend"].local_cpu_backend is backends["LocalCPUBackend"]
+
+
+def test_mixed_pd_p2p_sender_requires_local_cpu_capacity(monkeypatch):
+    """P2P construction reports missing LocalCPUBackend capacity explicitly."""
+    storage_backend_module = _patch_backend_constructors(monkeypatch)
+    config = _mixed_sender_config(max_local_cpu_size=0)
+
+    with pytest.raises(ValueError, match="max_local_cpu_size"):
+        storage_backend_module.CreateStorageBackends(
+            config,
+            _worker_metadata(),
+            MagicMock(),
+            lmcache_worker=MagicMock(),
+        )

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # ruff: noqa: F401
+# Standard
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
 # Third Party
 from lmcache_tests.v1.storage_backend.test_storage_manager import (
     TestStorageManagerPrefetchCallback,
@@ -8,3 +12,75 @@ from lmcache_tests.v1.storage_backend.test_storage_manager import (
     storage_manager_config,
     storage_manager_metadata,
 )
+
+
+def _make_copy_source():
+    src = MagicMock()
+    src.tensor = MagicMock()
+    src.meta.fmt = "fmt"
+    src.get_shape.return_value = "shape"
+    src.get_dtype.return_value = "dtype"
+    return src
+
+
+def _make_copy_target():
+    dst = MagicMock()
+    dst.tensor = MagicMock()
+    return dst
+
+
+def test_allocate_and_copy_objects_preserves_key_alignment_after_existing_key():
+    """Skipped existing keys must not shift copied objects onto wrong keys."""
+    # First Party
+    from lmcache_ascend.v1.storage_backend import storage_manager as sm
+
+    keys = ["k0", "k1", "k2"]
+    src_objs = [_make_copy_source(), _make_copy_source(), _make_copy_source()]
+    dst_objs = [_make_copy_target(), _make_copy_target()]
+
+    allocator = MagicMock()
+    allocator.contains.side_effect = lambda key: key == "k0"
+    allocator.allocate.side_effect = dst_objs
+
+    with patch.object(sm.torch.cuda, "stream", return_value=nullcontext()):
+        allocated_keys, allocated_objs = sm.allocate_and_copy_objects(
+            allocator,
+            keys,
+            src_objs,
+            stream=None,
+        )
+
+    assert allocated_keys == ["k1", "k2"]
+    assert allocated_objs == dst_objs
+    assert allocator.allocate.call_count == 2
+    dst_objs[0].tensor.copy_.assert_called_once_with(
+        src_objs[1].tensor,
+        non_blocking=True,
+    )
+    dst_objs[1].tensor.copy_.assert_called_once_with(
+        src_objs[2].tensor,
+        non_blocking=True,
+    )
+
+
+def test_batched_contains_uses_pd_request_lease_when_context_set():
+    """Pinned PD receiver lookup should create a request-scoped lease."""
+    # First Party
+    from lmcache_ascend.v1.storage_backend import storage_manager as sm
+
+    keys = ["k0", "k1"]
+    pd_backend = MagicMock()
+    pd_backend.batched_contains_and_lease.return_value = len(keys)
+    manager = MagicMock()
+    manager.get_active_storage_backends.return_value = [("PDBackend", pd_backend)]
+
+    token = sm.set_current_pd_lookup_id("req-1")
+    try:
+        hit_chunks, block_mapping = sm.batched_contains(manager, keys, pin=True)
+    finally:
+        sm.reset_current_pd_lookup_id(token)
+
+    assert hit_chunks == len(keys)
+    assert block_mapping == {"PDBackend": keys}
+    pd_backend.batched_contains_and_lease.assert_called_once_with(keys, "req-1")
+    pd_backend.batched_contains.assert_not_called()


### PR DESCRIPTION
## Overview

This PR enables Ascend PD and P2P to be used together on the PD sender path and hardens the related request lifecycle handling for PD KV transfer.

The changes cover three correctness areas:
- config validation for `enable_pd=true` + `enable_p2p=true` on Ascend sender
- PD/P2P store correctness when some destination keys already exist
- request-scoped PD receiver leases, delay-pull proxy isolation, and vLLM preemption cleanup

## Impact

Before this PR:
- Ascend config validation rejected `enable_pd=true` and `enable_p2p=true` even for the sender role.
- `allocate_and_copy_objects` could return misaligned keys when earlier keys were skipped because they already existed in the target backend, causing newly copied objects to be paired with the wrong keys.
- A shared PD receiver hit could be consumed or released through one request while another request still depended on the same PD entry.
- vLLM 0.23 preemption metadata was not carried through the Ascend connector path, so preempted requests could miss LMCache cleanup.

These issues affect PD/P2P mixed deployment correctness, especially when sender-side local/P2P cache hits, PD handoff, receiver-side shared hits, delay-pull proxy objects, and vLLM preemption interact.

## What changed

Config and sender-side store path:
- Allow `enable_pd=true` and `enable_p2p=true` for `pd_role="sender"` with explicit Ascend validation.
- Keep upstream PD validation while preserving Ascend-specific P2P requirements.
- Clamp PD producer store skip to `disagg_spec.num_transferred_tokens`, so the producer only skips tokens already transferred to the decoder.
- Preserve key/object alignment in `allocate_and_copy_objects` by tracking `allocated_keys` together with allocated memory objects.

PD receiver lifecycle:
- Add receiver-side `PDEntry` ownership metadata.
- Track PD hits by request id through lookup/retrieve context.
- Add request-scoped PD leases and release them from `lookup_unpin` / `retrieve`.
- Create request-local `ProxyMemoryObj` clones for delay-pull hits so one request consuming a proxy does not poison shared hits for another request.
- Delay PD Done signaling until the last active request lease is released.

vLLM preemption handling:
- Carry `scheduler_output.preempted_req_ids` in Ascend connector metadata for vLLM 0.23.
- Keep compatibility with the legacy vLLM 0.18 set-based preemption payload.
- On preemption, release lookup pins for preempted request ids.
- For async producer workers, drain pending stores before KV blocks can be reused.

## Tests

Added and adjusted regression tests for:
- key/object alignment after skipped existing keys
- PD producer skip clamping to decoder-transferred tokens
- PD request lease routing from `StorageManager.batched_contains`
- shared PD receiver entries surviving until the last request lease is released
- request-local delay-pull proxy leases
- PD transfer context Done signaling after the last request lease
- vLLM 0.23 metadata payload and legacy set payload preemption handling
- async producer preemption cleanup and drain behavior


## Scope note

This PR focuses on the first PD/P2P lifecycle boundary needed for Ascend sender compatibility and receiver request cleanup.

It does not include later PD KVPool work such as DSA KV layout changes, token-aware disaggregated proxy scheduling, or additional delay-pull handoff race diagnostics. Those will be handled in follow-up PRs.