### PR TITLE
Fix ProxyMemoryObj lookup pin lifecycle

### DIFF
--- a/lmcache_ascend/v1/proxy_memory_obj.py
+++ b/lmcache_ascend/v1/proxy_memory_obj.py
@@ -15,6 +15,7 @@ before scattering, enabling overlap of remote fetch and NPU scatter operations.
 # Standard
 from typing import Any, List, Optional
 import asyncio
+import threading
 
 # Third Party
 from lmcache.logging import init_logger
@@ -88,6 +89,11 @@ class ProxyMemoryObj(MemoryObj):
         self._resolved = False
         self._consumed = False  # True after data scattered into KV cache
         self._released = False
+        self._ref_lock = threading.Lock()
+        # One base owner represents the proxy's transfer-context ownership.
+        # Temporary lookup pins increment this count but must not consume the
+        # base owner when they are released.
+        self._ref_count = 1
 
         # Store allocation metadata for deferred buffer operations
         if backing_obj is not None:
@@ -133,8 +139,10 @@ class ProxyMemoryObj(MemoryObj):
         sender's pinned memory may be released, so the proxy's remote
         buffer references are no longer valid.
         """
-        self._consumed = True
-        self._released = True
+        with self._ref_lock:
+            self._consumed = True
+            self._released = True
+            self._ref_count = 0
 
     @property
     def backing_obj(self) -> Optional[MemoryObj]:
@@ -436,20 +444,27 @@ class ProxyMemoryObj(MemoryObj):
         return None
 
     def ref_count_up(self) -> None:
-        # No-op: proxy lifecycle is managed by the transfer context,
-        # not by the standard MemoryObj ref-count protocol.  Making
-        # this a no-op allows callers (cache engine, storage manager,
-        # PD backend pin/unpin) to use the same API without needing
-        # isinstance guards to skip proxies.
-        pass
+        with self._ref_lock:
+            if self._released:
+                return
+            self._ref_count += 1
 
     def ref_count_down(self) -> None:
         # When a proxy is discarded before the connector consumes it, notify
         # the shared context so the sender can release pending pull resources.
-        if self._released:
-            return
-        self._released = True
-        self._transfer_context.decref()
+        decref_context = False
+        with self._ref_lock:
+            if self._released:
+                return
+            if self._ref_count > 1:
+                self._ref_count -= 1
+                return
+            self._ref_count = 0
+            self._released = True
+            decref_context = True
+
+        if decref_context:
+            self._transfer_context.decref()
 
     def get_ref_count(self) -> int:
         # Always return 1 so the proxy looks "alive" to callers that

--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -262,9 +262,10 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         Consumed :class:`ProxyMemoryObj` instances are evicted from the
         store and treated as absent.
 
-        Pinning is safe for both regular ``MemoryObj`` and proxies because
-        ``ProxyMemoryObj.ref_count_up/down`` are no-ops — the proxy
-        lifecycle is managed by its transfer context, not by ref counts.
+        Pinning is safe for both regular ``MemoryObj`` instances and proxies.
+        ``ProxyMemoryObj`` tracks temporary lookup pins as logical references
+        above its base transfer owner, so releasing a lookup pin does not
+        release the shared transfer context.
 
         The caller **must** call ``ref_count_down()`` on every returned
         object when *pin* is ``True`` once the pin is no longer needed.

--- a/tests/v1/storage_backend/test_ascend_pd_backend.py
+++ b/tests/v1/storage_backend/test_ascend_pd_backend.py
@@ -307,6 +307,42 @@ class TestAscendPDBackend:
         assert new_idx == [1, 2]
         mock_obj0.ref_count_up.assert_called_once()
 
+    def test_partition_keys_proxy_pin_release_preserves_transfer_owner(self):
+        """Already-sent Proxy lookup release must not complete its transfer."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+        from lmcache_ascend.v1.storage_backend.utils import release_memory_objects
+
+        backend = _make_pd_backend_stub()
+        key = _make_key("proxy-key")
+        context = MagicMock()
+        proxy = ProxyMemoryObj(
+            backing_obj=None,
+            transfer_channel=MagicMock(),
+            target_peer_url="sender_1",
+            remote_buffer_uuid="suuid-0",
+            remote_mem_index=0,
+            transfer_context=context,
+            chunk_index=0,
+            shapes=[DEFAULT_SHAPE],
+            dtypes=[DEFAULT_DTYPE],
+            fmt=MemoryFormat.KV_2LTD,
+        )
+        backend.data[key] = proxy
+
+        already_sent_idx, already_sent_objs, new_idx = AscendPDBackend._partition_keys(
+            backend, [key.to_string()]
+        )
+        release_memory_objects(already_sent_objs)
+
+        assert already_sent_idx == [0]
+        assert already_sent_objs == [proxy]
+        assert new_idx == []
+        context.decref.assert_not_called()
+
+        proxy.ref_count_down()
+        context.decref.assert_called_once()
+
     def test_push_mode_allocate_and_put(self):
         """Push-mode allocate_and_put returns UUID-based refs."""
         # First Party

--- a/tests/v1/storage_backend/test_proxy_memory_obj.py
+++ b/tests/v1/storage_backend/test_proxy_memory_obj.py
@@ -48,6 +48,17 @@ def test_proxy_ref_count_down_decrefs_context_once():
     context.decref.assert_called_once()
 
 
+def test_proxy_temporary_pin_release_does_not_decref_context():
+    """Lookup pin/unpin should not consume the proxy's base transfer owner."""
+    context = MagicMock()
+    proxy = _make_proxy(context)
+
+    proxy.ref_count_up()
+    proxy.ref_count_down()
+
+    context.decref.assert_not_called()
+
+
 def test_proxy_mark_consumed_suppresses_later_ref_count_down():
     """Connector-consumed proxies should not later decref during cleanup."""
     context = MagicMock()


### PR DESCRIPTION
## Summary

This is a partial fix for #250. It addresses only the temporary lookup-pin imbalance in `_partition_keys()`: releasing an already-present `ProxyMemoryObj` returned by a pinned lookup must not consume the proxy's base transfer ownership.

`ProxyMemoryObj.ref_count_up()` now records a balanced logical reference, and `ref_count_down()` only decrements the shared transfer context when the base owner is actually released. This preserves the existing discard and consumed-proxy semantics while preventing `_partition_keys()` / `release_memory_objects()` from sending Done early for this lookup path.

## Scope

This PR intentionally does not close #250.

Concurrent retrieve requests can still receive the same unconsumed `ProxyMemoryObj` from `PDBackend.data`. `batched_to_gpu()` mutates the shared `_backing_obj`, `set_backing_obj()` resets `_resolved`, and there is currently no consumer-claim or single-flight mechanism. The first request to call `mark_consumed()` / `send_done_now()` can therefore release the remote lease before another request using that proxy has finished.

That request-level ownership redesign remains tracked in #250 and is outside this focused PR.

Related #250.

## Tests

- `PYTHONPATH=$PWD/test_bootstrap:$PWD:$PWD/../LMCache-v0.4.4 /data/pyptouser/songxiaoyou/va-venv/bin/python -m pytest --noconftest tests/v1/storage_backend/test_proxy_memory_obj.py -q`
- `LMCACHEPATH=$PWD/../LMCache-v0.4.4 PYTHONPATH=$PWD/test_bootstrap:$PWD:$PWD/../LMCache-v0.4.4 /data/pyptouser/songxiaoyou/va-venv/bin/python -m pytest --noconftest tests/v1/storage_backend/test_ascend_pd_backend.py -k 'partition_keys_proxy or partition_keys or pull_delay_transfer_context_done_callback_is_idempotent' -q`
- `LMCACHEPATH=$PWD/../LMCache-v0.4.4 PYTHONPATH=$PWD/test_bootstrap:$PWD:$PWD/../LMCache-v0.4.4 /data/pyptouser/songxiaoyou/va-venv/bin/python -m pytest --noconftest tests/v1/storage_backend/test_ascend_p2p_backend.py -k 'proxy_ref_count_down or proxy_mark_consumed or proxy_shared_context' -q`

Also smoke-tested `torch_npu` through the local task queue on Ascend 910/910C-class hardware.