### PR TITLE
[Perf] Use the non-draining NPUStream getter in the kernel launch paths

### DIFF
--- a/csrc/mem_kernels.cpp
+++ b/csrc/mem_kernels.cpp
@@ -183,7 +183,7 @@ void multi_layer_kv_transfer_310p(
   // we require the kv ptr list to be on the device too
   const c10::OptionalDeviceGuard kv_device_guard(device_of(key_value_ptrs));
 
-  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream(false);
 
   at_npu::native::OpCommand cmd;
   cmd.Name("multi_layer_kv_transfer_kernel_310p");
@@ -375,7 +375,7 @@ void load_and_reshape_flash(
   int num_blocks = key_cache.size(0);
   int hidden_dims = key_value.size(-1);
   const c10::OptionalDeviceGuard device_guard(device_of(key_cache));
-  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream(false);
 
   at::ScalarType scalar_type = key_value.scalar_type();
   at::ScalarType slot_type = slot_mapping.scalar_type();
@@ -425,7 +425,7 @@ void reshape_and_cache_back_flash(
   int num_blocks = key_cache.size(0);
   int hidden_dims = key_value.size(-1);
   const c10::OptionalDeviceGuard device_guard(device_of(key_cache));
-  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+  const aclrtStream stream = c10_npu::getCurrentNPUStream().stream(false);
 
   at::ScalarType scalar_type = key_value.scalar_type();
   at::ScalarType slot_type = slot_mapping.scalar_type();

--- a/csrc/pos_kernels.cpp
+++ b/csrc/pos_kernels.cpp
@@ -175,7 +175,7 @@ void rotary_embedding_k_fused(torch::Tensor &oldPositions,
   uint8_t *cosSinCachePtr = get_kernel_ptr<uint8_t, torch::Tensor>(cosSinCache);
   uint8_t *keyOutPtr = keyPtr;
 
-  auto aclStream = c10_npu::getCurrentNPUStream().stream();
+  auto aclStream = c10_npu::getCurrentNPUStream().stream(false);
 
   at_npu::native::OpCommand cmd;
   cmd.Name("fused_rope");

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -88,7 +88,7 @@ void compute_multi_layer_ub_params(MultiLayerKVConfig &config,
   // we require the kv ptr list to be on the device too
   const c10::OptionalDeviceGuard kv_device_guard(device_of(key_value_ptrs));
 
-  config.stream = c10_npu::getCurrentNPUStream().stream();
+  config.stream = c10_npu::getCurrentNPUStream().stream(false);
 
   auto ascendcPlatform =
       platform_ascendc::PlatformAscendCManager::GetInstance(config.socName);
@@ -152,7 +152,7 @@ void compute_single_layer_ub_params(const KVTransferDims &dims,
 
   const c10::OptionalDeviceGuard device_guard(device_of(vllm_cache));
 
-  ub_params.stream = c10_npu::getCurrentNPUStream().stream();
+  ub_params.stream = c10_npu::getCurrentNPUStream().stream(false);
   const char *socName = aclrtGetSocName();
 
   auto ascendcPlatform =


### PR DESCRIPTION
Fixes #219

## What changed

Replace all six remaining
`c10_npu::getCurrentNPUStream().stream()` calls in kernel-launch paths with
`stream(false)`.

`stream()` drains the torch_npu task queue before returning. These streams are
only consumed by `OpCommand` custom handlers enqueued on the current stream, so
queue and device-stream ordering already preserve dependencies. `stream(false)`
returns the same `aclrtStream` without the redundant drain.

`csrc/pac_kernels.cpp` already uses this form. `csrc/framework_hal.cpp` is
unchanged because `device_index()` does not drain the queue.

## Validation

Environment: 910B2, CANN 8.5.1, torch_npu 2.9.0.post1.

Host-side `multi_layer_kv_transfer` latency over 200 iterations:

| Operation | Pending ops | Mean (us) | P99 (us) | Max (us) |
|---|---:|---:|---:|---:|
| Scatter | 0  | 127.8 → **18.0** | 163.4 → 34.1 | 236.6 → 34.7 |
| Scatter | 32 | 33.9 → **22.4**  | 51.6 → 33.1  | 52.3 → 79.0 |
| Gather  | 0  | 88.6 → **20.4**  | 107.4 → 23.6 | 138.8 → 24.0 |
| Gather  | 32 | 27.9 → **25.7**  | 57.4 → 33.0  | 1098.1 → 33.1 |

- Three repeats measured 85–128 us before and 16–18 us after.
- All affected operations produced identical checksums; scatter/gather
  round trips were bit-exact.
- Device execution time was unchanged.
- With `TASK_QUEUE_ENABLE=0`, both builds measured 40–44 us.

`csrc/mem_kernels.cpp` and `csrc/utils.cpp` also overlap with #246; I can rebase
if needed.
