### PR TITLE
[Bug] Reject Cacheblend + vLLM prefix caching at startup

### DIFF
--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -43,6 +43,28 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1Impl):
         self._late_finished_sending: set[str] = set()
         logger.debug("store_async: %s", self.store_async)
 
+    def _apply_extra_config(self, config, vllm_config: "VllmConfig") -> None:
+        """Apply vLLM extra config, then reject unsupported combinations.
+
+        Runs before ``LMCacheManager`` is built and its services are started, so
+        a bad configuration is refused without leaving background threads or
+        sockets behind, and after the ``lmcache.`` extra-config keys have been
+        folded in.
+        """
+        super()._apply_extra_config(config, vllm_config)
+
+        cache_config = getattr(vllm_config, "cache_config", None)
+        if config.enable_blending and getattr(
+            cache_config, "enable_prefix_caching", False
+        ):
+            raise ValueError(
+                "Cacheblend is not compatible with vLLM's prefix cache. When "
+                "vLLM has already cached part of a request, LMCache retrieves "
+                "only the remaining suffix into the blend buffer, so blending "
+                "would run against a shifted KV window. Please start vLLM with "
+                "enable_prefix_caching=False."
+            )
+
     @_lmcache_nvtx_annotate
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         self.current_layer = 0

--- a/tests/integration/vllm/test_blend_prefix_cache_guard.py
+++ b/tests/integration/vllm/test_blend_prefix_cache_guard.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``LMCacheAscendConnectorV1Impl`` must reject CacheBlend + vLLM prefix cache.
+
+The two are documented as mutually exclusive in ``examples/blending/README.md``.
+When vLLM's prefix cache already covers part of a request, LMCache masks those
+tokens out of the retrieval, so the blend buffer holds only the remaining
+suffix and blending would run against a shifted KV window. vLLM enables prefix
+caching by default, so the combination has to be refused before
+``LMCacheManager`` is built and its services are started.
+"""
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+
+def _adapter_mod():
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    return pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+
+def _apply(*, enable_blending=False, extra_config=None, enable_prefix_caching):
+    """Run the hook the base ``__init__`` calls before creating any service."""
+    # Third Party
+    from lmcache.v1.config import LMCacheEngineConfig
+
+    adapter_mod = _adapter_mod()
+    config = LMCacheEngineConfig.from_legacy()
+    config.enable_blending = enable_blending
+    vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(kv_connector_extra_config=extra_config),
+        cache_config=SimpleNamespace(enable_prefix_caching=enable_prefix_caching),
+    )
+    adapter = object.__new__(adapter_mod.LMCacheAscendConnectorV1Impl)
+    adapter._apply_extra_config(config, vllm_config)
+    return config
+
+
+def test_blending_with_prefix_caching_is_rejected():
+    with pytest.raises(ValueError, match="prefix cache"):
+        _apply(enable_blending=True, enable_prefix_caching=True)
+
+
+def test_blending_from_extra_config_is_also_rejected():
+    """The check must run after the ``lmcache.`` extra-config keys are folded in."""
+    with pytest.raises(ValueError, match="prefix cache"):
+        _apply(
+            enable_blending=False,
+            extra_config={"lmcache.enable_blending": True},
+            enable_prefix_caching=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "enable_blending,enable_prefix_caching",
+    [(True, False), (False, True), (False, False)],
+)
+def test_other_combinations_are_accepted(enable_blending, enable_prefix_caching):
+    config = _apply(
+        enable_blending=enable_blending,
+        enable_prefix_caching=enable_prefix_caching,
+    )
+    assert config.enable_blending is enable_blending


### PR DESCRIPTION
## Summary

The legacy in-process CacheBlend path used by LMCache-Ascend is not compatible
with vLLM prefix caching. After a prefix-cache hit, LMCache retrieves only the
remaining suffix into the blend buffer, while `LMCBlender.process_qkv` applies
suffix-local indices to full-sequence tensors. This can corrupt QKV selection
and positions.

This PR rejects the unsupported combination in `_apply_extra_config`, after
LMCache extra config is applied but before `LMCacheManager` and its services are
created. Other configurations are unchanged. Users of this connector must set
`enable_prefix_caching=False` when enabling CacheBlend.

## Validation

- 910B2 / CANN 9.1.0 / torch_npu 2.10.0: `tests/integration` — 19 passed.
- `test_request_finished_chunk_hashes` fails identically on `main` and this PR.
- All 5 focused guard cases pass; both rejection cases fail on `main` as a
  negative control.
- Lint, format, type, and syntax checks pass.

Upstream context: LMCache/LMCache#3229 reproduces the combined legacy path
failing on GPU, and the upstream legacy example disables prefix caching.

Related to #277, but not claimed as its fix because #277 was not reproduced end
to end and its reported ratio-1 behavior does not match this failure mode.
