### PR TITLE
fix(hixl): add pkg_inc include path for CANN 9.1.0

### DIFF
--- a/csrc/hixl/CMakeLists.txt
+++ b/csrc/hixl/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(hixl_npu_comms PRIVATE
     ${ASCEND_CANN_PACKAGE_PATH}/include/experiment
     ${ASCEND_CANN_PACKAGE_PATH}/include/experiment/runtime
     ${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/include
+    ${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc
     ${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc/runtime
     ${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/include/experiment/msprof
 )


### PR DESCRIPTION
## Summary

Fix building the `hixl_npu_comms` module on CANN 9.1.0.

On CANN 9.1, `rt_external_device.h` lives at
`<CANN>/aarch64-linux/pkg_inc/runtime/rt_external_device.h`, but
`runtime/config.h` still includes `runtime/rt_external_device.h`. The hixl
include paths only listed `<CANN>/${ARCH_SUBDIR}/pkg_inc/runtime`, so the
header could not be resolved and compilation failed with:

```
fatal error: runtime/rt_external_device.h: No such file or directory
```

Adding `<CANN>/${ARCH_SUBDIR}/pkg_inc` makes the header resolvable. It is
harmless on older CANN versions (the extra `-I` path simply does not exist).

## Changes

- `csrc/hixl/CMakeLists.txt`: add `${ASCEND_CANN_PACKAGE_PATH}/${ARCH_SUBDIR}/pkg_inc`
  to the `hixl_npu_comms` include directories.

## Test

- Build verified on aarch64 with CANN 9.1.0 (SOC Ascend910B4); `hixl_npu_comms`
  compiles and links successfully.