### PR TITLE
fix(c_ops): add missing <stdexcept> include in mem_alloc.cpp

### DIFF
--- a/csrc/common/exception.h
+++ b/csrc/common/exception.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #if defined(USE_MINDSPORE) && (USE_MINDSPORE)

--- a/csrc/common/mem_alloc.cpp
+++ b/csrc/common/mem_alloc.cpp
@@ -5,6 +5,7 @@
 #include <cstring> // for strerror
 #include <errno.h>
 #include <numaif.h>
+#include <stdexcept>
 #include <string>
 #include <sys/mman.h>
 

--- a/csrc/mindspore/framework_hal.cpp
+++ b/csrc/mindspore/framework_hal.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 namespace py = pybind11;

--- a/csrc/mindspore/mem_kernels.cpp
+++ b/csrc/mindspore/mem_kernels.cpp
@@ -9,6 +9,7 @@
 #include <Python.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+#include <stdexcept>
 #include <string>
 
 kvcache_ops::AscendType get_dtype_from_np(const py::array &arr) {

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -8,6 +8,7 @@
 #include "pac_kernels.h"
 #include "pos_kernels.h"
 #include <iostream>
+#include <stdexcept>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <torch/csrc/autograd/python_variable.h>

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -8,9 +8,9 @@
 #include "pac_kernels.h"
 #include "pos_kernels.h"
 #include <iostream>
-#include <stdexcept>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <stdexcept>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/torch.h>
 


### PR DESCRIPTION
## Summary

Fix compilation of `c_ops` on newer toolchains.

`csrc/common/mem_alloc.cpp` uses `std::runtime_error` but never includes
`<stdexcept>`; it previously compiled only because another header pulled the
include in transitively. With GCC 13.3 / newer libstdc++ this no longer
happens and the build fails with:

```
error: 'runtime_error' is not a member of 'std'
note: 'std::runtime_error' is defined in header '<stdexcept>'; did you
      forget to '#include <stdexcept>'?
```

## Changes

- `csrc/common/mem_alloc.cpp`: add `#include <stdexcept>`.

## Test

- Build verified on aarch64 with CANN 9.1.0 (SOC Ascend910B4); `c_ops`
  compiles and links successfully.