### PR TITLE
[PD][P2P] Enable combined PD/P2P operation and token-aware proxy routing on Ascend

### DIFF
--- a/examples/disagg_prefill/disagg_proxy_request.py
+++ b/examples/disagg_prefill/disagg_proxy_request.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Any
+
+DEFAULT_COMPLETION_MAX_TOKENS = 16
+
+
+class UpstreamServiceError(Exception):
+    """An HTTP error response returned by a proxied vLLM service."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        url: str,
+        body: bytes,
+        content_type: str | None,
+    ) -> None:
+        self.status_code = status_code
+        self.url = url
+        self.body = body
+        self.content_type = content_type
+        self.body_text = body.decode("utf-8", errors="replace")
+        super().__init__(
+            f"Upstream service returned {status_code} for {url}: {self.body_text}"
+        )
+
+
+def upstream_service_error_from_response(response: Any) -> UpstreamServiceError:
+    """Capture an upstream HTTP response before its details are discarded."""
+    return UpstreamServiceError(
+        status_code=response.status_code,
+        url=str(response.request.url),
+        body=response.content,
+        content_type=response.headers.get("content-type"),
+    )
+
+
+def normalize_chat_request(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize semantically empty tool configuration for vLLM chat APIs."""
+    normalized = request_data.copy()
+    if normalized.get("tools") == [] and normalized.get("tool_choice") in (
+        None,
+        "none",
+    ):
+        normalized.pop("tools")
+    return normalized
+
+
+def parse_chat_render_output(
+    render_output: dict[str, Any],
+) -> tuple[list[int], int]:
+    """Extract rendered prompt tokens and the effective output budget."""
+    return (
+        list(render_output["token_ids"]),
+        render_output["sampling_params"]["max_tokens"],
+    )
+
+
+def build_chat_phase_requests(
+    request_data: dict[str, Any],
+    prompt_token_ids: list[int],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build an internal prefill request and a native Chat decode request."""
+    prefill_request = request_data.copy()
+    prefill_request.pop("max_completion_tokens", None)
+    prefill_request.pop("stream_options", None)
+    prefill_request["prompt"] = list(prompt_token_ids)
+    prefill_request["max_tokens"] = 1
+    prefill_request["stream"] = False
+
+    decode_request = request_data.copy()
+
+    return prefill_request, decode_request
+
+
+def build_phase_requests(
+    request_data: dict[str, Any],
+    prompt_token_ids: list[int],
+    *,
+    is_chat: bool,
+    resolved_max_tokens: int | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build independent Completion payloads for the prefill and decode phases."""
+    normalized = request_data.copy()
+
+    if is_chat:
+        normalized.pop("max_completion_tokens", None)
+        if resolved_max_tokens is None:
+            raise ValueError("Chat requests require a resolved max_tokens value")
+        max_tokens = resolved_max_tokens
+    else:
+        max_tokens = normalized.get("max_tokens", DEFAULT_COMPLETION_MAX_TOKENS)
+
+    stream_options = normalized.pop("stream_options", None)
+    normalized["prompt"] = list(prompt_token_ids)
+
+    prefill_request = normalized.copy()
+    prefill_request["prompt"] = list(prompt_token_ids)
+    prefill_request["max_tokens"] = 1
+    prefill_request["stream"] = False
+
+    decode_request = normalized.copy()
+    decode_request["prompt"] = list(prompt_token_ids)
+    decode_request["max_tokens"] = None if max_tokens is None else max_tokens - 1
+    decode_request["stream"] = True
+    if stream_options is not None:
+        decode_request["stream_options"] = stream_options
+
+    return prefill_request, decode_request

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -1,0 +1,777 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Optional
+import argparse
+import asyncio
+import itertools
+import json
+import math
+import os
+import time
+
+# Third Party
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+import httpx
+import msgspec
+import numpy as np
+import zmq
+import zmq.asyncio
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.pd_backend import (
+    PDMsg,
+    ProxyNotif,
+)
+
+logger = init_logger(__name__)
+
+
+class WeightedSemaphore:
+    """Async semaphore with variable-weight acquire.
+
+    Limits in-flight PD token usage: each request holds ceil(L/chunk_size)
+    slots until decoding starts, preventing decoder buffer exhaustion deadlocks.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        self._capacity = capacity
+        self._available = capacity
+        self._lock = asyncio.Condition()
+
+    async def acquire(self, slots: int) -> None:
+        """Acquire *slots* from the semaphore, blocking until available.
+
+        Args:
+            slots: Number of slots to acquire (must be <= capacity).
+
+        Raises:
+            ValueError: If slots exceeds total capacity (would block forever).
+        """
+        if slots > self._capacity:
+            raise ValueError(
+                f"Requested {slots} slots exceeds total capacity {self._capacity}"
+            )
+        async with self._lock:
+            await self._lock.wait_for(lambda: self._available >= slots)
+            self._available -= slots
+
+    async def release(self, slots: int) -> None:
+        """Return *slots* to the semaphore and wake waiting acquirers.
+
+        Args:
+            slots: Number of slots to release. No-op if <= 0.
+        """
+        if slots <= 0:
+            return
+        async with self._lock:
+            self._available += slots
+            self._lock.notify_all()
+
+    @property
+    def available(self) -> int:
+        """Number of slots currently available."""
+        return self._available
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    Lifespan context manager to handle startup and shutdown events.
+    """
+    # Startup: Initialize clients
+
+    # Build prefill clients with CSV-based broadcast pairing
+    pref_hosts = global_args.prefiller_host
+    pref_ports = global_args.prefiller_port
+
+    def pair_hosts_and_ports(hosts, ports, count=None):
+        """
+        Flexible host-port pairing with expansion strategies.
+
+        Multiple pairing strategies:
+        1. Single host + single port + count: Generate incremental ports on same host
+        2. Single host + multiple ports: Pair the host with each port
+        3. Multiple hosts + single port: Pair each host with the same port
+        4. Multiple hosts + multiple ports: Strict one-to-one pairing
+           (must have same length)
+        """
+        # Ensure lists
+        if not isinstance(hosts, list):
+            hosts = [hosts]
+        if not isinstance(ports, list):
+            ports = [ports]
+        # Single host/port with count -> incremental ports
+        if len(hosts) == 1 and len(ports) == 1:
+            if count is None or count <= 1:
+                return [(hosts[0], ports[0])]
+            else:
+                return [(hosts[0], ports[0] + i) for i in range(count)]
+        # Expand single host to multiple ports
+        if len(hosts) == 1:
+            return [(hosts[0], p) for p in ports]
+        # Expand single port to multiple hosts
+        if len(ports) == 1:
+            return [(h, ports[0]) for h in hosts]
+        # Strict one-to-one pairing when both lists are provided
+        if len(hosts) != len(ports):
+            raise ValueError(
+                "Length mismatch between hosts and ports lists for pairing"
+            )
+        return list(zip(hosts, ports, strict=False))
+
+    prefill_pairs = pair_hosts_and_ports(
+        pref_hosts, pref_ports, global_args.num_prefillers
+    )
+    for host, port in prefill_pairs:
+        prefiller_base_url = f"http://{host}:{int(port)}"
+        prefill_client = httpx.AsyncClient(timeout=None, base_url=prefiller_base_url)
+        app.state.prefill_clients.append(
+            ClientInfo(
+                prefill_client,
+            )
+        )
+
+    # Build decoder clients with CSV-based broadcast pairing
+    dec_hosts = global_args.decoder_host
+    dec_ports = global_args.decoder_port
+
+    decoder_pairs = pair_hosts_and_ports(dec_hosts, dec_ports, global_args.num_decoders)
+
+    # Whether the ports increase per instances
+    # (only when using single host/port with num_decoders > 1)
+    incremental_mode = (
+        len(dec_hosts) == 1 and len(dec_ports) == 1 and global_args.num_decoders > 1
+    )
+
+    for i, (host, port) in enumerate(decoder_pairs):
+        decoder_base_url = f"http://{host}:{int(port)}"
+        decode_client = httpx.AsyncClient(timeout=None, base_url=decoder_base_url)
+        if incremental_mode:
+            init_ports = [p + i for p in global_args.decoder_init_port]
+            alloc_ports = [p + i for p in global_args.decoder_alloc_port]
+        else:
+            # Use the provided ports as-is
+            # (suitable when different hosts can reuse same port numbers)
+            init_ports = list(global_args.decoder_init_port)
+            alloc_ports = list(global_args.decoder_alloc_port)
+
+        app.state.decode_clients.append(
+            ClientInfo(
+                decode_client,
+                host,
+                init_ports,
+                alloc_ports,
+            )
+        )
+
+    app.state.total_clients = app.state.prefill_clients + app.state.decode_clients
+
+    app.state.zmq_task = asyncio.create_task(zmq_pull_server())
+
+    global pd_buffer_semaphore
+    kv_bytes_per_token = compute_kv_bytes_per_token(global_args.model)
+    capacity_slots = global_args.pd_buffer_size // (
+        kv_bytes_per_token * global_args.chunk_size
+    )
+    pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
+    logger.info(
+        "PD buffer semaphore: capacity=%d slots"
+        " (%d bytes / (%d bytes/tok * %d chunk_size)) for model %s.",
+        capacity_slots,
+        global_args.pd_buffer_size,
+        kv_bytes_per_token,
+        global_args.chunk_size,
+        global_args.model,
+    )
+
+    yield
+
+    # Shutdown: Close clients
+    for client in app.state.prefill_clients:
+        await client.aclose()
+    for client in app.state.decode_clients:
+        await client.aclose()
+
+    global run_proxy
+    run_proxy = False
+    await app.state.zmq_task  # Wait for background task to finish
+
+
+# Update FastAPI app initialization to use lifespan
+app = FastAPI(lifespan=lifespan)
+
+
+class StatsCalculator:
+    def __init__(self):
+        self._stats = []
+        self._last_log_time = time.time()
+
+    def add(self, value):
+        self._stats.append(value)
+        if time.time() - self._last_log_time > 5:
+            self._log_stats()
+            self._last_log_time = time.time()
+
+    def _log_stats(self):
+        # Print average, median, and 99th percentile
+        np_arr = np.array(self._stats) * 1000
+        output_str = (
+            f"\nNum requests: {len(self._stats)}"
+            + "\nPrefill node TTFT stats:"
+            + f"\n - Average (ms): {np.mean(np_arr)}"
+            + f"\n - Median (ms): {np.median(np_arr)}"
+            + f"\n - 99th Percentile (ms): {np.percentile(np_arr, 99)}\n"
+        )
+        print(
+            "===============================",
+            output_str,
+            "===============================",
+        )
+
+
+stats_calculator = StatsCalculator()
+counter = 0
+
+
+def csv_ints(s):
+    return [int(x) for x in s.split(",")]
+
+
+def csv_strs(s):
+    return [x.strip() for x in s.split(",")]
+
+
+def compute_kv_bytes_per_token(model_name: str) -> int:
+    """Return the number of KV cache bytes per token for *model_name*.
+
+    Reads num_hidden_layers, num_key_value_heads, head_dim, and torch_dtype
+    from the HuggingFace config without downloading model weights.
+
+    Args:
+        model_name: HuggingFace model id or local path.
+
+    Returns:
+        Bytes per token across all layers and both K/V tensors.
+    """
+    # Third Party
+    from transformers import AutoConfig
+
+    cfg = AutoConfig.from_pretrained(model_name)
+    num_layers: int = cfg.num_hidden_layers
+    num_kv_heads: int = getattr(cfg, "num_key_value_heads", cfg.num_attention_heads)
+    head_dim: int = getattr(cfg, "head_dim", cfg.hidden_size // cfg.num_attention_heads)
+    # 4 bytes for float32, 2 bytes for float16/bfloat16 (the common default)
+    torch_dtype = str(getattr(cfg, "torch_dtype", "bfloat16"))
+    dtype_bytes = 4 if "float32" in torch_dtype else 2
+    return 2 * num_layers * num_kv_heads * head_dim * dtype_bytes
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--prefiller-host", type=csv_strs, default=["localhost"])
+    parser.add_argument("--prefiller-port", type=csv_ints, default=[8100])
+    parser.add_argument("--num-prefillers", type=int, default=1)
+    parser.add_argument("--decoder-host", type=csv_strs, default=["localhost"])
+    parser.add_argument("--decoder-port", type=csv_ints, default=[8200])
+    parser.add_argument("--decoder-init-port", type=csv_ints, default=[8300])
+    parser.add_argument("--decoder-alloc-port", type=csv_ints, default=[8400])
+
+    parser.add_argument("--num-decoders", type=int, default=1)
+    parser.add_argument("--proxy-host", type=str, default="localhost")
+    parser.add_argument("--proxy-port", type=int, default=8500)
+
+    # PD buffer concurrency limiting. A weighted semaphore caps in-flight
+    # chunk slots to prevent decoder buffer exhaustion deadlocks.
+    # capacity_slots = pd_buffer_size // (kv_bytes_per_token * chunk_size)
+    # kv_bytes_per_token is derived from the model config automatically.
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="meta-llama/Llama-3.1-8B-Instruct",
+        help=(
+            "HuggingFace model name or local path. Used to derive"
+            " kv_bytes_per_token for the PD buffer semaphore capacity."
+        ),
+    )
+    parser.add_argument(
+        "--pd-buffer-size",
+        type=int,
+        default=2 * 1024 * 1024 * 1024,  # 2 GB
+        help=(
+            "PD transfer buffer size in bytes (must match the decoder's"
+            " LMCache config). Used to derive the in-flight slot capacity."
+            " Default: 2 GB."
+        ),
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=256,
+        help="LMCache chunk size in tokens (must match the LMCache config).",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+@dataclass
+class ClientInfo:
+    client: httpx.AsyncClient
+    host: Optional[str] = None
+    init_port: Optional[list[int]] = None
+    alloc_port: Optional[list[int]] = None
+
+
+# Initialize variables to hold the persistent clients
+app.state.prefill_clients = []
+app.state.decode_clients = []
+app.state.total_clients = []
+
+"""
+client_request and prefill/decode map
+key:   str    - unique id for requests across same conversation
+value: tuple  - (tokenization_client, prefiller_client, decoder_client)
+"""
+app.state.bound_clients = {}
+
+# Keep finished reqs
+app.state.finished_reqs = defaultdict(int)
+
+pd_buffer_semaphore: Optional[WeightedSemaphore] = None
+
+
+zmq_ctx = zmq.asyncio.Context()
+run_proxy = True  # Shutdown flag
+
+
+async def zmq_pull_server():
+    socket = zmq_ctx.socket(zmq.PULL)
+    proxy_url = f"{global_args.proxy_host}:{global_args.proxy_port}"
+    try:
+        socket.bind(f"tcp://{proxy_url}")
+    except zmq.ZMQError:
+        logger.exception("ZMQ proxy server failed to bind on %s", proxy_url)
+        return
+    logger.info("ZMQ proxy server started on %s", proxy_url)
+
+    while run_proxy:
+        try:
+            msg_bytes = await socket.recv()
+        except zmq.Again:
+            await asyncio.sleep(0.01)  # Avoid busy loop
+            continue
+        except zmq.ZMQError as exc:
+            if exc.errno in (zmq.ETERM, zmq.ENOTSOCK):
+                break
+            logger.warning("ZMQ recv error: %s", exc)
+            await asyncio.sleep(0.05)
+            continue
+
+        try:
+            msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
+        except msgspec.DecodeError as exc:
+            logger.warning("ZMQ received non-PD message: %s", exc)
+            continue
+        except Exception as exc:
+            logger.exception("ZMQ message decode failed: %s", exc)
+            continue
+
+        if not isinstance(msg, ProxyNotif):
+            logger.debug("ZMQ ignored message type: %s", type(msg).__name__)
+            continue
+
+        req_id = msg.req_id
+        app.state.finished_reqs[req_id] += 1
+        logger.debug("Prefill of req %s done.", req_id)
+
+    socket.close()
+    logger.info("ZMQ PULL server stopped.")
+
+
+async def send_request_to_service(
+    client: httpx.AsyncClient, endpoint: str, req_data: dict
+):
+    """
+    Send a request to a service using a persistent client.
+    """
+
+    headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+    response = await client.post(endpoint, json=req_data, headers=headers)
+    response.raise_for_status()
+    return response
+
+
+async def stream_service_response(
+    client: httpx.AsyncClient, endpoint: str, req_data: dict
+):
+    """
+    Asynchronously stream the response from a service using a persistent client.
+    """
+    headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+    async with client.stream(
+        "POST", endpoint, json=req_data, headers=headers
+    ) as response:
+        response.raise_for_status()
+        async for chunk in response.aiter_bytes():
+            yield chunk
+
+
+def round_robin_pick_client(clients, idx):
+    return clients[idx % len(clients)]
+
+
+round_robin_counter = itertools.count()
+
+
+def round_robin_pick_clients() -> tuple[ClientInfo, ClientInfo, ClientInfo]:
+    idx = next(round_robin_counter)
+    tokenization_client = round_robin_pick_client(app.state.total_clients, idx)
+    prefill_client = round_robin_pick_client(app.state.prefill_clients, idx)
+    decode_client = round_robin_pick_client(app.state.decode_clients, idx)
+    return tokenization_client, prefill_client, decode_client
+
+
+async def wait_decode_kv_ready(req_id: str, num_tp_rank: int):
+    while app.state.finished_reqs[req_id] < num_tp_rank:
+        await asyncio.sleep(0.0001)  # sleep for 0.1 ms
+    logger.debug(f"Prefill node signaled kv ready for req {req_id}")
+    app.state.finished_reqs.pop(req_id)
+
+
+BOUND_CLIENTS_MAX_NUM = 1024 * 1024
+
+
+def pick_up_bound_clients(client_id: str) -> tuple[ClientInfo, ClientInfo, ClientInfo]:
+    if client_id not in app.state.bound_clients:
+        if len(app.state.bound_clients) >= BOUND_CLIENTS_MAX_NUM:
+            # Here simply clear the bound_clients if full
+            app.state.bound_clients.clear()
+        app.state.bound_clients[client_id] = round_robin_pick_clients()
+    return app.state.bound_clients[client_id]
+
+
+BOUND_CLIENT = os.getenv("CLIENT_BOUND", "false").lower() == "true"
+# CLIENT_BOUND_KEY, the field name of the client uid in http request
+CLIENT_BOUND_KEY = os.getenv("CLIENT_BOUND_KEY", "session-id")
+
+
+def pick_up_clients(request: Request) -> tuple[ClientInfo, ClientInfo, ClientInfo]:
+    bound_client_id = request.headers.get(CLIENT_BOUND_KEY) if BOUND_CLIENT else None
+    if bound_client_id:
+        # Use or create a persistent set of clients for the session.
+        return pick_up_bound_clients(bound_client_id)
+    return round_robin_pick_clients()
+
+
+@app.post("/v1/completions")
+async def handle_completions(request: Request):
+    global counter, stats_calculator
+    counter += 1
+    req_id = str(counter)  # we use counter as req_id
+
+    st = time.time()
+    slots = 0  # slots to release on error; set after successful acquire only
+    acquired = False
+    try:
+        req_data = await request.json()
+
+        # Pick tokenization, prefill and decode client
+        tokenization_client, prefill_client, decode_client = pick_up_clients(request)
+
+        tokenize_output = await send_request_to_service(
+            tokenization_client.client, "/tokenize", {"prompt": req_data["prompt"]}
+        )
+        tokenize_output = tokenize_output.json()
+
+        org_max_tokens = req_data["max_tokens"]
+        req_data["prompt"] = tokenize_output["tokens"]
+        req_data["max_tokens"] = 1
+
+        # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
+        slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
+        if pd_buffer_semaphore is not None:
+            await pd_buffer_semaphore.acquire(slots)
+            acquired = True
+
+        disagg_spec = {
+            "req_id": req_id,
+            "receiver_host": decode_client.host,
+            "receiver_init_port": decode_client.init_port,
+            "receiver_alloc_port": decode_client.alloc_port,
+        }
+        num_tp_rank = len(decode_client.init_port or [])
+
+        req_data["kv_transfer_params"] = {
+            "ret_first_tok": True,
+            "disagg_spec": disagg_spec,
+        }
+
+        req_data["stream"] = False
+        stream_options = req_data.pop("stream_options", None)
+
+        # Send request to prefill service, ignore the response
+        prefill_output = await send_request_to_service(
+            prefill_client.client, "/v1/completions", req_data
+        )
+
+        prefill_output = prefill_output.json()
+
+        et = time.time()
+        stats_calculator.add(et - st)
+
+        req_data["max_tokens"] = org_max_tokens - 1
+        req_data["prompt"].append(prefill_output["kv_transfer_params"]["first_tok"])
+        req_data.pop("kv_transfer_params")
+        req_data["stream"] = True
+        if stream_options is not None:
+            req_data["stream_options"] = stream_options
+
+        # Stream response from decode service
+        async def generate_stream():
+            head_chunk = {
+                "id": prefill_output["id"],
+                "object": "text_completion",
+                "created": prefill_output["created"],
+                "model": prefill_output["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "text": prefill_output["choices"][0]["text"],
+                        "logprobs": None,
+                        "finish_reason": None,
+                        "stop_reason": None,
+                    }
+                ],
+                "usage": None,
+            }
+            yield (
+                "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
+            ).encode()
+
+            try:
+                await wait_decode_kv_ready(req_id, num_tp_rank)
+            finally:
+                if pd_buffer_semaphore is not None:
+                    await pd_buffer_semaphore.release(slots)
+
+            async for chunk in stream_service_response(
+                decode_client.client, "/v1/completions", req_data
+            ):
+                yield chunk
+
+        return StreamingResponse(generate_stream(), media_type="application/json")
+
+    except Exception as e:
+        if pd_buffer_semaphore is not None and acquired:
+            await pd_buffer_semaphore.release(slots)
+        # Standard
+        import sys
+        import traceback
+
+        exc_info = sys.exc_info()
+        print("Error occurred in disagg prefill proxy server - completions endpoint")
+        print(e)
+        print("".join(traceback.format_exception(*exc_info)))
+        raise
+
+
+@app.post("/v1/chat/completions")
+async def handle_chat_completions(request: Request):
+    global counter, stats_calculator
+    counter += 1
+    req_id = str(counter)
+
+    st = time.time()
+    slots = 0  # slots to release on error; set after successful acquire only
+    acquired = False
+    try:
+        req_data = await request.json()
+
+        # Pick tokenization, prefill and decode client
+        tokenization_client, prefill_client, decode_client = pick_up_clients(request)
+
+        # For chat completions, we need to tokenize the messages
+        tokenize_output = await send_request_to_service(
+            tokenization_client.client, "/tokenize", {"messages": req_data["messages"]}
+        )
+        tokenize_output = tokenize_output.json()
+
+        org_max_tokens = req_data["max_tokens"]
+        req_data["prompt"] = tokenize_output["tokens"]
+        req_data["max_tokens"] = 1
+
+        org_max_completion_tokens = None
+        if "max_completion_tokens" in req_data:
+            org_max_completion_tokens = req_data["max_completion_tokens"]
+            req_data["max_completion_tokens"] = 1
+
+        # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
+        slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
+        if pd_buffer_semaphore is not None:
+            await pd_buffer_semaphore.acquire(slots)
+            acquired = True
+
+        disagg_spec = {
+            "req_id": req_id,
+            "receiver_host": decode_client.host,
+            "receiver_init_port": decode_client.init_port,
+            "receiver_alloc_port": decode_client.alloc_port,
+        }
+
+        num_tp_rank = len(decode_client.init_port or [])
+
+        req_data["kv_transfer_params"] = {
+            "ret_first_tok": True,
+            "disagg_spec": disagg_spec,
+        }
+
+        req_data["stream"] = False
+        stream_options = req_data.pop("stream_options", None)
+
+        # Send request to prefill service, get the response
+        prefill_output = await send_request_to_service(
+            prefill_client.client, "/v1/completions", req_data
+        )
+
+        prefill_output = prefill_output.json()
+
+        et = time.time()
+        stats_calculator.add(et - st)
+
+        req_data["max_tokens"] = org_max_tokens - 1
+        if org_max_completion_tokens is not None:
+            req_data["max_completion_tokens"] = org_max_completion_tokens - 1
+
+        # Add the first token from prefill to the tokenized messages for decode
+        req_data["prompt"].append(prefill_output["kv_transfer_params"]["first_tok"])
+
+        req_data.pop("kv_transfer_params")
+        req_data["stream"] = True
+        if stream_options is not None:
+            req_data["stream_options"] = stream_options
+
+        # Stream response from decode service
+        async def generate_stream():
+            initial_chunk = {
+                "id": prefill_output["id"],
+                "object": "chat.completion.chunk",
+                "created": prefill_output["created"],
+                "model": prefill_output["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "logprobs": None,
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield (
+                "data: " + json.dumps(initial_chunk, separators=(",", ":")) + "\n\n"
+            ).encode()
+
+            head_chunk = {
+                "id": prefill_output["id"],
+                "object": "chat.completion.chunk",
+                "created": prefill_output["created"],
+                "model": prefill_output["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": prefill_output["choices"][0]["text"]},
+                        "logprobs": None,
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield (
+                "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
+            ).encode()
+
+            try:
+                await wait_decode_kv_ready(req_id, num_tp_rank)
+            finally:
+                if pd_buffer_semaphore is not None:
+                    await pd_buffer_semaphore.release(slots)
+
+            # Stream and convert completion format chunks to chat completion format
+            async for chunk in stream_service_response(
+                decode_client.client, "/v1/completions", req_data
+            ):
+                chunk_str = chunk.decode("utf-8")
+                if chunk_str.startswith("data: ") and not chunk_str.startswith(
+                    "data: [DONE]"
+                ):
+                    try:
+                        json_str = chunk_str[6:].strip()  # Remove 'data: ' prefix
+                        if json_str:
+                            completion_data = json.loads(json_str)
+                            chat_completion_data = {
+                                "id": completion_data["id"],
+                                "object": "chat.completion.chunk",
+                                "created": completion_data["created"],
+                                "model": completion_data["model"],
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {
+                                            "content": completion_data["choices"][0][
+                                                "text"
+                                            ]
+                                        },
+                                        "logprobs": completion_data["choices"][0].get(
+                                            "logprobs"
+                                        ),
+                                        "finish_reason": completion_data["choices"][
+                                            0
+                                        ].get("finish_reason"),
+                                    }
+                                ],
+                            }
+                            converted_chunk = (
+                                "data: "
+                                + json.dumps(
+                                    chat_completion_data, separators=(",", ":")
+                                )
+                                + "\n\n"
+                            ).encode()
+                            yield converted_chunk
+                    except (json.JSONDecodeError, KeyError):
+                        yield chunk
+                else:
+                    yield chunk
+
+        return StreamingResponse(generate_stream(), media_type="application/json")
+
+    except Exception as e:
+        if pd_buffer_semaphore is not None and acquired:
+            await pd_buffer_semaphore.release(slots)
+        # Standard
+        import sys
+        import traceback
+
+        exc_info = sys.exc_info()
+        print(
+            "Error occurred in disagg prefill proxy server  - chat completions endpoint"
+        )
+        print(e)
+        print("".join(traceback.format_exception(*exc_info)))
+        raise
+
+
+if __name__ == "__main__":
+    global global_args
+    global_args = parse_args()
+
+    # Third Party
+    import uvicorn
+
+    uvicorn.run(app, host=global_args.host, port=global_args.port)

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -77,6 +77,11 @@ class WeightedSemaphore:
         """Number of slots currently available."""
         return self._available
 
+    @property
+    def capacity(self) -> int:
+        """Total slot capacity."""
+        return self._capacity
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -89,6 +94,8 @@ async def lifespan(app: FastAPI):
     app.state.total_clients = []
     app.state.prefiller_states = []
     app.state.prefiller_select_seq = 0
+    app.state.decoder_states = []
+    app.state.decoder_select_seq = 0
 
     # Build prefill clients with CSV-based broadcast pairing
     pref_hosts = global_args.prefiller_host
@@ -163,6 +170,11 @@ async def lifespan(app: FastAPI):
         len(dec_hosts) == 1 and len(dec_ports) == 1 and global_args.num_decoders > 1
     )
 
+    kv_bytes_per_token = compute_kv_bytes_per_token(global_args.model)
+    pd_capacity_slots = global_args.pd_buffer_size // (
+        kv_bytes_per_token * global_args.chunk_size
+    )
+
     for i, (host, port) in enumerate(decoder_pairs):
         decoder_base_url = f"http://{host}:{int(port)}"
         decode_client = httpx.AsyncClient(timeout=None, base_url=decoder_base_url)
@@ -175,14 +187,24 @@ async def lifespan(app: FastAPI):
             init_ports = list(global_args.decoder_init_port)
             alloc_ports = list(global_args.decoder_alloc_port)
 
-        app.state.decode_clients.append(
-            ClientInfo(
-                decode_client,
+        client_info = ClientInfo(
+            decode_client,
+            host=host,
+            init_port=init_ports,
+            alloc_port=alloc_ports,
+            name=f"decoder-{i}",
+            base_url=decoder_base_url,
+        )
+        app.state.decode_clients.append(client_info)
+        app.state.decoder_states.append(
+            DecoderState(
+                client_info=client_info,
+                name=client_info.name or f"decoder-{i}",
                 host=host,
+                port=int(port),
                 init_port=init_ports,
                 alloc_port=alloc_ports,
-                name=f"decoder-{i}",
-                base_url=decoder_base_url,
+                pd_buffer_semaphore=WeightedSemaphore(pd_capacity_slots),
             )
         )
 
@@ -190,16 +212,10 @@ async def lifespan(app: FastAPI):
 
     app.state.zmq_task = asyncio.create_task(zmq_pull_server())
 
-    global pd_buffer_semaphore
-    kv_bytes_per_token = compute_kv_bytes_per_token(global_args.model)
-    capacity_slots = global_args.pd_buffer_size // (
-        kv_bytes_per_token * global_args.chunk_size
-    )
-    pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
     logger.info(
-        "PD buffer semaphore: capacity=%d slots"
+        "Per-decoder PD buffer semaphore: capacity=%d slots per decoder"
         " (%d bytes / (%d bytes/tok * %d chunk_size)) for model %s.",
-        capacity_slots,
+        pd_capacity_slots,
         global_args.pd_buffer_size,
         kv_bytes_per_token,
         global_args.chunk_size,
@@ -390,6 +406,51 @@ class PrefillerState:
         }
 
 
+@dataclass
+class DecoderState:
+    client_info: ClientInfo
+    name: str
+    host: str
+    port: int
+    init_port: list[int]
+    alloc_port: list[int]
+    pd_buffer_semaphore: WeightedSemaphore
+    active_decode_tokens: int = 0
+    active_decode_requests: int = 0
+    total_decode_tokens: int = 0
+    total_decode_requests: int = 0
+    failed_decode_requests: int = 0
+    last_error: Optional[str] = None
+    last_decode_ms: Optional[float] = None
+    decode_ms_ewma: Optional[float] = None  # Smoothed recent decode latency in ms.
+    last_success_ts: Optional[float] = None
+    last_selected_seq: int = 0
+
+    @property
+    def load_score(self) -> int:
+        return self.active_decode_tokens
+
+    def snapshot(self) -> dict:
+        return {
+            "name": self.name,
+            "host": self.host,
+            "port": self.port,
+            "init_port": self.init_port,
+            "alloc_port": self.alloc_port,
+            "active_decode_tokens": self.active_decode_tokens,
+            "active_decode_requests": self.active_decode_requests,
+            "load_score": self.load_score,
+            "total_decode_tokens": self.total_decode_tokens,
+            "total_decode_requests": self.total_decode_requests,
+            "failed_decode_requests": self.failed_decode_requests,
+            "last_error": self.last_error,
+            "last_decode_ms": self.last_decode_ms,
+            "decode_ms_ewma": self.decode_ms_ewma,
+            "pd_slots_available": self.pd_buffer_semaphore.available,
+            "pd_slots_capacity": self.pd_buffer_semaphore.capacity,
+        }
+
+
 # Initialize variables to hold the persistent clients
 app.state.prefill_clients = []
 app.state.decode_clients = []
@@ -397,6 +458,9 @@ app.state.total_clients = []
 app.state.prefiller_states = []
 app.state.prefiller_lock = asyncio.Lock()
 app.state.prefiller_select_seq = 0
+app.state.decoder_states = []
+app.state.decoder_lock = asyncio.Lock()
+app.state.decoder_select_seq = 0
 
 """
 client_request and tokenization client map
@@ -407,8 +471,6 @@ app.state.bound_clients = {}
 
 # Keep finished reqs
 app.state.finished_reqs = defaultdict(int)
-
-pd_buffer_semaphore: Optional[WeightedSemaphore] = None
 
 
 zmq_ctx = zmq.asyncio.Context()
@@ -494,7 +556,6 @@ def round_robin_pick_client(clients, idx):
 
 
 tokenization_round_robin_counter = itertools.count()
-decoder_round_robin_counter = itertools.count()
 
 
 BOUND_CLIENTS_MAX_NUM = 1024 * 1024
@@ -525,9 +586,38 @@ def pick_up_tokenization_client(request: Request) -> ClientInfo:
     return round_robin_pick_client(app.state.total_clients, idx)
 
 
-def pick_up_decoder_client() -> ClientInfo:
-    idx = next(decoder_round_robin_counter)
-    return round_robin_pick_client(app.state.decode_clients, idx)
+async def select_decoder(
+    prompt_token_count: int,
+) -> tuple[DecoderState, dict]:
+    if not app.state.decoder_states:
+        raise ValueError("No decoder clients configured")
+
+    async with app.state.decoder_lock:
+        candidate_loads = [state.snapshot() for state in app.state.decoder_states]
+        selected = min(
+            app.state.decoder_states,
+            key=lambda state: (
+                state.load_score,
+                state.last_selected_seq,
+                state.name,
+            ),
+        )
+        selected_load_before = selected.load_score
+        app.state.decoder_select_seq += 1
+        selected.last_selected_seq = app.state.decoder_select_seq
+        selected.active_decode_tokens += prompt_token_count
+        selected.active_decode_requests += 1
+        selected.total_decode_tokens += prompt_token_count
+        selected.total_decode_requests += 1
+
+        return selected, {
+            "decoder_policy": "min_active_decode_tokens",
+            "decode_score": prompt_token_count,
+            "selected_decoder": selected.name,
+            "selected_decoder_load_before": selected_load_before,
+            "selected_decoder_state_after": selected.snapshot(),
+            "candidate_decoder_loads": candidate_loads,
+        }
 
 
 async def select_prefiller(
@@ -596,6 +686,37 @@ async def release_prefiller(
         return prefiller_state.snapshot()
 
 
+async def release_decoder(
+    decoder_state: DecoderState,
+    prompt_token_count: int,
+    success: bool,
+    decode_ms: Optional[float] = None,
+    error: Optional[str] = None,
+) -> dict:
+    async with app.state.decoder_lock:
+        decoder_state.active_decode_tokens = max(
+            0, decoder_state.active_decode_tokens - prompt_token_count
+        )
+        decoder_state.active_decode_requests = max(
+            0, decoder_state.active_decode_requests - 1
+        )
+        if success:
+            decoder_state.last_error = None
+            decoder_state.last_success_ts = time.time()
+            if decode_ms is not None:
+                decoder_state.last_decode_ms = decode_ms
+                if decoder_state.decode_ms_ewma is None:
+                    decoder_state.decode_ms_ewma = decode_ms
+                else:
+                    decoder_state.decode_ms_ewma = (
+                        decoder_state.decode_ms_ewma * 0.8 + decode_ms * 0.2
+                    )
+        else:
+            decoder_state.failed_decode_requests += 1
+            decoder_state.last_error = error
+        return decoder_state.snapshot()
+
+
 def _format_metric(value, digits: int = 3) -> str:
     if value is None:
         return "-"
@@ -639,10 +760,50 @@ def _format_candidate_prefillers(candidate_loads: list[dict]) -> str:
     )
 
 
+def _format_decoder_active(state: dict) -> str:
+    if not state:
+        return "-"
+    return (
+        f"{state.get('active_decode_requests', '-')}"
+        f"req/{state.get('active_decode_tokens', '-')}tok"
+    )
+
+
+def _format_decoder_candidate(state: dict) -> str:
+    name = state.get("name", "-")
+    host = state.get("host", "-")
+    port = state.get("port", "-")
+    return (
+        f"{name}@{host}:{port}"
+        f"(load={state.get('load_score', '-')},"
+        f"active={_format_decoder_active(state)},"
+        f"pd_slots={state.get('pd_slots_available', '-')}/"
+        f"{state.get('pd_slots_capacity', '-')},"
+        f"total={state.get('total_decode_requests', '-')}req/"
+        f"{state.get('total_decode_tokens', '-')}tok,"
+        f"failed={state.get('failed_decode_requests', '-')},"
+        f"last_ms={_format_metric(state.get('last_decode_ms'))},"
+        f"ewma_ms={_format_metric(state.get('decode_ms_ewma'))})"
+    )
+
+
+def _format_candidate_decoders(candidate_loads: list[dict]) -> str:
+    if not candidate_loads:
+        return "[]"
+    return (
+        "["
+        + "; ".join(_format_decoder_candidate(state) for state in candidate_loads)
+        + "]"
+    )
+
+
 def _format_route_summary(event: str, payload: dict) -> str:
-    selected_state = payload.get("selected_prefiller_state_after") or {}
-    released_state = payload.get("prefiller_state_after_release") or {}
-    active_state = released_state or selected_state
+    prefiller_selected_state = payload.get("selected_prefiller_state_after") or {}
+    prefiller_released_state = payload.get("prefiller_state_after_release") or {}
+    prefiller_active_state = prefiller_released_state or prefiller_selected_state
+    decoder_selected_state = payload.get("selected_decoder_state_after") or {}
+    decoder_released_state = payload.get("decoder_state_after_release") or {}
+    decoder_active_state = decoder_released_state or decoder_selected_state
 
     lines = [
         "===============================",
@@ -657,11 +818,22 @@ def _format_route_summary(event: str, payload: dict) -> str:
         f" - pd_slot_wait_ms: {_format_metric(payload.get('pd_slot_wait_ms'))}",
         " - prefiller_load_before: "
         f"{payload.get('selected_prefiller_load_before', '-')}",
-        f" - prefiller_load_after_select: {selected_state.get('load_score', '-')}",
-        f" - prefiller_load_after_release: {released_state.get('load_score', '-')}",
-        f" - prefiller_active_current: {_format_prefiller_active(active_state)}",
+        " - prefiller_load_after_select: "
+        f"{prefiller_selected_state.get('load_score', '-')}",
+        " - prefiller_load_after_release: "
+        f"{prefiller_released_state.get('load_score', '-')}",
+        f" - decoder_load_before: {payload.get('selected_decoder_load_before', '-')}",
+        " - decoder_load_after_select: "
+        f"{decoder_selected_state.get('load_score', '-')}",
+        " - decoder_load_after_release: "
+        f"{decoder_released_state.get('load_score', '-')}",
+        " - prefiller_active_current: "
+        f"{_format_prefiller_active(prefiller_active_state)}",
+        f" - decoder_active_current: {_format_decoder_active(decoder_active_state)}",
         " - candidate_prefiller_loads: "
         f"{_format_candidate_prefillers(payload.get('candidate_prefiller_loads', []))}",
+        " - candidate_decoder_loads: "
+        f"{_format_candidate_decoders(payload.get('candidate_decoder_loads', []))}",
     ]
 
     if payload.get("kv_ready_wait_ms") is not None:
@@ -713,12 +885,13 @@ async def handle_completions(request: Request):
     prompt_token_count = 0
     prefiller_state = None
     prefiller_released = False
+    decoder_state = None
+    decoder_released = False
     route_info = {}
     try:
         req_data = await request.json()
 
         tokenization_client = pick_up_tokenization_client(request)
-        decode_client = pick_up_decoder_client()
 
         tokenize_output = await send_request_to_service(
             tokenization_client.client, "/tokenize", {"prompt": req_data["prompt"]}
@@ -726,17 +899,24 @@ async def handle_completions(request: Request):
         tokenize_output = tokenize_output.json()
         prompt_token_count = len(tokenize_output["tokens"])
 
-        prefiller_state, route_info = await select_prefiller(prompt_token_count)
-        prefill_client = prefiller_state.client_info
+        decoder_state, decoder_info = await select_decoder(prompt_token_count)
+        route_info = dict(decoder_info)
         route_info.update(
             {
                 "req_id": req_id,
                 "endpoint": "/v1/completions",
                 "prompt_token_count": prompt_token_count,
-                "chosen_prefiller": prefiller_state.name,
-                "chosen_decoder": decode_client.name,
+                "chosen_decoder": decoder_state.name,
                 "tokenization_client": tokenization_client.name,
-                "decoder_policy": "round_robin",
+            }
+        )
+        decode_client = decoder_state.client_info
+        prefiller_state, prefiller_info = await select_prefiller(prompt_token_count)
+        route_info.update(prefiller_info)
+        prefill_client = prefiller_state.client_info
+        route_info.update(
+            {
+                "chosen_prefiller": prefiller_state.name,
             }
         )
         log_route_event("proxy_route_selected", route_info)
@@ -748,11 +928,10 @@ async def handle_completions(request: Request):
         # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
         slots = math.ceil(prompt_token_count / global_args.chunk_size)
         pd_slot_wait_ms = 0.0
-        if pd_buffer_semaphore is not None:
-            pd_slot_wait_start = time.time()
-            await pd_buffer_semaphore.acquire(slots)
-            pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
-            acquired = True
+        pd_slot_wait_start = time.time()
+        await decoder_state.pd_buffer_semaphore.acquire(slots)
+        pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
+        acquired = True
 
         disagg_spec = {
             "req_id": req_id,
@@ -809,7 +988,7 @@ async def handle_completions(request: Request):
 
         # Stream response from decode service
         async def generate_stream():
-            nonlocal pd_slots_released
+            nonlocal decoder_released, pd_slots_released
             kv_ready_wait_ms = None
             decode_stream_ms = None
             stream_error = None
@@ -837,8 +1016,8 @@ async def handle_completions(request: Request):
                 kv_ready_wait_start = time.time()
                 await wait_decode_kv_ready(req_id, num_tp_rank)
                 kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
-                if pd_buffer_semaphore is not None and acquired:
-                    await pd_buffer_semaphore.release(slots)
+                if acquired:
+                    await decoder_state.pd_buffer_semaphore.release(slots)
                     pd_slots_released = True
 
                 decode_stream_start = time.time()
@@ -851,18 +1030,25 @@ async def handle_completions(request: Request):
                 stream_error = str(exc)
                 raise
             finally:
-                if (
-                    pd_buffer_semaphore is not None
-                    and acquired
-                    and not pd_slots_released
-                ):
-                    await pd_buffer_semaphore.release(slots)
+                if acquired and not pd_slots_released:
+                    await decoder_state.pd_buffer_semaphore.release(slots)
                     pd_slots_released = True
+                decoder_release_state = None
+                if decoder_state is not None and not decoder_released:
+                    decoder_release_state = await release_decoder(
+                        decoder_state,
+                        prompt_token_count,
+                        success=stream_error is None,
+                        decode_ms=decode_stream_ms,
+                        error=stream_error,
+                    )
+                    decoder_released = True
                 complete_payload = dict(route_log_base)
                 complete_payload.update(
                     {
                         "kv_ready_wait_ms": kv_ready_wait_ms,
                         "decode_stream_ms": decode_stream_ms,
+                        "decoder_state_after_release": decoder_release_state,
                         "total_ms": (time.time() - st) * 1000,
                         "error": stream_error,
                     }
@@ -880,8 +1066,17 @@ async def handle_completions(request: Request):
                 error=str(e),
             )
             route_info["prefiller_state_after_release"] = release_state
-        if pd_buffer_semaphore is not None and acquired and not pd_slots_released:
-            await pd_buffer_semaphore.release(slots)
+        if decoder_state is not None and not decoder_released:
+            release_state = await release_decoder(
+                decoder_state,
+                prompt_token_count,
+                success=False,
+                error=str(e),
+            )
+            route_info["decoder_state_after_release"] = release_state
+            decoder_released = True
+        if decoder_state is not None and acquired and not pd_slots_released:
+            await decoder_state.pd_buffer_semaphore.release(slots)
             pd_slots_released = True
         if route_info:
             error_payload = dict(route_info)
@@ -917,12 +1112,13 @@ async def handle_chat_completions(request: Request):
     prompt_token_count = 0
     prefiller_state = None
     prefiller_released = False
+    decoder_state = None
+    decoder_released = False
     route_info = {}
     try:
         req_data = await request.json()
 
         tokenization_client = pick_up_tokenization_client(request)
-        decode_client = pick_up_decoder_client()
 
         # For chat completions, we need to tokenize the messages
         tokenize_output = await send_request_to_service(
@@ -931,17 +1127,24 @@ async def handle_chat_completions(request: Request):
         tokenize_output = tokenize_output.json()
         prompt_token_count = len(tokenize_output["tokens"])
 
-        prefiller_state, route_info = await select_prefiller(prompt_token_count)
-        prefill_client = prefiller_state.client_info
+        decoder_state, decoder_info = await select_decoder(prompt_token_count)
+        route_info = dict(decoder_info)
         route_info.update(
             {
                 "req_id": req_id,
                 "endpoint": "/v1/chat/completions",
                 "prompt_token_count": prompt_token_count,
-                "chosen_prefiller": prefiller_state.name,
-                "chosen_decoder": decode_client.name,
+                "chosen_decoder": decoder_state.name,
                 "tokenization_client": tokenization_client.name,
-                "decoder_policy": "round_robin",
+            }
+        )
+        decode_client = decoder_state.client_info
+        prefiller_state, prefiller_info = await select_prefiller(prompt_token_count)
+        route_info.update(prefiller_info)
+        prefill_client = prefiller_state.client_info
+        route_info.update(
+            {
+                "chosen_prefiller": prefiller_state.name,
             }
         )
         log_route_event("proxy_route_selected", route_info)
@@ -958,11 +1161,10 @@ async def handle_chat_completions(request: Request):
         # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
         slots = math.ceil(prompt_token_count / global_args.chunk_size)
         pd_slot_wait_ms = 0.0
-        if pd_buffer_semaphore is not None:
-            pd_slot_wait_start = time.time()
-            await pd_buffer_semaphore.acquire(slots)
-            pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
-            acquired = True
+        pd_slot_wait_start = time.time()
+        await decoder_state.pd_buffer_semaphore.acquire(slots)
+        pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
+        acquired = True
 
         disagg_spec = {
             "req_id": req_id,
@@ -1025,7 +1227,7 @@ async def handle_chat_completions(request: Request):
 
         # Stream response from decode service
         async def generate_stream():
-            nonlocal pd_slots_released
+            nonlocal decoder_released, pd_slots_released
             kv_ready_wait_ms = None
             decode_stream_ms = None
             stream_error = None
@@ -1069,8 +1271,8 @@ async def handle_chat_completions(request: Request):
                 kv_ready_wait_start = time.time()
                 await wait_decode_kv_ready(req_id, num_tp_rank)
                 kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
-                if pd_buffer_semaphore is not None and acquired:
-                    await pd_buffer_semaphore.release(slots)
+                if acquired:
+                    await decoder_state.pd_buffer_semaphore.release(slots)
                     pd_slots_released = True
 
                 decode_stream_start = time.time()
@@ -1125,18 +1327,25 @@ async def handle_chat_completions(request: Request):
                 stream_error = str(exc)
                 raise
             finally:
-                if (
-                    pd_buffer_semaphore is not None
-                    and acquired
-                    and not pd_slots_released
-                ):
-                    await pd_buffer_semaphore.release(slots)
+                if acquired and not pd_slots_released:
+                    await decoder_state.pd_buffer_semaphore.release(slots)
                     pd_slots_released = True
+                decoder_release_state = None
+                if decoder_state is not None and not decoder_released:
+                    decoder_release_state = await release_decoder(
+                        decoder_state,
+                        prompt_token_count,
+                        success=stream_error is None,
+                        decode_ms=decode_stream_ms,
+                        error=stream_error,
+                    )
+                    decoder_released = True
                 complete_payload = dict(route_log_base)
                 complete_payload.update(
                     {
                         "kv_ready_wait_ms": kv_ready_wait_ms,
                         "decode_stream_ms": decode_stream_ms,
+                        "decoder_state_after_release": decoder_release_state,
                         "total_ms": (time.time() - st) * 1000,
                         "error": stream_error,
                     }
@@ -1154,8 +1363,17 @@ async def handle_chat_completions(request: Request):
                 error=str(e),
             )
             route_info["prefiller_state_after_release"] = release_state
-        if pd_buffer_semaphore is not None and acquired and not pd_slots_released:
-            await pd_buffer_semaphore.release(slots)
+        if decoder_state is not None and not decoder_released:
+            release_state = await release_decoder(
+                decoder_state,
+                prompt_token_count,
+                success=False,
+                error=str(e),
+            )
+            route_info["decoder_state_after_release"] = release_state
+            decoder_released = True
+        if decoder_state is not None and acquired and not pd_slots_released:
+            await decoder_state.pd_buffer_semaphore.release(slots)
             pd_slots_released = True
         if route_info:
             error_payload = dict(route_info)

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -13,8 +13,16 @@ import os
 import time
 
 # Third Party
+from disagg_proxy_request import (
+    UpstreamServiceError,
+    build_chat_phase_requests,
+    build_phase_requests,
+    normalize_chat_request,
+    parse_chat_render_output,
+    upstream_service_error_from_response,
+)
 from fastapi import FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from lmcache.logging import init_logger
 from lmcache.v1.storage_backend.pd_backend import (
     PDMsg,
@@ -266,6 +274,25 @@ async def lifespan(app: FastAPI):
 
 # Update FastAPI app initialization to use lifespan
 app = FastAPI(lifespan=lifespan)
+
+
+@app.exception_handler(UpstreamServiceError)
+async def handle_upstream_service_error(
+    _request: Request, exc: UpstreamServiceError
+) -> Response:
+    """Return a proxied vLLM error without converting it to an HTTP 500."""
+    logger.error(
+        "Upstream service error: status=%d url=%s body=%s",
+        exc.status_code,
+        exc.url,
+        exc.body_text,
+    )
+    headers = {"content-type": exc.content_type} if exc.content_type else None
+    return Response(
+        content=exc.body,
+        status_code=exc.status_code,
+        headers=headers,
+    )
 
 
 class StatsCalculator:
@@ -591,7 +618,8 @@ async def send_request_to_service(
 
     headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
     response = await client.post(endpoint, json=req_data, headers=headers)
-    response.raise_for_status()
+    if not response.is_success:
+        raise upstream_service_error_from_response(response)
     return response
 
 
@@ -605,9 +633,66 @@ async def stream_service_response(
     async with client.stream(
         "POST", endpoint, json=req_data, headers=headers
     ) as response:
-        response.raise_for_status()
+        if not response.is_success:
+            await response.aread()
+            raise upstream_service_error_from_response(response)
         async for chunk in response.aiter_bytes():
             yield chunk
+
+
+def encode_sse_data(data: dict) -> bytes:
+    return ("data: " + json.dumps(data, separators=(",", ":")) + "\n\n").encode()
+
+
+async def stream_prefill_only_completion_response(
+    prefill_output: dict, include_usage: bool
+):
+    choice = prefill_output["choices"][0]
+    base_chunk = {
+        "id": prefill_output["id"],
+        "object": "text_completion",
+        "created": prefill_output["created"],
+        "model": prefill_output["model"],
+    }
+    yield encode_sse_data(
+        {
+            **base_chunk,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": choice["text"],
+                    "logprobs": choice.get("logprobs"),
+                    "finish_reason": None,
+                    "stop_reason": None,
+                }
+            ],
+            "usage": None,
+        }
+    )
+    yield encode_sse_data(
+        {
+            **base_chunk,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "",
+                    "logprobs": None,
+                    "finish_reason": choice.get("finish_reason"),
+                    "stop_reason": choice.get("stop_reason"),
+                }
+            ],
+            "usage": None,
+        }
+    )
+    if include_usage and prefill_output.get("usage") is not None:
+        yield encode_sse_data(
+            {
+                **base_chunk,
+                "choices": [],
+                "usage": prefill_output["usage"],
+            }
+        )
+    yield b"data: [DONE]\n\n"
 
 
 def round_robin_pick_client(clients, idx):
@@ -917,6 +1002,12 @@ def _format_route_summary(event: str, payload: dict) -> str:
         f"{_format_candidate_decoders(payload.get('candidate_decoder_loads', []))}",
     ]
 
+    if payload.get("response_mode") is not None:
+        lines.append(f" - response_mode: {payload['response_mode']}")
+    if "prefill_first_token_exposed" in payload:
+        lines.append(
+            f" - prefill_first_token_exposed: {payload['prefill_first_token_exposed']}"
+        )
     if payload.get("kv_ready_wait_ms") is not None:
         lines.append(
             f" - kv_ready_wait_ms: {_format_metric(payload['kv_ready_wait_ms'])}"
@@ -924,6 +1015,10 @@ def _format_route_summary(event: str, payload: dict) -> str:
     if payload.get("decode_stream_ms") is not None:
         lines.append(
             f" - decode_stream_ms: {_format_metric(payload['decode_stream_ms'])}"
+        )
+    if payload.get("decode_response_ms") is not None:
+        lines.append(
+            f" - decode_response_ms: {_format_metric(payload['decode_response_ms'])}"
         )
     if payload.get("total_ms") is not None:
         lines.append(f" - total_ms: {_format_metric(payload['total_ms'])}")
@@ -1004,6 +1099,68 @@ async def handle_completions(request: Request):
         )
         tokenize_output = tokenize_output.json()
         prompt_token_count = len(tokenize_output["tokens"])
+        prefill_req_data, decode_req_data = build_phase_requests(
+            req_data,
+            tokenize_output["tokens"],
+            is_chat=False,
+        )
+
+        if decode_req_data["max_tokens"] == 0:
+            prefiller_state, prefiller_info = await select_prefiller(prompt_token_count)
+            prefill_client = prefiller_state.client_info
+            route_info = dict(prefiller_info)
+            route_info.update(
+                {
+                    "req_id": req_id,
+                    "endpoint": "/v1/completions",
+                    "prompt_token_count": prompt_token_count,
+                    "chosen_prefiller": prefiller_state.name,
+                    "chosen_decoder": "prefill-only",
+                    "tokenization_client": tokenization_client.name,
+                    "pd_transfer_mode": "prefill-only",
+                    "pd_buffer_admission_enabled": False,
+                }
+            )
+            log_route_event("proxy_route_selected", route_info)
+
+            prefill_start = time.time()
+            prefill_output = await send_request_to_service(
+                prefill_client.client, "/v1/completions", prefill_req_data
+            )
+            prefill_ms = (time.time() - prefill_start) * 1000
+            prefiller_release_state = await release_prefiller(
+                prefiller_state,
+                prompt_token_count,
+                success=True,
+                prefill_ms=prefill_ms,
+            )
+            prefiller_released = True
+            route_info.update(
+                {
+                    "pd_slot_count": 0,
+                    "pd_slot_wait_ms": 0.0,
+                    "prefill_ms": prefill_ms,
+                    "prefiller_state_after_release": prefiller_release_state,
+                }
+            )
+            prefill_output = prefill_output.json()
+            stats_calculator.add(time.time() - st)
+
+            complete_payload = dict(route_info)
+            complete_payload.update(
+                {
+                    "total_ms": (time.time() - st) * 1000,
+                    "error": None,
+                }
+            )
+            log_route_event("proxy_route_complete", complete_payload)
+            include_usage = bool(
+                (req_data.get("stream_options") or {}).get("include_usage")
+            )
+            return StreamingResponse(
+                stream_prefill_only_completion_response(prefill_output, include_usage),
+                media_type="application/json",
+            )
 
         decoder_state, decoder_info = await select_decoder(prompt_token_count)
         route_info = dict(decoder_info)
@@ -1027,10 +1184,6 @@ async def handle_completions(request: Request):
         )
         log_route_event("proxy_route_selected", route_info)
 
-        org_max_tokens = req_data["max_tokens"]
-        req_data["prompt"] = tokenize_output["tokens"]
-        req_data["max_tokens"] = 1
-
         # Acquire decoder PD buffer slots before prefill when mode-aware
         # admission is enabled. Delay-pull mode skips buffer-size admission.
         slots, pd_slot_wait_ms, acquired = await acquire_pd_buffer_slots(
@@ -1046,18 +1199,15 @@ async def handle_completions(request: Request):
         }
         num_tp_rank = len(decode_client.init_port or [])
 
-        req_data["kv_transfer_params"] = {
+        prefill_req_data["kv_transfer_params"] = {
             "ret_first_tok": True,
             "disagg_spec": disagg_spec,
         }
 
-        req_data["stream"] = False
-        stream_options = req_data.pop("stream_options", None)
-
         # Send request to prefill service, ignore the response
         prefill_start = time.time()
         prefill_output = await send_request_to_service(
-            prefill_client.client, "/v1/completions", req_data
+            prefill_client.client, "/v1/completions", prefill_req_data
         )
         prefill_ms = (time.time() - prefill_start) * 1000
         prefiller_release_state = await release_prefiller(
@@ -1081,12 +1231,10 @@ async def handle_completions(request: Request):
         et = time.time()
         stats_calculator.add(et - st)
 
-        req_data["max_tokens"] = org_max_tokens - 1
-        req_data["prompt"].append(prefill_output["kv_transfer_params"]["first_tok"])
-        req_data.pop("kv_transfer_params")
-        req_data["stream"] = True
-        if stream_options is not None:
-            req_data["stream_options"] = stream_options
+        decode_req_data["prompt"].append(
+            prefill_output["kv_transfer_params"]["first_tok"]
+        )
+        decode_req_data.pop("kv_transfer_params", None)
 
         route_log_base = dict(route_info)
         log_route_event("proxy_route_prefill_done", route_log_base)
@@ -1127,8 +1275,35 @@ async def handle_completions(request: Request):
 
                 decode_stream_start = time.time()
                 async for chunk in stream_service_response(
-                    decode_client.client, "/v1/completions", req_data
+                    decode_client.client, "/v1/completions", decode_req_data
                 ):
+                    chunk_str = chunk.decode("utf-8")
+                    if chunk_str.startswith("data: ") and not chunk_str.startswith(
+                        "data: [DONE]"
+                    ):
+                        try:
+                            json_str = chunk_str[6:].strip()
+                            if json_str:
+                                completion_data = json.loads(json_str)
+                                usage = completion_data.get("usage")
+                                if usage is not None:
+                                    completion_tokens = usage.get("completion_tokens")
+                                    total_tokens = usage.get("total_tokens")
+                                    if completion_tokens is not None:
+                                        usage["completion_tokens"] = (
+                                            completion_tokens + 1
+                                        )
+                                    if total_tokens is not None:
+                                        usage["total_tokens"] = total_tokens + 1
+                                    chunk = (
+                                        "data: "
+                                        + json.dumps(
+                                            completion_data, separators=(",", ":")
+                                        )
+                                        + "\n\n"
+                                    ).encode()
+                        except (json.JSONDecodeError, KeyError, TypeError):
+                            pass
                     yield chunk
                 decode_stream_ms = (time.time() - decode_stream_start) * 1000
             except BaseException as exc:
@@ -1221,16 +1396,25 @@ async def handle_chat_completions(request: Request):
     decoder_released = False
     route_info = {}
     try:
-        req_data = await request.json()
+        req_data = normalize_chat_request(await request.json())
 
-        tokenization_client = pick_up_tokenization_client(request)
-
-        # For chat completions, we need to tokenize the messages
-        tokenize_output = await send_request_to_service(
-            tokenization_client.client, "/tokenize", {"messages": req_data["messages"]}
+        render_client = round_robin_pick_client(
+            app.state.prefill_clients, next(tokenization_round_robin_counter)
         )
-        tokenize_output = tokenize_output.json()
-        prompt_token_count = len(tokenize_output["tokens"])
+
+        # Render with vLLM's authoritative chat preprocessing so omitted token
+        # limits resolve exactly as they do on the mixed-serving chat endpoint.
+        render_output = await send_request_to_service(
+            render_client.client, "/v1/chat/completions/render", req_data
+        )
+        prompt_token_ids, resolved_max_tokens = parse_chat_render_output(
+            render_output.json()
+        )
+        prompt_token_count = len(prompt_token_ids)
+        prefill_req_data, decode_req_data = build_chat_phase_requests(
+            req_data,
+            prompt_token_ids,
+        )
 
         decoder_state, decoder_info = await select_decoder(prompt_token_count)
         route_info = dict(decoder_info)
@@ -1240,7 +1424,10 @@ async def handle_chat_completions(request: Request):
                 "endpoint": "/v1/chat/completions",
                 "prompt_token_count": prompt_token_count,
                 "chosen_decoder": decoder_state.name,
-                "tokenization_client": tokenization_client.name,
+                "render_client": render_client.name,
+                "resolved_max_tokens": resolved_max_tokens,
+                "response_mode": "decoder-native-chat",
+                "prefill_first_token_exposed": False,
             }
         )
         decode_client = decoder_state.client_info
@@ -1253,15 +1440,6 @@ async def handle_chat_completions(request: Request):
             }
         )
         log_route_event("proxy_route_selected", route_info)
-
-        org_max_tokens = req_data["max_tokens"]
-        req_data["prompt"] = tokenize_output["tokens"]
-        req_data["max_tokens"] = 1
-
-        org_max_completion_tokens = None
-        if "max_completion_tokens" in req_data:
-            org_max_completion_tokens = req_data["max_completion_tokens"]
-            req_data["max_completion_tokens"] = 1
 
         # Acquire decoder PD buffer slots before prefill when mode-aware
         # admission is enabled. Delay-pull mode skips buffer-size admission.
@@ -1279,18 +1457,13 @@ async def handle_chat_completions(request: Request):
 
         num_tp_rank = len(decode_client.init_port or [])
 
-        req_data["kv_transfer_params"] = {
-            "ret_first_tok": True,
-            "disagg_spec": disagg_spec,
-        }
+        prefill_req_data["kv_transfer_params"] = {"disagg_spec": disagg_spec}
 
-        req_data["stream"] = False
-        stream_options = req_data.pop("stream_options", None)
-
-        # Send request to prefill service, get the response
+        # Run the internal prefill. Its sampled token is intentionally discarded;
+        # the decoder produces the complete client-visible Chat response.
         prefill_start = time.time()
-        prefill_output = await send_request_to_service(
-            prefill_client.client, "/v1/completions", req_data
+        await send_request_to_service(
+            prefill_client.client, "/v1/completions", prefill_req_data
         )
         prefill_ms = (time.time() - prefill_start) * 1000
         prefiller_release_state = await release_prefiller(
@@ -1309,154 +1482,105 @@ async def handle_chat_completions(request: Request):
             }
         )
 
-        prefill_output = prefill_output.json()
-
         et = time.time()
         stats_calculator.add(et - st)
-
-        req_data["max_tokens"] = org_max_tokens - 1
-        if org_max_completion_tokens is not None:
-            req_data["max_completion_tokens"] = org_max_completion_tokens - 1
-
-        # Add the first token from prefill to the tokenized messages for decode
-        req_data["prompt"].append(prefill_output["kv_transfer_params"]["first_tok"])
-
-        req_data.pop("kv_transfer_params")
-        req_data["stream"] = True
-        if stream_options is not None:
-            req_data["stream_options"] = stream_options
 
         route_log_base = dict(route_info)
         log_route_event("proxy_route_prefill_done", route_log_base)
 
-        # Stream response from decode service
-        async def generate_stream():
-            nonlocal decoder_released, pd_slots_released
-            kv_ready_wait_ms = None
-            decode_stream_ms = None
-            stream_error = None
-            try:
-                initial_chunk = {
-                    "id": prefill_output["id"],
-                    "object": "chat.completion.chunk",
-                    "created": prefill_output["created"],
-                    "model": prefill_output["model"],
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"role": "assistant", "content": ""},
-                            "logprobs": None,
-                            "finish_reason": None,
-                        }
-                    ],
-                }
-                yield (
-                    "data: " + json.dumps(initial_chunk, separators=(",", ":")) + "\n\n"
-                ).encode()
+        if decode_req_data.get("stream", False):
 
-                head_chunk = {
-                    "id": prefill_output["id"],
-                    "object": "chat.completion.chunk",
-                    "created": prefill_output["created"],
-                    "model": prefill_output["model"],
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"content": prefill_output["choices"][0]["text"]},
-                            "logprobs": None,
-                            "finish_reason": None,
-                        }
-                    ],
-                }
-                yield (
-                    "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
-                ).encode()
+            async def generate_stream():
+                nonlocal decoder_released, pd_slots_released
+                kv_ready_wait_ms = None
+                decode_stream_ms = None
+                stream_error = None
+                try:
+                    kv_ready_wait_start = time.time()
+                    await wait_decode_kv_ready(req_id, num_tp_rank)
+                    kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
+                    if acquired:
+                        await release_pd_buffer_slots(decoder_state, slots)
+                        pd_slots_released = True
 
-                kv_ready_wait_start = time.time()
-                await wait_decode_kv_ready(req_id, num_tp_rank)
-                kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
-                if acquired:
-                    await release_pd_buffer_slots(decoder_state, slots)
-                    pd_slots_released = True
-
-                decode_stream_start = time.time()
-                # Stream and convert completion format chunks to chat completion format
-                async for chunk in stream_service_response(
-                    decode_client.client, "/v1/completions", req_data
-                ):
-                    chunk_str = chunk.decode("utf-8")
-                    if chunk_str.startswith("data: ") and not chunk_str.startswith(
-                        "data: [DONE]"
+                    decode_stream_start = time.time()
+                    async for chunk in stream_service_response(
+                        decode_client.client,
+                        "/v1/chat/completions",
+                        decode_req_data,
                     ):
-                        try:
-                            json_str = chunk_str[6:].strip()  # Remove 'data: ' prefix
-                            if json_str:
-                                completion_data = json.loads(json_str)
-                                chat_completion_data = {
-                                    "id": completion_data["id"],
-                                    "object": "chat.completion.chunk",
-                                    "created": completion_data["created"],
-                                    "model": completion_data["model"],
-                                    "choices": [
-                                        {
-                                            "index": 0,
-                                            "delta": {
-                                                "content": completion_data["choices"][
-                                                    0
-                                                ]["text"]
-                                            },
-                                            "logprobs": completion_data["choices"][
-                                                0
-                                            ].get("logprobs"),
-                                            "finish_reason": completion_data["choices"][
-                                                0
-                                            ].get("finish_reason"),
-                                        }
-                                    ],
-                                }
-                                converted_chunk = (
-                                    "data: "
-                                    + json.dumps(
-                                        chat_completion_data, separators=(",", ":")
-                                    )
-                                    + "\n\n"
-                                ).encode()
-                                yield converted_chunk
-                        except (json.JSONDecodeError, KeyError):
-                            yield chunk
-                    else:
                         yield chunk
-                decode_stream_ms = (time.time() - decode_stream_start) * 1000
-            except BaseException as exc:
-                stream_error = str(exc)
-                raise
-            finally:
-                if acquired and not pd_slots_released:
-                    await release_pd_buffer_slots(decoder_state, slots)
-                    pd_slots_released = True
-                decoder_release_state = None
-                if decoder_state is not None and not decoder_released:
-                    decoder_release_state = await release_decoder(
-                        decoder_state,
-                        prompt_token_count,
-                        success=stream_error is None,
-                        decode_ms=decode_stream_ms,
-                        error=stream_error,
+                    decode_stream_ms = (time.time() - decode_stream_start) * 1000
+                except BaseException as exc:
+                    stream_error = str(exc)
+                    raise
+                finally:
+                    if acquired and not pd_slots_released:
+                        await release_pd_buffer_slots(decoder_state, slots)
+                        pd_slots_released = True
+                    decoder_release_state = None
+                    if decoder_state is not None and not decoder_released:
+                        decoder_release_state = await release_decoder(
+                            decoder_state,
+                            prompt_token_count,
+                            success=stream_error is None,
+                            decode_ms=decode_stream_ms,
+                            error=stream_error,
+                        )
+                        decoder_released = True
+                    complete_payload = dict(route_log_base)
+                    complete_payload.update(
+                        {
+                            "kv_ready_wait_ms": kv_ready_wait_ms,
+                            "decode_stream_ms": decode_stream_ms,
+                            "decoder_state_after_release": decoder_release_state,
+                            "total_ms": (time.time() - st) * 1000,
+                            "error": stream_error,
+                        }
                     )
-                    decoder_released = True
-                complete_payload = dict(route_log_base)
-                complete_payload.update(
-                    {
-                        "kv_ready_wait_ms": kv_ready_wait_ms,
-                        "decode_stream_ms": decode_stream_ms,
-                        "decoder_state_after_release": decoder_release_state,
-                        "total_ms": (time.time() - st) * 1000,
-                        "error": stream_error,
-                    }
-                )
-                log_route_event("proxy_route_complete", complete_payload)
+                    log_route_event("proxy_route_complete", complete_payload)
 
-        return StreamingResponse(generate_stream(), media_type="application/json")
+            return StreamingResponse(generate_stream(), media_type="text/event-stream")
+
+        kv_ready_wait_start = time.time()
+        await wait_decode_kv_ready(req_id, num_tp_rank)
+        kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
+        if acquired:
+            await release_pd_buffer_slots(decoder_state, slots)
+            pd_slots_released = True
+
+        decode_response_start = time.time()
+        decode_response = await send_request_to_service(
+            decode_client.client,
+            "/v1/chat/completions",
+            decode_req_data,
+        )
+        decode_response_ms = (time.time() - decode_response_start) * 1000
+        decoder_release_state = await release_decoder(
+            decoder_state,
+            prompt_token_count,
+            success=True,
+            decode_ms=decode_response_ms,
+        )
+        decoder_released = True
+        complete_payload = dict(route_log_base)
+        complete_payload.update(
+            {
+                "kv_ready_wait_ms": kv_ready_wait_ms,
+                "decode_response_ms": decode_response_ms,
+                "decoder_state_after_release": decoder_release_state,
+                "total_ms": (time.time() - st) * 1000,
+                "error": None,
+            }
+        )
+        log_route_event("proxy_route_complete", complete_payload)
+        content_type = decode_response.headers.get("content-type")
+        headers = {"content-type": content_type} if content_type else None
+        return Response(
+            content=decode_response.content,
+            status_code=decode_response.status_code,
+            headers=headers,
+        )
 
     except Exception as e:
         if prefiller_state is not None and not prefiller_released:

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -29,13 +29,21 @@ import zmq.asyncio
 logger = init_logger(__name__)
 
 PREFILL_REQUEST_ALPHA = 256
+PD_TRANSFER_MODE_PUSH = "push"
+PD_TRANSFER_MODE_EAGER_PULL = "eager_pull"
+PD_TRANSFER_MODE_DELAY_PULL = "delay_pull"
+PD_BUFFER_ADMISSION_MODES = {
+    PD_TRANSFER_MODE_PUSH,
+    PD_TRANSFER_MODE_EAGER_PULL,
+}
 
 
 class WeightedSemaphore:
     """Async semaphore with variable-weight acquire.
 
     Limits in-flight PD token usage: each request holds ceil(L/chunk_size)
-    slots until decoding starts, preventing decoder buffer exhaustion deadlocks.
+    slots until decoding starts, preventing decoder buffer exhaustion deadlocks
+    in push and eager-pull modes.
     """
 
     def __init__(self, capacity: int) -> None:
@@ -170,10 +178,16 @@ async def lifespan(app: FastAPI):
         len(dec_hosts) == 1 and len(dec_ports) == 1 and global_args.num_decoders > 1
     )
 
-    kv_bytes_per_token = compute_kv_bytes_per_token(global_args.model)
-    pd_capacity_slots = global_args.pd_buffer_size // (
-        kv_bytes_per_token * global_args.chunk_size
+    pd_buffer_admission_enabled = (
+        global_args.pd_transfer_mode in PD_BUFFER_ADMISSION_MODES
     )
+    kv_bytes_per_token = None
+    pd_capacity_slots = None
+    if pd_buffer_admission_enabled:
+        kv_bytes_per_token = compute_kv_bytes_per_token(global_args.model)
+        pd_capacity_slots = global_args.pd_buffer_size // (
+            kv_bytes_per_token * global_args.chunk_size
+        )
 
     for i, (host, port) in enumerate(decoder_pairs):
         decoder_base_url = f"http://{host}:{int(port)}"
@@ -204,7 +218,12 @@ async def lifespan(app: FastAPI):
                 port=int(port),
                 init_port=init_ports,
                 alloc_port=alloc_ports,
-                pd_buffer_semaphore=WeightedSemaphore(pd_capacity_slots),
+                pd_buffer_semaphore=(
+                    WeightedSemaphore(pd_capacity_slots)
+                    if pd_capacity_slots is not None
+                    else None
+                ),
+                pd_transfer_mode=global_args.pd_transfer_mode,
             )
         )
 
@@ -212,15 +231,25 @@ async def lifespan(app: FastAPI):
 
     app.state.zmq_task = asyncio.create_task(zmq_pull_server())
 
-    logger.info(
-        "Per-decoder PD buffer semaphore: capacity=%d slots per decoder"
-        " (%d bytes / (%d bytes/tok * %d chunk_size)) for model %s.",
-        pd_capacity_slots,
-        global_args.pd_buffer_size,
-        kv_bytes_per_token,
-        global_args.chunk_size,
-        global_args.model,
-    )
+    if pd_buffer_admission_enabled:
+        logger.info(
+            "Per-decoder PD buffer semaphore: transfer_mode=%s capacity=%d"
+            " slots per decoder (%d bytes / (%d bytes/tok * %d chunk_size))"
+            " for model %s.",
+            global_args.pd_transfer_mode,
+            pd_capacity_slots,
+            global_args.pd_buffer_size,
+            kv_bytes_per_token,
+            global_args.chunk_size,
+            global_args.model,
+        )
+    else:
+        logger.info(
+            "Per-decoder PD buffer admission disabled for transfer_mode=%s;"
+            " --pd-buffer-size=%d is ignored by proxy admission control.",
+            global_args.pd_transfer_mode,
+            global_args.pd_buffer_size,
+        )
 
     yield
 
@@ -321,17 +350,36 @@ def parse_args():
     parser.add_argument("--proxy-host", type=str, default="localhost")
     parser.add_argument("--proxy-port", type=int, default=8500)
 
-    # PD buffer concurrency limiting. A weighted semaphore caps in-flight
-    # chunk slots to prevent decoder buffer exhaustion deadlocks.
+    # PD buffer concurrency limiting. In push and eager-pull modes, a weighted
+    # semaphore caps in-flight chunk slots to prevent decoder buffer exhaustion.
+    # Delay-pull mode does not pre-allocate the full decoder-side KV payload, so
+    # this buffer-size based admission control is disabled in that mode.
     # capacity_slots = pd_buffer_size // (kv_bytes_per_token * chunk_size)
     # kv_bytes_per_token is derived from the model config automatically.
+    parser.add_argument(
+        "--pd-transfer-mode",
+        type=str,
+        choices=[
+            PD_TRANSFER_MODE_PUSH,
+            PD_TRANSFER_MODE_EAGER_PULL,
+            PD_TRANSFER_MODE_DELAY_PULL,
+        ],
+        default=PD_TRANSFER_MODE_PUSH,
+        help=(
+            "PD transfer mode used by LMCache-Ascend. push and eager_pull"
+            " enable proxy-side PD buffer admission control; delay_pull uses"
+            " decoder load balancing only and ignores --pd-buffer-size for"
+            " proxy admission. Default: push."
+        ),
+    )
     parser.add_argument(
         "--model",
         type=str,
         default="meta-llama/Llama-3.1-8B-Instruct",
         help=(
             "HuggingFace model name or local path. Used to derive"
-            " kv_bytes_per_token for the PD buffer semaphore capacity."
+            " kv_bytes_per_token for the PD buffer semaphore capacity when"
+            " proxy-side PD buffer admission is enabled."
         ),
     )
     parser.add_argument(
@@ -340,8 +388,9 @@ def parse_args():
         default=2 * 1024 * 1024 * 1024,  # 2 GB
         help=(
             "PD transfer buffer size in bytes (must match the decoder's"
-            " LMCache config). Used to derive the in-flight slot capacity."
-            " Default: 2 GB."
+            " LMCache config). Used to derive the in-flight slot capacity in"
+            " push and eager_pull modes. Ignored by proxy admission control in"
+            " delay_pull mode. Default: 2 GB."
         ),
     )
     parser.add_argument(
@@ -414,7 +463,8 @@ class DecoderState:
     port: int
     init_port: list[int]
     alloc_port: list[int]
-    pd_buffer_semaphore: WeightedSemaphore
+    pd_buffer_semaphore: Optional[WeightedSemaphore] = None
+    pd_transfer_mode: str = PD_TRANSFER_MODE_PUSH
     active_decode_tokens: int = 0
     active_decode_requests: int = 0
     total_decode_tokens: int = 0
@@ -431,12 +481,15 @@ class DecoderState:
         return self.active_decode_tokens
 
     def snapshot(self) -> dict:
+        pd_buffer_admission_enabled = self.pd_buffer_semaphore is not None
         return {
             "name": self.name,
             "host": self.host,
             "port": self.port,
             "init_port": self.init_port,
             "alloc_port": self.alloc_port,
+            "pd_transfer_mode": self.pd_transfer_mode,
+            "pd_buffer_admission_enabled": pd_buffer_admission_enabled,
             "active_decode_tokens": self.active_decode_tokens,
             "active_decode_requests": self.active_decode_requests,
             "load_score": self.load_score,
@@ -446,8 +499,16 @@ class DecoderState:
             "last_error": self.last_error,
             "last_decode_ms": self.last_decode_ms,
             "decode_ms_ewma": self.decode_ms_ewma,
-            "pd_slots_available": self.pd_buffer_semaphore.available,
-            "pd_slots_capacity": self.pd_buffer_semaphore.capacity,
+            "pd_slots_available": (
+                self.pd_buffer_semaphore.available
+                if pd_buffer_admission_enabled
+                else None
+            ),
+            "pd_slots_capacity": (
+                self.pd_buffer_semaphore.capacity
+                if pd_buffer_admission_enabled
+                else None
+            ),
         }
 
 
@@ -613,6 +674,8 @@ async def select_decoder(
         return selected, {
             "decoder_policy": "min_active_decode_tokens",
             "decode_score": prompt_token_count,
+            "pd_transfer_mode": selected.pd_transfer_mode,
+            "pd_buffer_admission_enabled": (selected.pd_buffer_semaphore is not None),
             "selected_decoder": selected.name,
             "selected_decoder_load_before": selected_load_before,
             "selected_decoder_state_after": selected.snapshot(),
@@ -769,6 +832,22 @@ def _format_decoder_active(state: dict) -> str:
     )
 
 
+def _format_pd_slots(state: dict) -> str:
+    if not state:
+        return "-"
+    if not state.get("pd_buffer_admission_enabled", False):
+        return "disabled"
+    return (
+        f"{state.get('pd_slots_available', '-')}/{state.get('pd_slots_capacity', '-')}"
+    )
+
+
+def _format_pd_buffer_admission(value) -> str:
+    if value is None:
+        return "-"
+    return "enabled" if value else "disabled"
+
+
 def _format_decoder_candidate(state: dict) -> str:
     name = state.get("name", "-")
     host = state.get("host", "-")
@@ -777,8 +856,7 @@ def _format_decoder_candidate(state: dict) -> str:
         f"{name}@{host}:{port}"
         f"(load={state.get('load_score', '-')},"
         f"active={_format_decoder_active(state)},"
-        f"pd_slots={state.get('pd_slots_available', '-')}/"
-        f"{state.get('pd_slots_capacity', '-')},"
+        f"pd_slots={_format_pd_slots(state)},"
         f"total={state.get('total_decode_requests', '-')}req/"
         f"{state.get('total_decode_tokens', '-')}tok,"
         f"failed={state.get('failed_decode_requests', '-')},"
@@ -814,6 +892,9 @@ def _format_route_summary(event: str, payload: dict) -> str:
         f" - chosen_decoder: {payload.get('chosen_decoder', '-')}",
         f" - prompt_token_count: {payload.get('prompt_token_count', '-')}",
         f" - prefill_ms: {_format_metric(payload.get('prefill_ms'))}",
+        f" - pd_transfer_mode: {payload.get('pd_transfer_mode', '-')}",
+        " - pd_buffer_admission: "
+        f"{_format_pd_buffer_admission(payload.get('pd_buffer_admission_enabled'))}",
         f" - pd_slot_count: {payload.get('pd_slot_count', '-')}",
         f" - pd_slot_wait_ms: {_format_metric(payload.get('pd_slot_wait_ms'))}",
         " - prefiller_load_before: "
@@ -872,6 +953,31 @@ async def wait_decode_kv_ready(req_id: str, num_tp_rank: int):
     app.state.finished_reqs.pop(req_id)
 
 
+async def acquire_pd_buffer_slots(
+    decoder_state: DecoderState,
+    prompt_token_count: int,
+) -> tuple[int, float, bool]:
+    """Acquire decoder PD buffer slots when mode-aware admission is enabled."""
+    if decoder_state.pd_buffer_semaphore is None:
+        return 0, 0.0, False
+
+    slots = math.ceil(prompt_token_count / global_args.chunk_size)
+    pd_slot_wait_start = time.time()
+    await decoder_state.pd_buffer_semaphore.acquire(slots)
+    pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
+    return slots, pd_slot_wait_ms, True
+
+
+async def release_pd_buffer_slots(
+    decoder_state: DecoderState,
+    slots: int,
+) -> None:
+    """Release decoder PD buffer slots if mode-aware admission is enabled."""
+    if decoder_state.pd_buffer_semaphore is None:
+        return
+    await decoder_state.pd_buffer_semaphore.release(slots)
+
+
 @app.post("/v1/completions")
 async def handle_completions(request: Request):
     global counter, stats_calculator
@@ -925,13 +1031,12 @@ async def handle_completions(request: Request):
         req_data["prompt"] = tokenize_output["tokens"]
         req_data["max_tokens"] = 1
 
-        # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
-        slots = math.ceil(prompt_token_count / global_args.chunk_size)
-        pd_slot_wait_ms = 0.0
-        pd_slot_wait_start = time.time()
-        await decoder_state.pd_buffer_semaphore.acquire(slots)
-        pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
-        acquired = True
+        # Acquire decoder PD buffer slots before prefill when mode-aware
+        # admission is enabled. Delay-pull mode skips buffer-size admission.
+        slots, pd_slot_wait_ms, acquired = await acquire_pd_buffer_slots(
+            decoder_state,
+            prompt_token_count,
+        )
 
         disagg_spec = {
             "req_id": req_id,
@@ -1017,7 +1122,7 @@ async def handle_completions(request: Request):
                 await wait_decode_kv_ready(req_id, num_tp_rank)
                 kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
                 if acquired:
-                    await decoder_state.pd_buffer_semaphore.release(slots)
+                    await release_pd_buffer_slots(decoder_state, slots)
                     pd_slots_released = True
 
                 decode_stream_start = time.time()
@@ -1031,7 +1136,7 @@ async def handle_completions(request: Request):
                 raise
             finally:
                 if acquired and not pd_slots_released:
-                    await decoder_state.pd_buffer_semaphore.release(slots)
+                    await release_pd_buffer_slots(decoder_state, slots)
                     pd_slots_released = True
                 decoder_release_state = None
                 if decoder_state is not None and not decoder_released:
@@ -1076,7 +1181,7 @@ async def handle_completions(request: Request):
             route_info["decoder_state_after_release"] = release_state
             decoder_released = True
         if decoder_state is not None and acquired and not pd_slots_released:
-            await decoder_state.pd_buffer_semaphore.release(slots)
+            await release_pd_buffer_slots(decoder_state, slots)
             pd_slots_released = True
         if route_info:
             error_payload = dict(route_info)
@@ -1158,13 +1263,12 @@ async def handle_chat_completions(request: Request):
             org_max_completion_tokens = req_data["max_completion_tokens"]
             req_data["max_completion_tokens"] = 1
 
-        # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
-        slots = math.ceil(prompt_token_count / global_args.chunk_size)
-        pd_slot_wait_ms = 0.0
-        pd_slot_wait_start = time.time()
-        await decoder_state.pd_buffer_semaphore.acquire(slots)
-        pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
-        acquired = True
+        # Acquire decoder PD buffer slots before prefill when mode-aware
+        # admission is enabled. Delay-pull mode skips buffer-size admission.
+        slots, pd_slot_wait_ms, acquired = await acquire_pd_buffer_slots(
+            decoder_state,
+            prompt_token_count,
+        )
 
         disagg_spec = {
             "req_id": req_id,
@@ -1272,7 +1376,7 @@ async def handle_chat_completions(request: Request):
                 await wait_decode_kv_ready(req_id, num_tp_rank)
                 kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
                 if acquired:
-                    await decoder_state.pd_buffer_semaphore.release(slots)
+                    await release_pd_buffer_slots(decoder_state, slots)
                     pd_slots_released = True
 
                 decode_stream_start = time.time()
@@ -1328,7 +1432,7 @@ async def handle_chat_completions(request: Request):
                 raise
             finally:
                 if acquired and not pd_slots_released:
-                    await decoder_state.pd_buffer_semaphore.release(slots)
+                    await release_pd_buffer_slots(decoder_state, slots)
                     pd_slots_released = True
                 decoder_release_state = None
                 if decoder_state is not None and not decoder_released:
@@ -1373,7 +1477,7 @@ async def handle_chat_completions(request: Request):
             route_info["decoder_state_after_release"] = release_state
             decoder_released = True
         if decoder_state is not None and acquired and not pd_slots_released:
-            await decoder_state.pd_buffer_semaphore.release(slots)
+            await release_pd_buffer_slots(decoder_state, slots)
             pd_slots_released = True
         if route_info:
             error_payload = dict(route_info)

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -15,20 +15,20 @@ import time
 # Third Party
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.pd_backend import (
+    PDMsg,
+    ProxyNotif,
+)
 import httpx
 import msgspec
 import numpy as np
 import zmq
 import zmq.asyncio
 
-# First Party
-from lmcache.logging import init_logger
-from lmcache.v1.storage_backend.pd_backend import (
-    PDMsg,
-    ProxyNotif,
-)
-
 logger = init_logger(__name__)
+
+PREFILL_REQUEST_ALPHA = 256
 
 
 class WeightedSemaphore:
@@ -84,6 +84,11 @@ async def lifespan(app: FastAPI):
     Lifespan context manager to handle startup and shutdown events.
     """
     # Startup: Initialize clients
+    app.state.prefill_clients = []
+    app.state.decode_clients = []
+    app.state.total_clients = []
+    app.state.prefiller_states = []
+    app.state.prefiller_select_seq = 0
 
     # Build prefill clients with CSV-based broadcast pairing
     pref_hosts = global_args.prefiller_host
@@ -127,12 +132,22 @@ async def lifespan(app: FastAPI):
     prefill_pairs = pair_hosts_and_ports(
         pref_hosts, pref_ports, global_args.num_prefillers
     )
-    for host, port in prefill_pairs:
+    for i, (host, port) in enumerate(prefill_pairs):
         prefiller_base_url = f"http://{host}:{int(port)}"
         prefill_client = httpx.AsyncClient(timeout=None, base_url=prefiller_base_url)
-        app.state.prefill_clients.append(
-            ClientInfo(
-                prefill_client,
+        client_info = ClientInfo(
+            prefill_client,
+            host=host,
+            name=f"prefiller-{i}",
+            base_url=prefiller_base_url,
+        )
+        app.state.prefill_clients.append(client_info)
+        app.state.prefiller_states.append(
+            PrefillerState(
+                client_info=client_info,
+                name=client_info.name or f"prefiller-{i}",
+                host=host,
+                port=int(port),
             )
         )
 
@@ -163,9 +178,11 @@ async def lifespan(app: FastAPI):
         app.state.decode_clients.append(
             ClientInfo(
                 decode_client,
-                host,
-                init_ports,
-                alloc_ports,
+                host=host,
+                init_port=init_ports,
+                alloc_port=alloc_ports,
+                name=f"decoder-{i}",
+                base_url=decoder_base_url,
             )
         )
 
@@ -193,9 +210,9 @@ async def lifespan(app: FastAPI):
 
     # Shutdown: Close clients
     for client in app.state.prefill_clients:
-        await client.aclose()
+        await client.client.aclose()
     for client in app.state.decode_clients:
-        await client.aclose()
+        await client.client.aclose()
 
     global run_proxy
     run_proxy = False
@@ -328,17 +345,63 @@ class ClientInfo:
     host: Optional[str] = None
     init_port: Optional[list[int]] = None
     alloc_port: Optional[list[int]] = None
+    name: Optional[str] = None
+    base_url: Optional[str] = None
+
+
+@dataclass
+class PrefillerState:
+    client_info: ClientInfo
+    name: str
+    host: str
+    port: int
+    active_prefill_tokens: int = 0
+    active_prefill_requests: int = 0
+    total_prefill_tokens: int = 0
+    total_prefill_requests: int = 0
+    failed_prefill_requests: int = 0
+    last_error: Optional[str] = None
+    last_prefill_ms: Optional[float] = None
+    prefill_ms_ewma: Optional[float] = None  # Smoothed recent prefill latency in ms.
+    last_success_ts: Optional[float] = None
+    last_selected_seq: int = 0
+
+    @property
+    def load_score(self) -> int:
+        return (
+            self.active_prefill_tokens
+            + self.active_prefill_requests * PREFILL_REQUEST_ALPHA
+        )
+
+    def snapshot(self) -> dict:
+        return {
+            "name": self.name,
+            "host": self.host,
+            "port": self.port,
+            "active_prefill_tokens": self.active_prefill_tokens,
+            "active_prefill_requests": self.active_prefill_requests,
+            "load_score": self.load_score,
+            "total_prefill_tokens": self.total_prefill_tokens,
+            "total_prefill_requests": self.total_prefill_requests,
+            "failed_prefill_requests": self.failed_prefill_requests,
+            "last_error": self.last_error,
+            "last_prefill_ms": self.last_prefill_ms,
+            "prefill_ms_ewma": self.prefill_ms_ewma,
+        }
 
 
 # Initialize variables to hold the persistent clients
 app.state.prefill_clients = []
 app.state.decode_clients = []
 app.state.total_clients = []
+app.state.prefiller_states = []
+app.state.prefiller_lock = asyncio.Lock()
+app.state.prefiller_select_seq = 0
 
 """
-client_request and prefill/decode map
+client_request and tokenization client map
 key:   str    - unique id for requests across same conversation
-value: tuple  - (tokenization_client, prefiller_client, decoder_client)
+value: ClientInfo - tokenization client only
 """
 app.state.bound_clients = {}
 
@@ -425,18 +488,209 @@ async def stream_service_response(
 
 
 def round_robin_pick_client(clients, idx):
+    if not clients:
+        raise ValueError("No clients configured")
     return clients[idx % len(clients)]
 
 
-round_robin_counter = itertools.count()
+tokenization_round_robin_counter = itertools.count()
+decoder_round_robin_counter = itertools.count()
 
 
-def round_robin_pick_clients() -> tuple[ClientInfo, ClientInfo, ClientInfo]:
-    idx = next(round_robin_counter)
-    tokenization_client = round_robin_pick_client(app.state.total_clients, idx)
-    prefill_client = round_robin_pick_client(app.state.prefill_clients, idx)
-    decode_client = round_robin_pick_client(app.state.decode_clients, idx)
-    return tokenization_client, prefill_client, decode_client
+BOUND_CLIENTS_MAX_NUM = 1024 * 1024
+
+BOUND_CLIENT = os.getenv("CLIENT_BOUND", "false").lower() == "true"
+# CLIENT_BOUND_KEY, the field name of the client uid in http request
+CLIENT_BOUND_KEY = os.getenv("CLIENT_BOUND_KEY", "session-id")
+
+
+def pick_up_bound_tokenization_client(client_id: str) -> ClientInfo:
+    if client_id not in app.state.bound_clients:
+        if len(app.state.bound_clients) >= BOUND_CLIENTS_MAX_NUM:
+            # Here simply clear the bound_clients if full
+            app.state.bound_clients.clear()
+        idx = next(tokenization_round_robin_counter)
+        app.state.bound_clients[client_id] = round_robin_pick_client(
+            app.state.total_clients, idx
+        )
+    return app.state.bound_clients[client_id]
+
+
+def pick_up_tokenization_client(request: Request) -> ClientInfo:
+    bound_client_id = request.headers.get(CLIENT_BOUND_KEY) if BOUND_CLIENT else None
+    if bound_client_id:
+        # keeps tokenizer binding. Prefiller selection is load-aware.
+        return pick_up_bound_tokenization_client(bound_client_id)
+    idx = next(tokenization_round_robin_counter)
+    return round_robin_pick_client(app.state.total_clients, idx)
+
+
+def pick_up_decoder_client() -> ClientInfo:
+    idx = next(decoder_round_robin_counter)
+    return round_robin_pick_client(app.state.decode_clients, idx)
+
+
+async def select_prefiller(
+    prompt_token_count: int,
+) -> tuple[PrefillerState, dict]:
+    if not app.state.prefiller_states:
+        raise ValueError("No prefiller clients configured")
+
+    async with app.state.prefiller_lock:
+        candidate_loads = [state.snapshot() for state in app.state.prefiller_states]
+        selected = min(
+            app.state.prefiller_states,
+            key=lambda state: (
+                state.load_score,
+                state.last_selected_seq,
+                state.name,
+            ),
+        )
+        selected_load_before = selected.load_score
+        app.state.prefiller_select_seq += 1
+        selected.last_selected_seq = app.state.prefiller_select_seq
+        selected.active_prefill_tokens += prompt_token_count
+        selected.active_prefill_requests += 1
+        selected.total_prefill_tokens += prompt_token_count
+        selected.total_prefill_requests += 1
+
+        return selected, {
+            "request_alpha": PREFILL_REQUEST_ALPHA,
+            "route_reason": "min_active_prefill_tokens_plus_requests",
+            "prefill_score": prompt_token_count,
+            "selected_prefiller": selected.name,
+            "selected_prefiller_load_before": selected_load_before,
+            "selected_prefiller_state_after": selected.snapshot(),
+            "candidate_prefiller_loads": candidate_loads,
+        }
+
+
+async def release_prefiller(
+    prefiller_state: PrefillerState,
+    prompt_token_count: int,
+    success: bool,
+    prefill_ms: Optional[float] = None,
+    error: Optional[str] = None,
+) -> dict:
+    async with app.state.prefiller_lock:
+        prefiller_state.active_prefill_tokens = max(
+            0, prefiller_state.active_prefill_tokens - prompt_token_count
+        )
+        prefiller_state.active_prefill_requests = max(
+            0, prefiller_state.active_prefill_requests - 1
+        )
+        if success:
+            prefiller_state.last_error = None
+            prefiller_state.last_success_ts = time.time()
+            if prefill_ms is not None:
+                prefiller_state.last_prefill_ms = prefill_ms
+                if prefiller_state.prefill_ms_ewma is None:
+                    prefiller_state.prefill_ms_ewma = prefill_ms
+                else:
+                    prefiller_state.prefill_ms_ewma = (
+                        prefiller_state.prefill_ms_ewma * 0.8 + prefill_ms * 0.2
+                    )
+        else:
+            prefiller_state.failed_prefill_requests += 1
+            prefiller_state.last_error = error
+        return prefiller_state.snapshot()
+
+
+def _format_metric(value, digits: int = 3) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _format_prefiller_active(state: dict) -> str:
+    if not state:
+        return "-"
+    return (
+        f"{state.get('active_prefill_requests', '-')}"
+        f"req/{state.get('active_prefill_tokens', '-')}tok"
+    )
+
+
+def _format_prefiller_candidate(state: dict) -> str:
+    name = state.get("name", "-")
+    host = state.get("host", "-")
+    port = state.get("port", "-")
+    return (
+        f"{name}@{host}:{port}"
+        f"(load={state.get('load_score', '-')},"
+        f"active={_format_prefiller_active(state)},"
+        f"total={state.get('total_prefill_requests', '-')}req/"
+        f"{state.get('total_prefill_tokens', '-')}tok,"
+        f"failed={state.get('failed_prefill_requests', '-')},"
+        f"last_ms={_format_metric(state.get('last_prefill_ms'))},"
+        f"ewma_ms={_format_metric(state.get('prefill_ms_ewma'))})"
+    )
+
+
+def _format_candidate_prefillers(candidate_loads: list[dict]) -> str:
+    if not candidate_loads:
+        return "[]"
+    return (
+        "["
+        + "; ".join(_format_prefiller_candidate(state) for state in candidate_loads)
+        + "]"
+    )
+
+
+def _format_route_summary(event: str, payload: dict) -> str:
+    selected_state = payload.get("selected_prefiller_state_after") or {}
+    released_state = payload.get("prefiller_state_after_release") or {}
+    active_state = released_state or selected_state
+
+    lines = [
+        "===============================",
+        f"Proxy route event: {event}",
+        f" - req_id: {payload.get('req_id', '-')}",
+        f" - endpoint: {payload.get('endpoint', '-')}",
+        f" - chosen_prefiller: {payload.get('chosen_prefiller', '-')}",
+        f" - chosen_decoder: {payload.get('chosen_decoder', '-')}",
+        f" - prompt_token_count: {payload.get('prompt_token_count', '-')}",
+        f" - prefill_ms: {_format_metric(payload.get('prefill_ms'))}",
+        f" - pd_slot_count: {payload.get('pd_slot_count', '-')}",
+        f" - pd_slot_wait_ms: {_format_metric(payload.get('pd_slot_wait_ms'))}",
+        " - prefiller_load_before: "
+        f"{payload.get('selected_prefiller_load_before', '-')}",
+        f" - prefiller_load_after_select: {selected_state.get('load_score', '-')}",
+        f" - prefiller_load_after_release: {released_state.get('load_score', '-')}",
+        f" - prefiller_active_current: {_format_prefiller_active(active_state)}",
+        " - candidate_prefiller_loads: "
+        f"{_format_candidate_prefillers(payload.get('candidate_prefiller_loads', []))}",
+    ]
+
+    if payload.get("kv_ready_wait_ms") is not None:
+        lines.append(
+            f" - kv_ready_wait_ms: {_format_metric(payload['kv_ready_wait_ms'])}"
+        )
+    if payload.get("decode_stream_ms") is not None:
+        lines.append(
+            f" - decode_stream_ms: {_format_metric(payload['decode_stream_ms'])}"
+        )
+    if payload.get("total_ms") is not None:
+        lines.append(f" - total_ms: {_format_metric(payload['total_ms'])}")
+    if payload.get("error") is not None:
+        lines.append(f" - error: {payload['error'] or '-'}")
+
+    lines.append(" ===============================")
+    return "\n" + "\n".join(lines)
+
+
+def log_route_event(event: str, payload: dict):
+    try:
+        logger.info(_format_route_summary(event, payload))
+        logger.debug(
+            "%s_full %s",
+            event,
+            json.dumps(payload, separators=(",", ":"), sort_keys=True),
+        )
+    except TypeError:
+        logger.info("%s %s", event, payload)
 
 
 async def wait_decode_kv_ready(req_id: str, num_tp_rank: int):
@@ -444,31 +698,6 @@ async def wait_decode_kv_ready(req_id: str, num_tp_rank: int):
         await asyncio.sleep(0.0001)  # sleep for 0.1 ms
     logger.debug(f"Prefill node signaled kv ready for req {req_id}")
     app.state.finished_reqs.pop(req_id)
-
-
-BOUND_CLIENTS_MAX_NUM = 1024 * 1024
-
-
-def pick_up_bound_clients(client_id: str) -> tuple[ClientInfo, ClientInfo, ClientInfo]:
-    if client_id not in app.state.bound_clients:
-        if len(app.state.bound_clients) >= BOUND_CLIENTS_MAX_NUM:
-            # Here simply clear the bound_clients if full
-            app.state.bound_clients.clear()
-        app.state.bound_clients[client_id] = round_robin_pick_clients()
-    return app.state.bound_clients[client_id]
-
-
-BOUND_CLIENT = os.getenv("CLIENT_BOUND", "false").lower() == "true"
-# CLIENT_BOUND_KEY, the field name of the client uid in http request
-CLIENT_BOUND_KEY = os.getenv("CLIENT_BOUND_KEY", "session-id")
-
-
-def pick_up_clients(request: Request) -> tuple[ClientInfo, ClientInfo, ClientInfo]:
-    bound_client_id = request.headers.get(CLIENT_BOUND_KEY) if BOUND_CLIENT else None
-    if bound_client_id:
-        # Use or create a persistent set of clients for the session.
-        return pick_up_bound_clients(bound_client_id)
-    return round_robin_pick_clients()
 
 
 @app.post("/v1/completions")
@@ -480,25 +709,49 @@ async def handle_completions(request: Request):
     st = time.time()
     slots = 0  # slots to release on error; set after successful acquire only
     acquired = False
+    pd_slots_released = False
+    prompt_token_count = 0
+    prefiller_state = None
+    prefiller_released = False
+    route_info = {}
     try:
         req_data = await request.json()
 
-        # Pick tokenization, prefill and decode client
-        tokenization_client, prefill_client, decode_client = pick_up_clients(request)
+        tokenization_client = pick_up_tokenization_client(request)
+        decode_client = pick_up_decoder_client()
 
         tokenize_output = await send_request_to_service(
             tokenization_client.client, "/tokenize", {"prompt": req_data["prompt"]}
         )
         tokenize_output = tokenize_output.json()
+        prompt_token_count = len(tokenize_output["tokens"])
+
+        prefiller_state, route_info = await select_prefiller(prompt_token_count)
+        prefill_client = prefiller_state.client_info
+        route_info.update(
+            {
+                "req_id": req_id,
+                "endpoint": "/v1/completions",
+                "prompt_token_count": prompt_token_count,
+                "chosen_prefiller": prefiller_state.name,
+                "chosen_decoder": decode_client.name,
+                "tokenization_client": tokenization_client.name,
+                "decoder_policy": "round_robin",
+            }
+        )
+        log_route_event("proxy_route_selected", route_info)
 
         org_max_tokens = req_data["max_tokens"]
         req_data["prompt"] = tokenize_output["tokens"]
         req_data["max_tokens"] = 1
 
         # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
-        slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
+        slots = math.ceil(prompt_token_count / global_args.chunk_size)
+        pd_slot_wait_ms = 0.0
         if pd_buffer_semaphore is not None:
+            pd_slot_wait_start = time.time()
             await pd_buffer_semaphore.acquire(slots)
+            pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
             acquired = True
 
         disagg_spec = {
@@ -518,8 +771,25 @@ async def handle_completions(request: Request):
         stream_options = req_data.pop("stream_options", None)
 
         # Send request to prefill service, ignore the response
+        prefill_start = time.time()
         prefill_output = await send_request_to_service(
             prefill_client.client, "/v1/completions", req_data
+        )
+        prefill_ms = (time.time() - prefill_start) * 1000
+        prefiller_release_state = await release_prefiller(
+            prefiller_state,
+            prompt_token_count,
+            success=True,
+            prefill_ms=prefill_ms,
+        )
+        prefiller_released = True
+        route_info.update(
+            {
+                "pd_slot_count": slots,
+                "pd_slot_wait_ms": pd_slot_wait_ms,
+                "prefill_ms": prefill_ms,
+                "prefiller_state_after_release": prefiller_release_state,
+            }
         )
 
         prefill_output = prefill_output.json()
@@ -534,44 +804,95 @@ async def handle_completions(request: Request):
         if stream_options is not None:
             req_data["stream_options"] = stream_options
 
+        route_log_base = dict(route_info)
+        log_route_event("proxy_route_prefill_done", route_log_base)
+
         # Stream response from decode service
         async def generate_stream():
-            head_chunk = {
-                "id": prefill_output["id"],
-                "object": "text_completion",
-                "created": prefill_output["created"],
-                "model": prefill_output["model"],
-                "choices": [
-                    {
-                        "index": 0,
-                        "text": prefill_output["choices"][0]["text"],
-                        "logprobs": None,
-                        "finish_reason": None,
-                        "stop_reason": None,
-                    }
-                ],
-                "usage": None,
-            }
-            yield (
-                "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
-            ).encode()
-
+            nonlocal pd_slots_released
+            kv_ready_wait_ms = None
+            decode_stream_ms = None
+            stream_error = None
             try:
-                await wait_decode_kv_ready(req_id, num_tp_rank)
-            finally:
-                if pd_buffer_semaphore is not None:
-                    await pd_buffer_semaphore.release(slots)
+                head_chunk = {
+                    "id": prefill_output["id"],
+                    "object": "text_completion",
+                    "created": prefill_output["created"],
+                    "model": prefill_output["model"],
+                    "choices": [
+                        {
+                            "index": 0,
+                            "text": prefill_output["choices"][0]["text"],
+                            "logprobs": None,
+                            "finish_reason": None,
+                            "stop_reason": None,
+                        }
+                    ],
+                    "usage": None,
+                }
+                yield (
+                    "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
+                ).encode()
 
-            async for chunk in stream_service_response(
-                decode_client.client, "/v1/completions", req_data
-            ):
-                yield chunk
+                kv_ready_wait_start = time.time()
+                await wait_decode_kv_ready(req_id, num_tp_rank)
+                kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
+                if pd_buffer_semaphore is not None and acquired:
+                    await pd_buffer_semaphore.release(slots)
+                    pd_slots_released = True
+
+                decode_stream_start = time.time()
+                async for chunk in stream_service_response(
+                    decode_client.client, "/v1/completions", req_data
+                ):
+                    yield chunk
+                decode_stream_ms = (time.time() - decode_stream_start) * 1000
+            except BaseException as exc:
+                stream_error = str(exc)
+                raise
+            finally:
+                if (
+                    pd_buffer_semaphore is not None
+                    and acquired
+                    and not pd_slots_released
+                ):
+                    await pd_buffer_semaphore.release(slots)
+                    pd_slots_released = True
+                complete_payload = dict(route_log_base)
+                complete_payload.update(
+                    {
+                        "kv_ready_wait_ms": kv_ready_wait_ms,
+                        "decode_stream_ms": decode_stream_ms,
+                        "total_ms": (time.time() - st) * 1000,
+                        "error": stream_error,
+                    }
+                )
+                log_route_event("proxy_route_complete", complete_payload)
 
         return StreamingResponse(generate_stream(), media_type="application/json")
 
     except Exception as e:
-        if pd_buffer_semaphore is not None and acquired:
+        if prefiller_state is not None and not prefiller_released:
+            release_state = await release_prefiller(
+                prefiller_state,
+                prompt_token_count,
+                success=False,
+                error=str(e),
+            )
+            route_info["prefiller_state_after_release"] = release_state
+        if pd_buffer_semaphore is not None and acquired and not pd_slots_released:
             await pd_buffer_semaphore.release(slots)
+            pd_slots_released = True
+        if route_info:
+            error_payload = dict(route_info)
+            error_payload.update(
+                {
+                    "pd_slot_count": slots,
+                    "total_ms": (time.time() - st) * 1000,
+                    "error": str(e),
+                }
+            )
+            log_route_event("proxy_route_error", error_payload)
         # Standard
         import sys
         import traceback
@@ -592,17 +913,38 @@ async def handle_chat_completions(request: Request):
     st = time.time()
     slots = 0  # slots to release on error; set after successful acquire only
     acquired = False
+    pd_slots_released = False
+    prompt_token_count = 0
+    prefiller_state = None
+    prefiller_released = False
+    route_info = {}
     try:
         req_data = await request.json()
 
-        # Pick tokenization, prefill and decode client
-        tokenization_client, prefill_client, decode_client = pick_up_clients(request)
+        tokenization_client = pick_up_tokenization_client(request)
+        decode_client = pick_up_decoder_client()
 
         # For chat completions, we need to tokenize the messages
         tokenize_output = await send_request_to_service(
             tokenization_client.client, "/tokenize", {"messages": req_data["messages"]}
         )
         tokenize_output = tokenize_output.json()
+        prompt_token_count = len(tokenize_output["tokens"])
+
+        prefiller_state, route_info = await select_prefiller(prompt_token_count)
+        prefill_client = prefiller_state.client_info
+        route_info.update(
+            {
+                "req_id": req_id,
+                "endpoint": "/v1/chat/completions",
+                "prompt_token_count": prompt_token_count,
+                "chosen_prefiller": prefiller_state.name,
+                "chosen_decoder": decode_client.name,
+                "tokenization_client": tokenization_client.name,
+                "decoder_policy": "round_robin",
+            }
+        )
+        log_route_event("proxy_route_selected", route_info)
 
         org_max_tokens = req_data["max_tokens"]
         req_data["prompt"] = tokenize_output["tokens"]
@@ -614,9 +956,12 @@ async def handle_chat_completions(request: Request):
             req_data["max_completion_tokens"] = 1
 
         # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
-        slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
+        slots = math.ceil(prompt_token_count / global_args.chunk_size)
+        pd_slot_wait_ms = 0.0
         if pd_buffer_semaphore is not None:
+            pd_slot_wait_start = time.time()
             await pd_buffer_semaphore.acquire(slots)
+            pd_slot_wait_ms = (time.time() - pd_slot_wait_start) * 1000
             acquired = True
 
         disagg_spec = {
@@ -637,8 +982,25 @@ async def handle_chat_completions(request: Request):
         stream_options = req_data.pop("stream_options", None)
 
         # Send request to prefill service, get the response
+        prefill_start = time.time()
         prefill_output = await send_request_to_service(
             prefill_client.client, "/v1/completions", req_data
+        )
+        prefill_ms = (time.time() - prefill_start) * 1000
+        prefiller_release_state = await release_prefiller(
+            prefiller_state,
+            prompt_token_count,
+            success=True,
+            prefill_ms=prefill_ms,
+        )
+        prefiller_released = True
+        route_info.update(
+            {
+                "pd_slot_count": slots,
+                "pd_slot_wait_ms": pd_slot_wait_ms,
+                "prefill_ms": prefill_ms,
+                "prefiller_state_after_release": prefiller_release_state,
+            }
         )
 
         prefill_output = prefill_output.json()
@@ -658,102 +1020,153 @@ async def handle_chat_completions(request: Request):
         if stream_options is not None:
             req_data["stream_options"] = stream_options
 
+        route_log_base = dict(route_info)
+        log_route_event("proxy_route_prefill_done", route_log_base)
+
         # Stream response from decode service
         async def generate_stream():
-            initial_chunk = {
-                "id": prefill_output["id"],
-                "object": "chat.completion.chunk",
-                "created": prefill_output["created"],
-                "model": prefill_output["model"],
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {"role": "assistant", "content": ""},
-                        "logprobs": None,
-                        "finish_reason": None,
-                    }
-                ],
-            }
-            yield (
-                "data: " + json.dumps(initial_chunk, separators=(",", ":")) + "\n\n"
-            ).encode()
-
-            head_chunk = {
-                "id": prefill_output["id"],
-                "object": "chat.completion.chunk",
-                "created": prefill_output["created"],
-                "model": prefill_output["model"],
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {"content": prefill_output["choices"][0]["text"]},
-                        "logprobs": None,
-                        "finish_reason": None,
-                    }
-                ],
-            }
-            yield (
-                "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
-            ).encode()
-
+            nonlocal pd_slots_released
+            kv_ready_wait_ms = None
+            decode_stream_ms = None
+            stream_error = None
             try:
-                await wait_decode_kv_ready(req_id, num_tp_rank)
-            finally:
-                if pd_buffer_semaphore is not None:
-                    await pd_buffer_semaphore.release(slots)
+                initial_chunk = {
+                    "id": prefill_output["id"],
+                    "object": "chat.completion.chunk",
+                    "created": prefill_output["created"],
+                    "model": prefill_output["model"],
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": ""},
+                            "logprobs": None,
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield (
+                    "data: " + json.dumps(initial_chunk, separators=(",", ":")) + "\n\n"
+                ).encode()
 
-            # Stream and convert completion format chunks to chat completion format
-            async for chunk in stream_service_response(
-                decode_client.client, "/v1/completions", req_data
-            ):
-                chunk_str = chunk.decode("utf-8")
-                if chunk_str.startswith("data: ") and not chunk_str.startswith(
-                    "data: [DONE]"
+                head_chunk = {
+                    "id": prefill_output["id"],
+                    "object": "chat.completion.chunk",
+                    "created": prefill_output["created"],
+                    "model": prefill_output["model"],
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": prefill_output["choices"][0]["text"]},
+                            "logprobs": None,
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield (
+                    "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
+                ).encode()
+
+                kv_ready_wait_start = time.time()
+                await wait_decode_kv_ready(req_id, num_tp_rank)
+                kv_ready_wait_ms = (time.time() - kv_ready_wait_start) * 1000
+                if pd_buffer_semaphore is not None and acquired:
+                    await pd_buffer_semaphore.release(slots)
+                    pd_slots_released = True
+
+                decode_stream_start = time.time()
+                # Stream and convert completion format chunks to chat completion format
+                async for chunk in stream_service_response(
+                    decode_client.client, "/v1/completions", req_data
                 ):
-                    try:
-                        json_str = chunk_str[6:].strip()  # Remove 'data: ' prefix
-                        if json_str:
-                            completion_data = json.loads(json_str)
-                            chat_completion_data = {
-                                "id": completion_data["id"],
-                                "object": "chat.completion.chunk",
-                                "created": completion_data["created"],
-                                "model": completion_data["model"],
-                                "choices": [
-                                    {
-                                        "index": 0,
-                                        "delta": {
-                                            "content": completion_data["choices"][0][
-                                                "text"
-                                            ]
-                                        },
-                                        "logprobs": completion_data["choices"][0].get(
-                                            "logprobs"
-                                        ),
-                                        "finish_reason": completion_data["choices"][
-                                            0
-                                        ].get("finish_reason"),
-                                    }
-                                ],
-                            }
-                            converted_chunk = (
-                                "data: "
-                                + json.dumps(
-                                    chat_completion_data, separators=(",", ":")
-                                )
-                                + "\n\n"
-                            ).encode()
-                            yield converted_chunk
-                    except (json.JSONDecodeError, KeyError):
+                    chunk_str = chunk.decode("utf-8")
+                    if chunk_str.startswith("data: ") and not chunk_str.startswith(
+                        "data: [DONE]"
+                    ):
+                        try:
+                            json_str = chunk_str[6:].strip()  # Remove 'data: ' prefix
+                            if json_str:
+                                completion_data = json.loads(json_str)
+                                chat_completion_data = {
+                                    "id": completion_data["id"],
+                                    "object": "chat.completion.chunk",
+                                    "created": completion_data["created"],
+                                    "model": completion_data["model"],
+                                    "choices": [
+                                        {
+                                            "index": 0,
+                                            "delta": {
+                                                "content": completion_data["choices"][
+                                                    0
+                                                ]["text"]
+                                            },
+                                            "logprobs": completion_data["choices"][
+                                                0
+                                            ].get("logprobs"),
+                                            "finish_reason": completion_data["choices"][
+                                                0
+                                            ].get("finish_reason"),
+                                        }
+                                    ],
+                                }
+                                converted_chunk = (
+                                    "data: "
+                                    + json.dumps(
+                                        chat_completion_data, separators=(",", ":")
+                                    )
+                                    + "\n\n"
+                                ).encode()
+                                yield converted_chunk
+                        except (json.JSONDecodeError, KeyError):
+                            yield chunk
+                    else:
                         yield chunk
-                else:
-                    yield chunk
+                decode_stream_ms = (time.time() - decode_stream_start) * 1000
+            except BaseException as exc:
+                stream_error = str(exc)
+                raise
+            finally:
+                if (
+                    pd_buffer_semaphore is not None
+                    and acquired
+                    and not pd_slots_released
+                ):
+                    await pd_buffer_semaphore.release(slots)
+                    pd_slots_released = True
+                complete_payload = dict(route_log_base)
+                complete_payload.update(
+                    {
+                        "kv_ready_wait_ms": kv_ready_wait_ms,
+                        "decode_stream_ms": decode_stream_ms,
+                        "total_ms": (time.time() - st) * 1000,
+                        "error": stream_error,
+                    }
+                )
+                log_route_event("proxy_route_complete", complete_payload)
 
         return StreamingResponse(generate_stream(), media_type="application/json")
 
     except Exception as e:
-        if pd_buffer_semaphore is not None and acquired:
+        if prefiller_state is not None and not prefiller_released:
+            release_state = await release_prefiller(
+                prefiller_state,
+                prompt_token_count,
+                success=False,
+                error=str(e),
+            )
+            route_info["prefiller_state_after_release"] = release_state
+        if pd_buffer_semaphore is not None and acquired and not pd_slots_released:
             await pd_buffer_semaphore.release(slots)
+            pd_slots_released = True
+        if route_info:
+            error_payload = dict(route_info)
+            error_payload.update(
+                {
+                    "pd_slot_count": slots,
+                    "total_ms": (time.time() - st) * 1000,
+                    "error": str(e),
+                }
+            )
+            log_route_event("proxy_route_error", error_payload)
         # Standard
         import sys
         import traceback

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -104,6 +104,9 @@ async def lifespan(app: FastAPI):
     """
     Lifespan context manager to handle startup and shutdown events.
     """
+    global run_proxy
+    run_proxy = True
+
     # Startup: Initialize clients
     app.state.prefill_clients = []
     app.state.decode_clients = []
@@ -259,17 +262,19 @@ async def lifespan(app: FastAPI):
             global_args.pd_buffer_size,
         )
 
-    yield
-
-    # Shutdown: Close clients
-    for client in app.state.prefill_clients:
-        await client.client.aclose()
-    for client in app.state.decode_clients:
-        await client.client.aclose()
-
-    global run_proxy
-    run_proxy = False
-    await app.state.zmq_task  # Wait for background task to finish
+    try:
+        yield
+    finally:
+        run_proxy = False
+        # Changing the loop flag cannot wake a pending socket.recv().
+        app.state.zmq_task.cancel()
+        try:
+            await app.state.zmq_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            for client in app.state.total_clients:
+                await client.client.aclose()
 
 
 # Update FastAPI app initialization to use lifespan
@@ -569,44 +574,45 @@ async def zmq_pull_server():
     socket = zmq_ctx.socket(zmq.PULL)
     proxy_url = f"{global_args.proxy_host}:{global_args.proxy_port}"
     try:
-        socket.bind(f"tcp://{proxy_url}")
-    except zmq.ZMQError:
-        logger.exception("ZMQ proxy server failed to bind on %s", proxy_url)
-        return
-    logger.info("ZMQ proxy server started on %s", proxy_url)
-
-    while run_proxy:
         try:
-            msg_bytes = await socket.recv()
-        except zmq.Again:
-            await asyncio.sleep(0.01)  # Avoid busy loop
-            continue
-        except zmq.ZMQError as exc:
-            if exc.errno in (zmq.ETERM, zmq.ENOTSOCK):
-                break
-            logger.warning("ZMQ recv error: %s", exc)
-            await asyncio.sleep(0.05)
-            continue
+            socket.bind(f"tcp://{proxy_url}")
+        except zmq.ZMQError:
+            logger.exception("ZMQ proxy server failed to bind on %s", proxy_url)
+            return
+        logger.info("ZMQ proxy server started on %s", proxy_url)
 
-        try:
-            msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
-        except msgspec.DecodeError as exc:
-            logger.warning("ZMQ received non-PD message: %s", exc)
-            continue
-        except Exception as exc:
-            logger.exception("ZMQ message decode failed: %s", exc)
-            continue
+        while run_proxy:
+            try:
+                msg_bytes = await socket.recv()
+            except zmq.Again:
+                await asyncio.sleep(0.01)  # Avoid busy loop
+                continue
+            except zmq.ZMQError as exc:
+                if exc.errno in (zmq.ETERM, zmq.ENOTSOCK):
+                    break
+                logger.warning("ZMQ recv error: %s", exc)
+                await asyncio.sleep(0.05)
+                continue
 
-        if not isinstance(msg, ProxyNotif):
-            logger.debug("ZMQ ignored message type: %s", type(msg).__name__)
-            continue
+            try:
+                msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
+            except msgspec.DecodeError as exc:
+                logger.warning("ZMQ received non-PD message: %s", exc)
+                continue
+            except Exception as exc:
+                logger.exception("ZMQ message decode failed: %s", exc)
+                continue
 
-        req_id = msg.req_id
-        app.state.finished_reqs[req_id] += 1
-        logger.debug("Prefill of req %s done.", req_id)
+            if not isinstance(msg, ProxyNotif):
+                logger.debug("ZMQ ignored message type: %s", type(msg).__name__)
+                continue
 
-    socket.close()
-    logger.info("ZMQ PULL server stopped.")
+            req_id = msg.req_id
+            app.state.finished_reqs[req_id] += 1
+            logger.debug("Prefill of req %s done.", req_id)
+    finally:
+        socket.close(linger=0)
+        logger.info("ZMQ PULL server stopped.")
 
 
 async def send_request_to_service(
@@ -1337,7 +1343,7 @@ async def handle_completions(request: Request):
 
         return StreamingResponse(generate_stream(), media_type="application/json")
 
-    except Exception as e:
+    except (Exception, asyncio.CancelledError) as e:
         if prefiller_state is not None and not prefiller_released:
             release_state = await release_prefiller(
                 prefiller_state,
@@ -1582,7 +1588,7 @@ async def handle_chat_completions(request: Request):
             headers=headers,
         )
 
-    except Exception as e:
+    except (Exception, asyncio.CancelledError) as e:
         if prefiller_state is not None and not prefiller_released:
             release_state = await release_prefiller(
                 prefiller_state,

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -507,6 +507,9 @@ def _patch_storage_manager():
         allocate_and_copy_objects as ascend_allocate_and_copy_objects,
     )
     from lmcache_ascend.v1.storage_backend.storage_manager import (
+        batched_contains as ascend_batched_contains,
+    )
+    from lmcache_ascend.v1.storage_backend.storage_manager import (
         batched_get as ascend_batched_get,
     )
     from lmcache_ascend.v1.storage_backend.storage_manager import get as ascend_get
@@ -517,6 +520,7 @@ def _patch_storage_manager():
     )
 
     lm_storage_manager.StorageManager.get = ascend_get
+    lm_storage_manager.StorageManager.batched_contains = ascend_batched_contains
     lm_storage_manager.StorageManager.batched_get = ascend_batched_get
     lm_storage_manager.StorageManager.prefetch_all_done_callback = (
         patched_prefetch_all_done_callback

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -279,8 +279,78 @@ def _patch_config():
         ),
     }
 
+    def _ascend_validate_config(self):
+        if not (self.enable_pd and self.enable_p2p):
+            return lmcache.v1.config._validate_config(self)
+
+        if self.pd_role != "sender":
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_pd=true` and "
+                '`enable_p2p=true` are only supported for `pd_role="sender"` '
+                f"in Phase 1, got pd_role={self.pd_role!r}."
+            )
+
+        if self.enable_async_loading:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_async_loading=true` is "
+                "not supported when `enable_pd=true` and `enable_p2p=true` in "
+                "Phase 1. Use blocking retrieve with enable_async_loading=false."
+            )
+
+        if not self.enable_controller:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_controller=true` is "
+                "required when `enable_p2p=true`."
+            )
+        if self.controller_pull_url is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `controller_pull_url` is "
+                "required when `enable_p2p=true`."
+            )
+        if self.controller_reply_url is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `controller_reply_url` is "
+                "required when `enable_p2p=true`."
+            )
+        if not self.lmcache_worker_ports:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `lmcache_worker_ports` is "
+                "required and cannot be empty when `enable_p2p=true`."
+            )
+        if self.p2p_host is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `p2p_host` is required when "
+                "`enable_p2p=true`."
+            )
+        if self.p2p_init_ports is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `p2p_init_ports` is required "
+                "when `enable_p2p=true`."
+            )
+        if self.p2p_lookup_ports is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `p2p_lookup_ports` is required "
+                "when `enable_p2p=true`."
+            )
+        if self.transfer_channel is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `transfer_channel` is required "
+                "when `enable_p2p=true`."
+            )
+
+        original_enable_p2p = self.enable_p2p
+        # LMCache 0.4.5 rejects PD + P2P together. Validate P2P fields above,
+        # then run upstream controller/PD checks (including pd_backend_mode
+        # and save_unfull_chunk auto-fix) with only that assertion bypassed.
+        # Restore the flag even when upstream validation raises.
+        try:
+            self.enable_p2p = False
+            return lmcache.v1.config._validate_config(self)
+        finally:
+            self.enable_p2p = original_enable_p2p
+
     namespace_extras = {
-        "validate": lmcache.v1.config._validate_config,
+        "validate": _ascend_validate_config,
         "log_config": lmcache.v1.config._log_config,
         "get_extra_config_value": lmcache.v1.config._get_extra_config_value,
         "get_lmcache_worker_ids": lmcache.v1.config._get_lmcache_worker_ids,

--- a/lmcache_ascend/__init__.py
+++ b/lmcache_ascend/__init__.py
@@ -701,7 +701,17 @@ def _patch_vllm_v1_adapter():
     lmc_vllm_v1_adapter.ReqMeta = mg.ReqMeta
     lmc_vllm_v1_adapter.LMCacheConnectorV1Impl = ascend_LMCacheAscendConnectorV1Impl
 
-    def handle_preemptions(self, preempted_req_ids):
+    def handle_preemptions(self, preemption_payload):
+        # New vLLM carries preemptions in metadata; older versions pass a set.
+        if isinstance(preemption_payload, set):
+            preempted_req_ids = set(preemption_payload)
+        else:
+            preempted_req_ids = set(
+                getattr(preemption_payload, "preempted_req_ids", None) or ()
+            )
+        if not preempted_req_ids:
+            return
+
         method = getattr(self._lmcache_engine, "handle_preemptions", None)
         if callable(method):
             method(preempted_req_ids)

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -486,6 +486,10 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
                 else:
                     skip_leading_tokens = 0
 
+                skip_leading_tokens = self._pd_producer_skip_leading_tokens(
+                    skip_leading_tokens, request
+                )
+
                 if skip_leading_tokens == len(token_ids):
                     continue
                 skip_leading_tokens = (
@@ -573,6 +577,23 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
 
         self._wait_for_save_done = True
         self._replay_finished_stores_after_save()
+
+    def _pd_producer_skip_leading_tokens(
+        self, skip_leading_tokens: int, request
+    ) -> int:
+        """Clamp producer store skip to tokens already transferred to D.
+
+        ``skip_leading_tokens`` may come from local/P2P cache hits, but PD
+        handoff can only skip tokens that the paired decoder has already
+        received for this request. This preserves the upstream LMCache producer
+        guard while keeping Ascend's LocalCPU backfill skip calculation.
+        """
+        if self.kv_role == "kv_producer" and request.disagg_spec:
+            return min(
+                skip_leading_tokens,
+                request.disagg_spec.num_transferred_tokens,
+            )
+        return skip_leading_tokens
 
     def _local_persist_skip(self, request, token_ids) -> Optional[int]:
         """Decide whether a remote-loaded prefix must be persisted locally.

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
 # Third Party
@@ -8,6 +9,7 @@ from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVConnectorMetadata,
     KVConnectorRole,
 )
 from vllm.distributed.parallel_state import get_pp_group
@@ -30,9 +32,17 @@ if TYPE_CHECKING:
     # Third Party
     from vllm.config import VllmConfig
     from vllm.forward_context import ForwardContext
+    from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class LMCacheAscendConnectorMetadata(LMCacheConnectorMetadata):
+    """Multi-group LMCache requests plus scheduler preemption hints."""
+
+    preempted_req_ids: set[str] = field(default_factory=set)
 
 
 class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
@@ -58,6 +68,20 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
         self._finished_req_ids_waiting_for_save: set[str] = set()
         self._late_finished_sending: set[str] = set()
         logger.debug("store_async: %s", self.store_async)
+
+    @_lmcache_nvtx_annotate
+    def build_connector_meta(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> KVConnectorMetadata:
+        """Preserve multi-group request metadata and carry preemptions to workers."""
+        metadata = super().build_connector_meta(scheduler_output)
+        assert isinstance(metadata, LMCacheConnectorMetadata)
+        return LMCacheAscendConnectorMetadata(
+            requests=metadata.requests,
+            preempted_req_ids=set(
+                getattr(scheduler_output, "preempted_req_ids", None) or ()
+            ),
+        )
 
     @_lmcache_nvtx_annotate
     def register_kv_caches(
@@ -702,7 +726,7 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
         )
 
     def handle_preemptions(self, preempted_req_ids: set[str]) -> None:
-        if self.lmcache_engine is None:
+        if self.lmcache_engine is None or not preempted_req_ids:
             return
 
         logger.debug(

--- a/lmcache_ascend/v1/cache_engine.py
+++ b/lmcache_ascend/v1/cache_engine.py
@@ -121,6 +121,26 @@ class AscendLMCacheEngine(LMCacheEngine):
         if self.kv_events_enabled and self.is_store_async:
             self.kv_events = ThreadSafeEventList()
 
+    def _is_pd_receiver(self) -> bool:
+        config = getattr(self, "config", None)
+        return bool(
+            getattr(config, "enable_pd", False)
+            and getattr(config, "pd_role", None) == "receiver"
+        )
+
+    def _release_pd_request_lease(self, request_id: Optional[str]) -> None:
+        if not request_id or request_id == "unspecified":
+            return
+
+        storage_manager = getattr(self, "storage_manager", None)
+        if not self._is_pd_receiver() or storage_manager is None:
+            return
+
+        pd_backend = storage_manager.storage_backends.get("PDBackend")
+        release_request_lease = getattr(pd_backend, "release_request_lease", None)
+        if callable(release_request_lease):
+            release_request_lease(request_id)
+
     def _ensure_store_worker(self) -> None:
         if self._store_queue is not None:
             return
@@ -612,7 +632,7 @@ class AscendLMCacheEngine(LMCacheEngine):
                         pass
 
     @torch.inference_mode()
-    def retrieve(
+    def _retrieve_impl(
         self,
         tokens: Union[torch.Tensor, list[int]],
         mask: Optional[torch.Tensor] = None,
@@ -1055,19 +1075,68 @@ class AscendLMCacheEngine(LMCacheEngine):
     ) -> int:
         # Serialize against the store-worker thread's
         with self._engine_state_lock:
-            return super().lookup(
-                tokens=tokens,
-                hashes=hashes,
-                offsets=offsets,
-                search_range=search_range,
-                lookup_id=lookup_id,
-                pin=pin,
-                request_configs=request_configs,
-            )
+            token = None
+            if self._is_pd_receiver() and pin and lookup_id is not None:
+                # First Party
+                from lmcache_ascend.v1.storage_backend.storage_manager import (
+                    set_current_pd_lookup_id,
+                )
+
+                token = set_current_pd_lookup_id(lookup_id)
+            try:
+                return super().lookup(
+                    tokens=tokens,
+                    hashes=hashes,
+                    offsets=offsets,
+                    search_range=search_range,
+                    lookup_id=lookup_id,
+                    pin=pin,
+                    request_configs=request_configs,
+                )
+            finally:
+                if token is not None:
+                    # First Party
+                    from lmcache_ascend.v1.storage_backend.storage_manager import (
+                        reset_current_pd_lookup_id,
+                    )
+
+                    reset_current_pd_lookup_id(token)
 
     def lookup_unpin(self, lookup_id: str) -> None:
         with self._engine_state_lock:
-            super().lookup_unpin(lookup_id)
+            try:
+                super().lookup_unpin(lookup_id)
+            finally:
+                self._release_pd_request_lease(lookup_id)
+
+    @torch.inference_mode()
+    def retrieve(
+        self,
+        tokens: Union[torch.Tensor, list[int]],
+        mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        req_id = self._get_req_id(kwargs)
+        token = None
+        if self._is_pd_receiver():
+            # First Party
+            from lmcache_ascend.v1.storage_backend.storage_manager import (
+                set_current_pd_retrieve_id,
+            )
+
+            token = set_current_pd_retrieve_id(req_id)
+
+        try:
+            return self._retrieve_impl(tokens, mask=mask, **kwargs)
+        finally:
+            if token is not None:
+                # First Party
+                from lmcache_ascend.v1.storage_backend.storage_manager import (
+                    reset_current_pd_retrieve_id,
+                )
+
+                reset_current_pd_retrieve_id(token)
+            self._release_pd_request_lease(req_id)
 
     @torch.inference_mode()
     def store(

--- a/lmcache_ascend/v1/proxy_memory_obj.py
+++ b/lmcache_ascend/v1/proxy_memory_obj.py
@@ -94,6 +94,7 @@ class ProxyMemoryObj(MemoryObj):
         # Temporary lookup pins increment this count but must not consume the
         # base owner when they are released.
         self._ref_count = 1
+        self._lease_request_id: Optional[str] = None
 
         # Store allocation metadata for deferred buffer operations
         if backing_obj is not None:
@@ -143,6 +144,28 @@ class ProxyMemoryObj(MemoryObj):
             self._consumed = True
             self._released = True
             self._ref_count = 0
+
+    def clone_for_request(self, request_id: str) -> "ProxyMemoryObj":
+        """Create a request-local proxy over the same remote buffer reference.
+
+        The backend keeps an unconsumed prototype so other requests can still
+        declare hits for the same PD key.  The connector consumes only this
+        clone, making ``mark_consumed()`` request-local.
+        """
+        proxy = ProxyMemoryObj(
+            backing_obj=None,
+            transfer_channel=self._transfer_channel,
+            target_peer_url=self._target_peer_url,
+            remote_buffer_uuid=self._remote_buffer_uuid,
+            remote_mem_index=self._remote_mem_index,
+            transfer_context=self._transfer_context,
+            chunk_index=self._chunk_index,
+            shapes=self._shapes,
+            dtypes=self._dtypes,
+            fmt=self._fmt,
+        )
+        proxy._lease_request_id = request_id
+        return proxy
 
     @property
     def backing_obj(self) -> Optional[MemoryObj]:

--- a/lmcache_ascend/v1/proxy_memory_obj.py
+++ b/lmcache_ascend/v1/proxy_memory_obj.py
@@ -15,6 +15,7 @@ before scattering, enabling overlap of remote fetch and NPU scatter operations.
 # Standard
 from typing import Any, List, Optional
 import asyncio
+import threading
 
 # Third Party
 from lmcache.logging import init_logger
@@ -88,6 +89,11 @@ class ProxyMemoryObj(MemoryObj):
         self._resolved = False
         self._consumed = False  # True after data scattered into KV cache
         self._released = False
+        self._ref_lock = threading.Lock()
+        # One base owner represents the proxy's transfer-context ownership.
+        # Temporary lookup pins increment this count but must not consume the
+        # base owner when they are released.
+        self._ref_count = 1
 
         # Store allocation metadata for deferred buffer operations
         if backing_obj is not None:
@@ -133,8 +139,10 @@ class ProxyMemoryObj(MemoryObj):
         sender's pinned memory may be released, so the proxy's remote
         buffer references are no longer valid.
         """
-        self._consumed = True
-        self._released = True
+        with self._ref_lock:
+            self._consumed = True
+            self._released = True
+            self._ref_count = 0
 
     @property
     def backing_obj(self) -> Optional[MemoryObj]:
@@ -436,20 +444,27 @@ class ProxyMemoryObj(MemoryObj):
         return None
 
     def ref_count_up(self) -> None:
-        # No-op: proxy lifecycle is managed by the transfer context,
-        # not by the standard MemoryObj ref-count protocol.  Making
-        # this a no-op allows callers (cache engine, storage manager,
-        # PD backend pin/unpin) to use the same API without needing
-        # isinstance guards to skip proxies.
-        pass
+        with self._ref_lock:
+            if self._released:
+                return
+            self._ref_count += 1
 
     def ref_count_down(self) -> None:
         # When a proxy is discarded before the connector consumes it, notify
         # the shared context so the sender can release pending pull resources.
-        if self._released:
-            return
-        self._released = True
-        self._transfer_context.decref()
+        decref_context = False
+        with self._ref_lock:
+            if self._released:
+                return
+            if self._ref_count > 1:
+                self._ref_count -= 1
+                return
+            self._ref_count = 0
+            self._released = True
+            decref_context = True
+
+        if decref_context:
+            self._transfer_context.decref()
 
     def get_ref_count(self) -> int:
         # Always return 1 so the proxy looks "alive" to callers that

--- a/lmcache_ascend/v1/storage_backend/__init__.py
+++ b/lmcache_ascend/v1/storage_backend/__init__.py
@@ -80,6 +80,9 @@ def CreateStorageBackends(
     # Reuse existing LocalCPUBackend when available so that
     # dependent backends (disk, remote, p2p, …) keep working.
     local_cpu_backend: Optional[LocalCPUBackend] = None
+    needs_local_cpu_backend = (
+        not config.enable_pd or config.local_cpu or config.enable_p2p
+    )
     if existing_backends and "LocalCPUBackend" in existing_backends:
         _existing_cpu = existing_backends["LocalCPUBackend"]
         if isinstance(_existing_cpu, LocalCPUBackend):
@@ -88,7 +91,7 @@ def CreateStorageBackends(
     if metadata.role == "scheduler":
         # For scheduler role, local_cpu_backend is None
         pass
-    elif not config.enable_pd or config.local_cpu:
+    elif needs_local_cpu_backend:
         if "LocalCPUBackend" in _skip:
             pass  # Skipped — already exists
         elif config.max_local_cpu_size > 0:
@@ -110,7 +113,11 @@ def CreateStorageBackends(
                 "with `use_layerwise=true`. The Ascend P2P backend does not support "
                 "layerwise mode in current implementation. Disable one of them."
             )
-        assert local_cpu_backend is not None
+        if local_cpu_backend is None:
+            raise ValueError(
+                "Invalid LMCache-Ascend config: `enable_p2p=true` requires "
+                "`max_local_cpu_size > 0` or an existing `LocalCPUBackend`."
+            )
         assert lmcache_worker is not None
         p2p_backend = AscendP2PBackend(
             config,

--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -265,9 +265,10 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         Consumed :class:`ProxyMemoryObj` instances are evicted from the
         store and treated as absent.
 
-        Pinning is safe for both regular ``MemoryObj`` and proxies because
-        ``ProxyMemoryObj.ref_count_up/down`` are no-ops — the proxy
-        lifecycle is managed by its transfer context, not by ref counts.
+        Pinning is safe for both regular ``MemoryObj`` instances and proxies.
+        ``ProxyMemoryObj`` tracks temporary lookup pins as logical references
+        above its base transfer owner, so releasing a lookup pin does not
+        release the shared transfer context.
 
         The caller **must** call ``ref_count_down()`` on every returned
         object when *pin* is ``True`` once the pin is no longer needed.

--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -8,6 +8,7 @@ allocation, and key lookup/partitioning.
 """
 
 # Standard
+from dataclasses import dataclass, field
 from typing import Optional, Union
 import threading
 
@@ -37,6 +38,17 @@ from lmcache_ascend.v1.storage_backend.utils import resolve_memory_format
 from lmcache_ascend.v1.transfer_channel import CreateTransferChannel, get_correct_device
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class PDEntry:
+    """Receiver-side PD object plus request ownership metadata."""
+
+    base_obj: MemoryObj
+    owners: set[str] = field(default_factory=set)
+    # Request-local proxy clones used for delay-pull mode.
+    proxy_leases: dict[str, ProxyMemoryObj] = field(default_factory=dict)
+    pending_delete: bool = False
 
 
 class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
@@ -73,6 +85,8 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
 
         # Receiver-side KV store
         self.data: dict[CacheEngineKey, MemoryObj] = {}
+        self._pd_entries: dict[CacheEngineKey, PDEntry] = {}
+        self._pd_request_keys: dict[str, set[CacheEngineKey]] = {}
         self.data_lock = threading.Lock()
 
         self.memory_allocator = self.initialize_allocator(config, metadata)
@@ -274,12 +288,13 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         object when *pin* is ``True`` once the pin is no longer needed.
         """
         with self.data_lock:
-            mem_obj = self.data.get(key, None)
-            if mem_obj is None:
+            entry = self._pd_entries.get(key)
+            if entry is None:
                 return None
 
+            mem_obj = entry.base_obj
             if isinstance(mem_obj, ProxyMemoryObj) and mem_obj.consumed:
-                del self.data[key]
+                self._delete_pd_entry_locked(key, entry, release_obj=False)
                 return None
 
             if pin:
@@ -306,6 +321,188 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         Returns ``None`` when the key is absent or is a consumed proxy.
         """
         return self._lookup(key, pin=True)
+
+    def put(
+        self,
+        key: CacheEngineKey,
+        mem_obj: MemoryObj,
+    ):
+        with self.data_lock:
+            old_entry = self._pd_entries.get(key)
+            if old_entry is not None and old_entry.owners:
+                logger.warning(
+                    "PD receiver overwriting key %s with active owners: %s",
+                    key,
+                    sorted(old_entry.owners),
+                )
+            self.data[key] = mem_obj
+            self._pd_entries[key] = PDEntry(base_obj=mem_obj)
+
+    def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        with self.data_lock:
+            entry = self._pd_entries.get(key)
+            assert entry is not None, f"Key {key} not found in local data."
+            return entry.base_obj
+
+    def batched_get_blocking_for_request(
+        self,
+        keys: list[CacheEngineKey],
+        request_id: str,
+    ) -> list[Optional[MemoryObj]]:
+        memory_objs: list[Optional[MemoryObj]] = []
+        with self.data_lock:
+            for key in keys:
+                entry = self._pd_entries.get(key)
+                if entry is None:
+                    logger.warning(
+                        "PD request %s declared hit for missing key %s.",
+                        request_id,
+                        key,
+                    )
+                    memory_objs.append(None)
+                    continue
+
+                if request_id not in entry.owners:
+                    logger.debug(
+                        "PD request %s retrieves key %s without a prior lease; "
+                        "registering a lazy lease.",
+                        request_id,
+                        key,
+                    )
+                    self._ensure_request_lease_locked(key, entry, request_id)
+
+                base_obj = entry.base_obj
+                if isinstance(base_obj, ProxyMemoryObj):
+                    proxy = entry.proxy_leases.get(request_id)
+                    if proxy is None or proxy.consumed:
+                        logger.warning(
+                            "PD request %s has no usable proxy lease for key %s.",
+                            request_id,
+                            key,
+                        )
+                        memory_objs.append(None)
+                    else:
+                        memory_objs.append(proxy)
+                    continue
+
+                base_obj.ref_count_up()
+                memory_objs.append(base_obj)
+        return memory_objs
+
+    def batched_contains_and_lease(
+        self,
+        keys: list[CacheEngineKey],
+        request_id: str,
+    ) -> int:
+        hit_chunks = 0
+        with self.data_lock:
+            for key in keys:
+                entry = self._pd_entries.get(key)
+                if entry is None:
+                    break
+
+                base_obj = entry.base_obj
+                if isinstance(base_obj, ProxyMemoryObj) and base_obj.consumed:
+                    self._delete_pd_entry_locked(key, entry, release_obj=False)
+                    break
+
+                self._ensure_request_lease_locked(key, entry, request_id)
+
+                hit_chunks += 1
+        return hit_chunks
+
+    def _ensure_request_lease_locked(
+        self,
+        key: CacheEngineKey,
+        entry: PDEntry,
+        request_id: str,
+    ) -> None:
+        entry.owners.add(request_id)
+        self._pd_request_keys.setdefault(request_id, set()).add(key)
+
+        base_obj = entry.base_obj
+        if not isinstance(base_obj, ProxyMemoryObj):
+            return
+
+        if request_id in entry.proxy_leases:
+            return
+
+        entry.proxy_leases[request_id] = base_obj.clone_for_request(request_id)
+        transfer_context = base_obj.transfer_context
+        acquire_request = getattr(
+            transfer_context,
+            "acquire_request",
+            None,
+        )
+        if callable(acquire_request):
+            acquire_request(request_id)
+
+    def release_request_lease(self, request_id: str) -> None:
+        proxy_contexts = []
+        with self.data_lock:
+            keys = self._pd_request_keys.pop(request_id, set())
+            for key in list(keys):
+                entry = self._pd_entries.get(key)
+                if entry is None:
+                    continue
+
+                entry.owners.discard(request_id)
+                proxy = entry.proxy_leases.pop(request_id, None)
+                if proxy is not None:
+                    proxy_contexts.append(proxy.transfer_context)
+
+                entry.pending_delete = True
+                if not entry.owners:
+                    self._delete_pd_entry_locked(key, entry, release_obj=True)
+
+        for transfer_context in proxy_contexts:
+            release_request = getattr(
+                transfer_context,
+                "release_request",
+                None,
+            )
+            if callable(release_request):
+                release_request(request_id)
+
+    def remove(
+        self,
+        key: CacheEngineKey,
+        force: bool = True,
+    ) -> bool:
+        with self.data_lock:
+            entry = self._pd_entries.get(key)
+            if entry is None:
+                return False
+
+            entry.pending_delete = True
+            if entry.owners:
+                return True
+
+            self._delete_pd_entry_locked(key, entry, release_obj=True)
+            return True
+
+    def _delete_pd_entry_locked(
+        self,
+        key: CacheEngineKey,
+        entry: PDEntry,
+        release_obj: bool,
+    ) -> None:
+        self.data.pop(key, None)
+        self._pd_entries.pop(key, None)
+        for owner in list(entry.owners):
+            owned_keys = self._pd_request_keys.get(owner)
+            if owned_keys is not None:
+                owned_keys.discard(key)
+                if not owned_keys:
+                    self._pd_request_keys.pop(owner, None)
+        entry.owners.clear()
+        entry.proxy_leases.clear()
+
+        if release_obj:
+            try:
+                entry.base_obj.ref_count_down()
+            except Exception as e:
+                logger.warning("Failed to release PD entry for key %s: %s", key, e)
 
     def _partition_keys(
         self,

--- a/lmcache_ascend/v1/storage_backend/pd/receiver_mixin.py
+++ b/lmcache_ascend/v1/storage_backend/pd/receiver_mixin.py
@@ -141,7 +141,11 @@ class AscendPDReceiverMixin:
                 )
                 with self.data_lock:
                     for k in allocated_keys:
-                        self.data.pop(k, None)
+                        entry = self._pd_entries.get(k)
+                        if entry is not None:
+                            self._delete_pd_entry_locked(k, entry, release_obj=False)
+                        else:
+                            self.data.pop(k, None)
                 release_memory_objects(allocated_objs + already_sent_objs)
                 return AscendAllocResponse(
                     already_sent_indexes=already_sent_indexes,

--- a/lmcache_ascend/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/v1/storage_backend/storage_manager.py
@@ -92,6 +92,7 @@ def allocate_and_copy_objects(
     Upstream uses singular ``get_shape()``/``get_dtype()``, which only cover
     group 0 and under-allocate multi-group objs (dropping later groups).
     """
+    allocated_keys = []
     allocated_objects = []
     for key, src_memory_obj in zip(keys, src_memory_objs, strict=False):
         if allocator_backend.contains(key):
@@ -125,11 +126,12 @@ def allocate_and_copy_objects(
 
         with torch_dev.stream(stream):
             memory_obj.tensor.copy_(src_memory_obj.tensor, non_blocking=True)
+        allocated_keys.append(key)
         allocated_objects.append(memory_obj)
 
     if stream is not None:
         stream.synchronize()
-    return keys[: len(allocated_objects)], allocated_objects
+    return allocated_keys, allocated_objects
 
 
 def get(

--- a/lmcache_ascend/v1/storage_backend/storage_manager.py
+++ b/lmcache_ascend/v1/storage_backend/storage_manager.py
@@ -65,6 +65,7 @@ no-op for missing keys instead of aborting the lookup.
 
 # Standard
 from typing import Any, List, Optional, Sequence, cast
+import contextvars
 
 # Third Party
 from lmcache import torch_dev
@@ -79,6 +80,29 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache_ascend.v1.memory_management import is_multi_group_memory_obj
 
 logger = init_logger(__name__)
+
+_current_pd_lookup_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "current_pd_lookup_id", default=None
+)
+_current_pd_retrieve_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "current_pd_retrieve_id", default=None
+)
+
+
+def set_current_pd_lookup_id(request_id: str) -> contextvars.Token:
+    return _current_pd_lookup_id.set(request_id)
+
+
+def reset_current_pd_lookup_id(token: contextvars.Token) -> None:
+    _current_pd_lookup_id.reset(token)
+
+
+def set_current_pd_retrieve_id(request_id: str) -> contextvars.Token:
+    return _current_pd_retrieve_id.set(request_id)
+
+
+def reset_current_pd_retrieve_id(token: contextvars.Token) -> None:
+    _current_pd_retrieve_id.reset(token)
 
 
 def allocate_and_copy_objects(
@@ -169,7 +193,19 @@ def batched_get(
     """Blocking batched get with a delay-pull proxy guard on local write-back."""
     # TODO (ApostaC): remove the nested optional here
     for backend_name, storage_backend in self.get_active_storage_backends(location):
-        memory_objs = storage_backend.batched_get_blocking(keys)
+        request_id = _current_pd_retrieve_id.get()
+        if (
+            backend_name == "PDBackend"
+            and request_id is not None
+            and hasattr(storage_backend, "batched_get_blocking_for_request")
+        ):
+            memory_objs = storage_backend.batched_get_blocking_for_request(
+                keys,
+                request_id,
+            )
+        else:
+            memory_objs = storage_backend.batched_get_blocking(keys)
+
         if memory_objs and any(m is not None for m in memory_objs):
             # Align with single-key `get()` logic:
             # auto-write remote data to local CPU cache, but skip deferred-fetch
@@ -193,6 +229,44 @@ def batched_get(
                 local_cpu_backend.batched_submit_put_task(keys, memory_objs_no_none)
             return memory_objs
     return [None] * len(keys)
+
+
+def batched_contains(
+    self,
+    keys: List[CacheEngineKey],
+    search_range: Optional[List[str]] = None,
+    pin: bool = False,
+) -> tuple[int, dict]:
+    """Prefix lookup with PD receiver request-lease registration."""
+    total_keys = len(keys)
+    total_hit_chunks = 0
+    block_mapping = {}
+    for backend_name, backend in self.get_active_storage_backends(
+        search_range=search_range
+    ):
+        request_id = _current_pd_lookup_id.get()
+        if (
+            backend_name == "PDBackend"
+            and pin
+            and request_id is not None
+            and hasattr(backend, "batched_contains_and_lease")
+        ):
+            hit_chunks = backend.batched_contains_and_lease(keys, request_id)
+        else:
+            # Preserve upstream semantics: PDBackend is not pinned by the
+            # generic pin path. Ascend PD leases are handled above.
+            pin_in_backend = pin if backend_name != "PDBackend" else False
+            hit_chunks = backend.batched_contains(keys, pin_in_backend)
+
+        if hit_chunks == 0:
+            continue
+        block_mapping[backend_name] = keys[:hit_chunks]
+        total_hit_chunks += hit_chunks
+        if total_hit_chunks == total_keys:
+            break
+        keys = keys[hit_chunks:]
+
+    return total_hit_chunks, block_mapping
 
 
 def _best_effort_touch_cache(self, cache_dict) -> None:

--- a/lmcache_ascend/v1/transfer_context.py
+++ b/lmcache_ascend/v1/transfer_context.py
@@ -354,6 +354,8 @@ class PDTransferContext(AscendBaseTransferContext):
         self._sender_id = sender_id
         self._done_callback = done_callback
         self._loop = None
+        self._active_request_counts: dict[str, int] = {}
+        self._active_lease_count = 0
 
         logger.debug(
             "PDTransferContext: sender_id=%s, num_proxies=%d, "
@@ -364,6 +366,64 @@ class PDTransferContext(AscendBaseTransferContext):
             dtypes,
             fmt,
         )
+
+    def acquire_request(self, request_id: str) -> None:
+        """Register one request-level lease on this PD pull context."""
+        with self._lock:
+            if self._done_sent:
+                raise RuntimeError(
+                    "Cannot acquire PD request lease after Done was sent "
+                    f"for sender {self._sender_id}, request {request_id}"
+                )
+            self._active_request_counts[request_id] = (
+                self._active_request_counts.get(request_id, 0) + 1
+            )
+            self._active_lease_count += 1
+
+    def release_request(self, request_id: str) -> None:
+        """Release one request-level lease and send Done after the last lease."""
+        send_done = False
+        with self._lock:
+            count = self._active_request_counts.get(request_id, 0)
+            if count <= 0:
+                return
+
+            if count == 1:
+                self._active_request_counts.pop(request_id, None)
+            else:
+                self._active_request_counts[request_id] = count - 1
+
+            self._active_lease_count -= 1
+            if self._active_lease_count <= 0 and not self._done_sent:
+                self._done_sent = True
+                send_done = True
+
+        if send_done:
+            self._send_done()
+
+    def decref(self) -> None:
+        """Ignore generic proxy refcounting for PD delay-pull.
+
+        PD receiver proxies are shared prototypes in the backend store plus
+        per-request clones handed to the connector.  The sender-side resources
+        must be released by request leases, not by incidental pins from
+        receiver control-plane deduplication.
+        """
+        return None
+
+    def send_done_now(self) -> None:
+        """Send Done only when no request-level leases are active."""
+        send_done = False
+        with self._lock:
+            if self._done_sent:
+                return
+            if self._active_lease_count > 0:
+                return
+            self._done_sent = True
+            send_done = True
+
+        if send_done:
+            self._send_done()
 
     def _send_done(self) -> None:
         """Invoke the done callback to signal the sender."""

--- a/tests/integration/vllm/test_handle_preemptions.py
+++ b/tests/integration/vllm/test_handle_preemptions.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call, patch
+import pickle
 
 # Third Party
 import pytest
@@ -29,19 +30,97 @@ def _make_adapter(adapter_mod, *, store_async, kv_role, lmcache_engine):
     return adapter
 
 
-def test_lmcache_connector_delegates_preemptions_after_ascend_patch():
-    """Ascend patches the outer vLLM connector to delegate preemptions."""
+def test_build_connector_meta_carries_preempted_request_ids():
+    """Scheduler metadata preserves LMCache requests and preemption hints."""
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    adapter = object.__new__(adapter_mod.LMCacheAscendConnectorV1Impl)
+    request_metadata = SimpleNamespace(
+        slot_mappings_by_group=(object(), object()),
+        allocated_block_ids_by_group=([1, 2], [3]),
+        primary_kv_group_idx=1,
+        filtered_slot_by_group=(object(), object()),
+        slot_valid_prefix_by_group=(object(), object()),
+    )
+    base_metadata = adapter_mod.LMCacheConnectorMetadata(requests=[request_metadata])
+    preempted_req_ids = {"req-1", "req-2"}
+    scheduler_output = SimpleNamespace(preempted_req_ids=preempted_req_ids)
+
+    with patch.object(
+        adapter_mod.LMCacheConnectorV1ImplMultiGroup,
+        "build_connector_meta",
+        return_value=base_metadata,
+    ) as build_multi_group:
+        metadata = adapter.build_connector_meta(scheduler_output)
+
+    build_multi_group.assert_called_once_with(scheduler_output)
+    assert isinstance(metadata, adapter_mod.LMCacheAscendConnectorMetadata)
+    assert metadata.requests is base_metadata.requests
+    assert metadata.requests[0] is request_metadata
+    assert metadata.preempted_req_ids == preempted_req_ids
+
+    preempted_req_ids.add("req-added-after-build")
+    assert "req-added-after-build" not in metadata.preempted_req_ids
+
+
+def test_ascend_connector_metadata_is_pickleable():
+    """Custom metadata survives scheduler-to-worker style serialization."""
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    metadata = adapter_mod.LMCacheAscendConnectorMetadata(
+        preempted_req_ids={"req-1", "req-2"}
+    )
+    restored = pickle.loads(pickle.dumps(metadata))
+
+    assert isinstance(restored, adapter_mod.LMCacheAscendConnectorMetadata)
+    assert restored.preempted_req_ids == {"req-1", "req-2"}
+
+
+@pytest.mark.parametrize("payload_kind", ["v023_metadata", "legacy_set"])
+def test_lmcache_connector_normalizes_preemption_payload(payload_kind):
+    """The patched connector accepts both vLLM 0.23 and legacy payloads."""
     LMCacheConnectorV1 = _import_and_patch_vllm_connector()
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
 
     connector = object.__new__(LMCacheConnectorV1)
     connector._lmcache_engine = MagicMock()
 
-    preempted_req_ids = {"req-1", "req-2"}
-    connector.handle_preemptions(preempted_req_ids)
+    expected_req_ids = {"req-1", "req-2"}
+    if payload_kind == "v023_metadata":
+        payload = adapter_mod.LMCacheAscendConnectorMetadata(
+            preempted_req_ids=expected_req_ids
+        )
+    else:
+        payload = set(expected_req_ids)
+
+    connector.handle_preemptions(payload)
 
     connector._lmcache_engine.handle_preemptions.assert_called_once_with(
-        preempted_req_ids
+        expected_req_ids
     )
+
+
+@pytest.mark.parametrize("payload_kind", ["empty_metadata", "base_metadata"])
+def test_lmcache_connector_skips_payloads_without_preemptions(payload_kind):
+    """Payloads with no preempted request ids must be no-ops."""
+    LMCacheConnectorV1 = _import_and_patch_vllm_connector()
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    connector = object.__new__(LMCacheConnectorV1)
+    connector._lmcache_engine = MagicMock()
+
+    if payload_kind == "empty_metadata":
+        payload = adapter_mod.LMCacheAscendConnectorMetadata()
+    else:
+        payload = adapter_mod.LMCacheConnectorMetadata()
+
+    connector.handle_preemptions(payload)
+
+    connector._lmcache_engine.handle_preemptions.assert_not_called()
 
 
 def test_lmcache_connector_preemption_patch_handles_no_inner_impl():
@@ -72,6 +151,9 @@ def test_ascend_adapter_drains_pending_stores_for_async_producer():
     preempted_req_ids = {"req-1", "req-2"}
     adapter.handle_preemptions(preempted_req_ids)
 
+    lmcache_engine.lookup_unpin.assert_has_calls(
+        [call("req-1"), call("req-2")], any_order=True
+    )
     lmcache_engine.wait_for_pending_stores.assert_called_once_with(preempted_req_ids)
 
 
@@ -101,4 +183,5 @@ def test_ascend_adapter_skips_preemption_drain_when_not_required(
     adapter.handle_preemptions({"req-1"})
 
     if has_engine:
+        lmcache_engine.lookup_unpin.assert_called_once_with("req-1")
         lmcache_engine.wait_for_pending_stores.assert_not_called()

--- a/tests/integration/vllm/test_local_persist_skip.py
+++ b/tests/integration/vllm/test_local_persist_skip.py
@@ -103,6 +103,25 @@ def test_consumer_role_skips_without_lookup():
     engine.lookup.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("kv_role", "disagg_spec", "expected_skip"),
+    [
+        ("kv_producer", SimpleNamespace(num_transferred_tokens=2 * CHUNK), 2 * CHUNK),
+        ("kv_both", SimpleNamespace(num_transferred_tokens=2 * CHUNK), 4 * CHUNK),
+        ("kv_producer", None, 4 * CHUNK),
+    ],
+)
+def test_pd_producer_skip_is_clamped_to_transferred_tokens(
+    kv_role,
+    disagg_spec,
+    expected_skip,
+):
+    adapter, _ = _make_adapter(kv_role=kv_role)
+    request = SimpleNamespace(disagg_spec=disagg_spec)
+
+    assert adapter._pd_producer_skip_leading_tokens(4 * CHUNK, request) == expected_skip
+
+
 def test_local_cpu_disabled_skips_without_lookup():
     adapter, engine = _make_adapter(local_cpu=False, local_present=0)
     request = _make_request()

--- a/tests/v1/disagg_proxy_test_utils.py
+++ b/tests/v1/disagg_proxy_test_utils.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from pathlib import Path
+from types import ModuleType
+import importlib
+import logging
+import sys
+
+
+def _install_lmcache_stubs() -> None:
+    try:
+        importlib.import_module("lmcache.v1.storage_backend.pd_backend")
+        return
+    except ModuleNotFoundError as exc:
+        if exc.name is not None and not exc.name.startswith("lmcache"):
+            raise
+
+    lmcache = ModuleType("lmcache")
+    lmcache.__path__ = []
+    lmcache_logging = ModuleType("lmcache.logging")
+    lmcache_v1 = ModuleType("lmcache.v1")
+    lmcache_v1.__path__ = []
+    storage_backend = ModuleType("lmcache.v1.storage_backend")
+    storage_backend.__path__ = []
+    pd_backend = ModuleType("lmcache.v1.storage_backend.pd_backend")
+
+    class ProxyNotif:
+        def __init__(self, req_id: str):
+            self.req_id = req_id
+
+    lmcache_logging.init_logger = logging.getLogger
+    pd_backend.PDMsg = object
+    pd_backend.ProxyNotif = ProxyNotif
+
+    sys.modules.update(
+        {
+            "lmcache": lmcache,
+            "lmcache.logging": lmcache_logging,
+            "lmcache.v1": lmcache_v1,
+            "lmcache.v1.storage_backend": storage_backend,
+            "lmcache.v1.storage_backend.pd_backend": pd_backend,
+        }
+    )
+
+
+def load_proxy_server():
+    _install_lmcache_stubs()
+    example_dir = Path(__file__).parents[2] / "examples" / "disagg_prefill"
+    if str(example_dir) not in sys.path:
+        sys.path.insert(0, str(example_dir))
+    return importlib.import_module("disagg_proxy_server")
+
+
+class FakeRequest:
+    def __init__(self, payload: dict, headers: dict | None = None):
+        self.payload = payload
+        self.headers = headers or {}
+
+    async def json(self) -> dict:
+        return self.payload
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        payload: dict | None = None,
+        *,
+        content: bytes = b"",
+        status_code: int = 200,
+        content_type: str = "application/json",
+    ):
+        self.payload = payload
+        self.content = content
+        self.status_code = status_code
+        self.headers = {"content-type": content_type}
+
+    def json(self) -> dict:
+        assert self.payload is not None
+        return self.payload
+
+
+async def collect_streaming_response(response) -> bytes:
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.encode() if isinstance(chunk, str) else chunk)
+    return b"".join(chunks)

--- a/tests/v1/storage_backend/test_ascend_pd_backend.py
+++ b/tests/v1/storage_backend/test_ascend_pd_backend.py
@@ -312,6 +312,42 @@ class TestAscendPDBackend:
         assert new_idx == [1, 2]
         mock_obj0.ref_count_up.assert_called_once()
 
+    def test_partition_keys_proxy_pin_release_preserves_transfer_owner(self):
+        """Already-sent Proxy lookup release must not complete its transfer."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+        from lmcache_ascend.v1.storage_backend.utils import release_memory_objects
+
+        backend = _make_pd_backend_stub()
+        key = _make_key("proxy-key")
+        context = MagicMock()
+        proxy = ProxyMemoryObj(
+            backing_obj=None,
+            transfer_channel=MagicMock(),
+            target_peer_url="sender_1",
+            remote_buffer_uuid="suuid-0",
+            remote_mem_index=0,
+            transfer_context=context,
+            chunk_index=0,
+            shapes=[DEFAULT_SHAPE],
+            dtypes=[DEFAULT_DTYPE],
+            fmt=MemoryFormat.KV_2LTD,
+        )
+        backend.data[key] = proxy
+
+        already_sent_idx, already_sent_objs, new_idx = AscendPDBackend._partition_keys(
+            backend, [key.to_string()]
+        )
+        release_memory_objects(already_sent_objs)
+
+        assert already_sent_idx == [0]
+        assert already_sent_objs == [proxy]
+        assert new_idx == []
+        context.decref.assert_not_called()
+
+        proxy.ref_count_down()
+        context.decref.assert_called_once()
+
     def test_push_mode_allocate_and_put(self):
         """Push-mode allocate_and_put returns UUID-based refs."""
         # First Party

--- a/tests/v1/storage_backend/test_ascend_pd_backend.py
+++ b/tests/v1/storage_backend/test_ascend_pd_backend.py
@@ -66,20 +66,30 @@ def _make_mock_mem_obj(
     return mock
 
 
-def _make_consumed_proxy() -> ProxyMemoryObj:
-    """Create a ProxyMemoryObj that is already consumed."""
+def _make_proxy(
+    context: MagicMock | None = None,
+    chunk_index: int = 0,
+) -> ProxyMemoryObj:
+    if context is None:
+        context = MagicMock()
     proxy = ProxyMemoryObj(
         backing_obj=None,
         transfer_channel=MagicMock(),
         target_peer_url="fake_url",
-        remote_buffer_uuid="fake_uuid",
-        remote_mem_index=0,
-        transfer_context=MagicMock(),
-        chunk_index=0,
+        remote_buffer_uuid=f"fake_uuid_{chunk_index}",
+        remote_mem_index=chunk_index,
+        transfer_context=context,
+        chunk_index=chunk_index,
         shapes=[DEFAULT_SHAPE],
         dtypes=[DEFAULT_DTYPE],
         fmt=MemoryFormat.KV_2LTD,
     )
+    return proxy
+
+
+def _make_consumed_proxy() -> ProxyMemoryObj:
+    """Create a ProxyMemoryObj that is already consumed."""
+    proxy = _make_proxy()
     proxy.mark_consumed()
     return proxy
 
@@ -96,10 +106,22 @@ def _make_pd_backend_stub(
 ):
     """Create a mock object with the minimal attributes needed by PD backend methods."""
     # First Party
-    from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+    from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend, PDEntry
 
     backend = MagicMock()
-    backend.data = {}
+    backend._pd_entries = {}
+    backend._pd_request_keys = {}
+
+    class _PDDataDict(dict):
+        def __setitem__(self, key, value):
+            super().__setitem__(key, value)
+            backend._pd_entries[key] = PDEntry(base_obj=value)
+
+        def pop(self, key, default=None):
+            backend._pd_entries.pop(key, None)
+            return super().pop(key, default)
+
+    backend.data = _PDDataDict()
     backend.data_lock = threading.Lock()
     backend.pd_config = MagicMock()
     backend.pd_config.role = role
@@ -131,6 +153,22 @@ def _make_pd_backend_stub(
     )
     backend._partition_keys = lambda keys: AscendPDBackend._partition_keys(
         backend, keys
+    )
+    backend._ensure_request_lease_locked = (
+        lambda key, entry, request_id: AscendPDBackend._ensure_request_lease_locked(
+            backend,
+            key,
+            entry,
+            request_id,
+        )
+    )
+    backend._delete_pd_entry_locked = (
+        lambda key, entry, release_obj: AscendPDBackend._delete_pd_entry_locked(
+            backend,
+            key,
+            entry,
+            release_obj,
+        )
     )
 
     return backend
@@ -348,6 +386,68 @@ class TestAscendPDBackend:
         proxy.ref_count_down()
         context.decref.assert_called_once()
 
+    def test_pd_backend_keeps_shared_entry_until_last_request_lease_released(self):
+        """A shared PD hit is deleted only after every request lease is released."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+
+        backend = _make_pd_backend_stub()
+        key = _make_key("shared_lease")
+        mem_obj = _make_mock_mem_obj()
+        AscendPDBackend.put(backend, key, mem_obj)
+
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-1") == 1
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-2") == 1
+
+        AscendPDBackend.release_request_lease(backend, "req-1")
+
+        assert key in backend.data
+        assert key in backend._pd_entries
+        assert backend._pd_entries[key].owners == {"req-2"}
+        mem_obj.ref_count_down.assert_not_called()
+
+        AscendPDBackend.release_request_lease(backend, "req-2")
+
+        assert key not in backend.data
+        assert key not in backend._pd_entries
+        assert backend._pd_request_keys == {}
+        mem_obj.ref_count_down.assert_called_once()
+
+    def test_pd_backend_proxy_leases_are_request_local(self):
+        """Consuming one request's proxy clone must not poison shared PD hits."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+
+        backend = _make_pd_backend_stub()
+        key = _make_key("shared_proxy")
+        transfer_context = MagicMock()
+        base_proxy = _make_proxy(transfer_context)
+        AscendPDBackend.put(backend, key, base_proxy)
+
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-1") == 1
+        assert AscendPDBackend.batched_contains_and_lease(backend, [key], "req-2") == 1
+
+        entry = backend._pd_entries[key]
+        req1_proxy = entry.proxy_leases["req-1"]
+        req2_proxy = entry.proxy_leases["req-2"]
+
+        assert req1_proxy is not base_proxy
+        assert req2_proxy is not base_proxy
+        assert req1_proxy is not req2_proxy
+        transfer_context.acquire_request.assert_any_call("req-1")
+        transfer_context.acquire_request.assert_any_call("req-2")
+
+        req1_proxy.mark_consumed()
+
+        assert req1_proxy.consumed is True
+        assert base_proxy.consumed is False
+        assert req2_proxy.consumed is False
+        assert AscendPDBackend.batched_get_blocking_for_request(
+            backend,
+            [key],
+            "req-2",
+        ) == [req2_proxy]
+
     def test_push_mode_allocate_and_put(self):
         """Push-mode allocate_and_put returns UUID-based refs."""
         # First Party
@@ -409,6 +509,48 @@ class TestAscendPDBackend:
         assert isinstance(resp, AscendAllocResponse)
         assert resp.alloc_failed is True
         backend.put.assert_not_called()
+
+    def test_push_mode_partial_alloc_failure_cleans_pd_entries(self):
+        """Partial push allocation rollback removes both receiver indexes."""
+        # First Party
+        from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+        from lmcache_ascend.v1.storage_backend.pd.receiver_mixin import (
+            AscendPDReceiverMixin,
+        )
+
+        backend = _make_pd_backend_stub()
+        backend.data = {}
+        backend._pd_entries = {}
+        backend.put = lambda key, mem_obj: AscendPDBackend.put(backend, key, mem_obj)
+        allocated_obj = _make_mock_mem_obj()
+        backend.transfer_channel.get_local_buffer_refs.return_value = (
+            ["uuid-alloc"],
+            [42],
+        )
+        key0 = _make_key("partial-alloc-0")
+        key1 = _make_key("partial-alloc-1")
+
+        alloc_req = AllocRequest(
+            keys=[key0.to_string(), key1.to_string()],
+            fmt=MemoryFormat.KV_2LTD.value,
+            shape=list(DEFAULT_SHAPE),
+            dtype="bfloat16",
+            last_chunk_toks=256,
+        )
+
+        with patch(
+            "lmcache_ascend.v1.storage_backend.pd.receiver_mixin.allocate_with_retry",
+            side_effect=[allocated_obj, None],
+        ):
+            resp = AscendPDReceiverMixin._allocate_and_put(backend, alloc_req)
+
+        assert isinstance(resp, AscendAllocResponse)
+        assert resp.alloc_failed is True
+        assert key0 not in backend.data
+        assert key0 not in backend._pd_entries
+        assert key1 not in backend.data
+        assert key1 not in backend._pd_entries
+        allocated_obj.ref_count_down.assert_called_once()
 
     def test_pull_eager_flow(self):
         """Pull-eager: allocates, reads from sender, returns ack + callback."""

--- a/tests/v1/storage_backend/test_pd_multi_group_lifecycle.py
+++ b/tests/v1/storage_backend/test_pd_multi_group_lifecycle.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PD request ownership with heterogeneous KV groups; transport is mocked."""
+
+# Standard
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import threading
+
+# Third Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.storage_backend.pd_backend import AllocRequest
+import pytest
+import torch
+
+# First Party
+from lmcache_ascend.v1.cache_engine import AscendLMCacheEngine
+from lmcache_ascend.v1.storage_backend import storage_manager as sm
+from lmcache_ascend.v1.storage_backend.pd import receiver_mixin
+from lmcache_ascend.v1.storage_backend.pd.backend import AscendPDBackend
+from lmcache_ascend.v1.storage_backend.pd.messages import PullReadyNotif
+
+DTYPES = [torch.bfloat16, torch.float32]
+FMT = MemoryFormat.KV_2LTD
+
+
+def _shapes(num_tokens=8):
+    return [torch.Size([2, 1, num_tokens, 4]), torch.Size([1, 1, num_tokens // 4, 4])]
+
+
+def _memory_obj(fill=0):
+    shapes = _shapes()
+    size = sum(s.numel() * d.itemsize for s, d in zip(shapes, DTYPES, strict=True))
+    metadata = MemoryObjMetadata(
+        shape=shapes[0],
+        dtype=DTYPES[0],
+        address=0,
+        phy_size=size,
+        ref_count=1,
+        fmt=FMT,
+        shapes=shapes,
+        dtypes=list(DTYPES),
+    )
+    return TensorMemoryObj(
+        torch.full((size,), fill, dtype=torch.uint8, device="cpu"),
+        metadata,
+        parent_allocator=None,
+    )
+
+
+def _key(index):
+    return CacheEngineKey("multi-group", 1, 0, index, torch.bfloat16, None)
+
+
+def _backend():
+    backend = object.__new__(AscendPDBackend)
+    backend.data = {}
+    backend._pd_entries = {}
+    backend._pd_request_keys = {}
+    backend.data_lock = threading.Lock()
+    backend._metadata = MagicMock()
+    backend._metadata.get_num_groups.return_value = 2
+    backend._metadata.get_shapes.side_effect = _shapes
+    backend._metadata.get_dtypes.return_value = list(DTYPES)
+    backend.transfer_channel = MagicMock()
+    backend.memory_allocator = MagicMock()
+    backend._peer_alloc_backoff_ttl = 0
+    backend._fmt = FMT
+    backend._send_pull_done_to_sender = MagicMock()
+    return backend
+
+
+@pytest.mark.parametrize("failure", [None, "out_of_memory", "missing_tensor"])
+def test_multi_group_copy_preserves_layout_bytes_and_key_alignment(failure):
+    sources = [_memory_obj(fill=i + 1) for i in range(3)]
+    targets = [_memory_obj(), _memory_obj()]
+    invalid = MagicMock(tensor=None)
+    second = {None: targets[1], "out_of_memory": None, "missing_tensor": invalid}[
+        failure
+    ]
+    allocator = MagicMock()
+    allocator.contains.side_effect = lambda key: key == "k0"
+    allocator.allocate.side_effect = [targets[0], second]
+    stream = MagicMock()
+
+    with patch.object(sm.torch_dev, "stream", return_value=nullcontext()):
+        keys, objects = sm.allocate_and_copy_objects(
+            allocator,
+            ["k0", "k1", "k2"],
+            sources,
+            stream,
+        )
+
+    assert keys == (["k1", "k2"] if failure is None else ["k1"])
+    assert objects == (targets if failure is None else targets[:1])
+    for source, target in zip(sources[1:], objects, strict=False):
+        assert target.get_shapes() == source.get_shapes() == _shapes()
+        assert target.get_dtypes() == source.get_dtypes() == DTYPES
+        assert torch.equal(target.raw_data, source.raw_data)
+        for group in range(2):
+            assert torch.equal(target.get_tensor(group), source.get_tensor(group))
+    for allocation in allocator.allocate.call_args_list:
+        assert allocation.args == (_shapes(), DTYPES)
+    stream.synchronize.assert_called_once()
+    if failure == "missing_tensor":
+        invalid.ref_count_down.assert_called_once()
+
+
+def test_multi_group_shared_entry_releases_all_groups_after_last_request():
+    backend = _backend()
+    key = _key(0)
+    obj = _memory_obj()
+    allocator = MagicMock()
+    allocator.free.side_effect = lambda memory_obj: memory_obj.invalidate()
+    obj.parent_allocator = allocator
+    backend.put(key, obj)
+    for request in ("req-1", "req-2"):
+        assert backend.batched_contains_and_lease([key], request) == 1
+    first = backend.batched_get_blocking_for_request([key], "req-1")[0]
+    second = backend.batched_get_blocking_for_request([key], "req-2")[0]
+    assert first is second is obj
+    assert obj.get_ref_count() == 3
+    first.ref_count_down()
+    backend.release_request_lease("req-1")
+    assert obj.get_ref_count() == 2
+    allocator.free.assert_not_called()
+    assert backend.data[key] is obj
+    assert second.get_shapes() == _shapes()
+    second.ref_count_down()
+    backend.release_request_lease("req-2")
+    assert obj.get_ref_count() == 0
+    allocator.free.assert_called_once_with(obj)
+    assert not obj.is_valid()
+    assert backend.data == backend._pd_entries == backend._pd_request_keys == {}
+
+
+def test_multi_group_delay_pull_clones_keep_partial_layout_and_request_ownership():
+    backend = _backend()
+    keys = [_key(0), _key(1)]
+    message = PullReadyNotif(
+        pull_id="pull-1",
+        keys=[key.to_string() for key in keys],
+        sender_buffer_uuids=["buffer-0", "buffer-1"],
+        sender_mem_indexes=[10, 11],
+        sender_id="sender-1",
+        sender_done_url="tcp://localhost:9901",
+        fmt=FMT.value,
+        shape=list(_shapes()[0]),
+        dtype="bfloat16",
+        last_chunk_toks=4,
+    )
+    ack, callback = backend._handle_pull_delay(message, "sender-1")
+    assert ack.already_sent_indexes == []
+    assert callback is None
+    prototypes = [backend.data[key] for key in keys]
+    context = prototypes[0].transfer_context
+    assert prototypes[1].transfer_context is context
+
+    # #274: temporary deduplication pins must not consume the prototype.
+    pinned = backend._contains_and_pin(keys[0])
+    assert pinned.get_ref_count() == 2
+    pinned.ref_count_down()
+    assert pinned.get_ref_count() == 1
+    backend._send_pull_done_to_sender.assert_not_called()
+
+    for request in ("req-1", "req-2"):
+        assert backend.batched_contains_and_lease(keys, request) == 2
+        assert backend.batched_contains_and_lease(keys, request) == 2
+    assert context._active_lease_count == 4
+    first = backend.batched_get_blocking_for_request(keys, "req-1")
+    second = backend.batched_get_blocking_for_request(keys, "req-2")
+    for index, (one, two, prototype) in enumerate(
+        zip(first, second, prototypes, strict=True)
+    ):
+        assert one is not two and two is not prototype
+        expected_shapes = _shapes(8 if index == 0 else 4)
+        assert one.get_shapes() == two.get_shapes() == expected_shapes
+        assert one.get_dtypes() == two.get_dtypes() == DTYPES
+        assert two._remote_buffer_uuid == message.sender_buffer_uuids[index]
+        assert two._remote_mem_index == message.sender_mem_indexes[index]
+        one.mark_consumed()
+        assert not two.consumed and not prototype.consumed
+
+    context.allocate_buffers(2)
+    backend.memory_allocator.batched_allocate.assert_called_once_with(
+        _shapes(),
+        DTYPES,
+        2,
+        FMT,
+        "gpu",
+    )
+    backend.release_request_lease("req-1")
+    context.send_done_now()
+    backend._send_pull_done_to_sender.assert_not_called()
+    assert all(key in backend.data for key in keys)
+    backend.release_request_lease("req-2")
+    backend._send_pull_done_to_sender.assert_called_once_with("sender-1", "pull-1")
+    assert backend.data == backend._pd_entries == backend._pd_request_keys == {}
+    backend.release_request_lease("req-2")
+    context.send_done_now()
+    backend._send_pull_done_to_sender.assert_called_once()
+
+
+def test_multi_group_push_rollback_clears_new_entries_and_releases_existing_pin():
+    backend = _backend()
+    keys = [_key(i) for i in range(3)]
+    existing, allocated = _memory_obj(), _memory_obj()
+    backend.put(keys[0], existing)
+    backend.transfer_channel.get_local_buffer_refs.return_value = (["buffer"], [10])
+    request = AllocRequest(
+        keys=[key.to_string() for key in keys],
+        fmt=FMT.value,
+        shape=list(_shapes()[0]),
+        dtype="bfloat16",
+        last_chunk_toks=4,
+    )
+    with patch.object(
+        receiver_mixin, "allocate_with_retry", side_effect=[allocated, None]
+    ) as allocate:
+        response = backend._allocate_and_put(request)
+    assert response.alloc_failed
+    assert response.already_sent_indexes == [0]
+    assert response.remote_buffer_uuids == response.remote_indexes == []
+    assert allocate.call_args_list[0].args[1:3] == (_shapes(), DTYPES)
+    assert allocate.call_args_list[1].args[1:3] == (_shapes(4), DTYPES)
+    assert set(backend.data) == set(backend._pd_entries) == {keys[0]}
+    assert backend._pd_request_keys == {}
+    assert existing.get_ref_count() == 1
+    assert allocated.get_ref_count() == 0
+
+
+@pytest.mark.parametrize("pd_receiver", [False, True])
+@pytest.mark.parametrize("fails", [False, True])
+def test_retrieve_forwards_group_mappings_and_restores_request_context(
+    pd_receiver, fails
+):
+    engine = object.__new__(AscendLMCacheEngine)
+    engine.config = SimpleNamespace(enable_pd=pd_receiver, pd_role="receiver")
+    backend = MagicMock()
+    engine.storage_manager = SimpleNamespace(storage_backends={"PDBackend": backend})
+    tokens = list(range(8))
+    mappings = (torch.arange(8), torch.arange(2))
+    result = torch.ones(8, dtype=torch.bool)
+
+    def retrieve_impl(actual_tokens, mask=None, **kwargs):
+        assert actual_tokens is tokens
+        assert kwargs["slot_mappings_by_group"] is mappings
+        assert kwargs["slot_mappings_npu_by_group"] is mappings
+        assert sm._current_pd_retrieve_id.get() == ("req-1" if pd_receiver else "outer")
+        if fails:
+            raise RuntimeError("retrieve failed")
+        return result
+
+    engine._retrieve_impl = retrieve_impl
+    token = sm.set_current_pd_retrieve_id("outer")
+    try:
+        kwargs = dict(
+            req_id="req-1",
+            slot_mappings_by_group=mappings,
+            slot_mappings_npu_by_group=mappings,
+        )
+        if fails:
+            with pytest.raises(RuntimeError, match="retrieve failed"):
+                engine.retrieve(tokens, **kwargs)
+        else:
+            assert engine.retrieve(tokens, **kwargs) is result
+        assert sm._current_pd_retrieve_id.get() == "outer"
+    finally:
+        sm.reset_current_pd_retrieve_id(token)
+    if pd_receiver:
+        backend.release_request_lease.assert_called_once_with("req-1")
+    else:
+        backend.release_request_lease.assert_not_called()

--- a/tests/v1/storage_backend/test_proxy_memory_obj.py
+++ b/tests/v1/storage_backend/test_proxy_memory_obj.py
@@ -48,6 +48,17 @@ def test_proxy_ref_count_down_decrefs_context_once():
     context.decref.assert_called_once()
 
 
+def test_proxy_temporary_pin_release_does_not_decref_context():
+    """Lookup pin/unpin should not consume the proxy's base transfer owner."""
+    context = MagicMock()
+    proxy = _make_proxy(context)
+
+    proxy.ref_count_up()
+    proxy.ref_count_down()
+
+    context.decref.assert_not_called()
+
+
 def test_proxy_mark_consumed_suppresses_later_ref_count_down():
     """Connector-consumed proxies should not later decref during cleanup."""
     context = MagicMock()

--- a/tests/v1/storage_backend/test_proxy_memory_obj.py
+++ b/tests/v1/storage_backend/test_proxy_memory_obj.py
@@ -93,3 +93,37 @@ def test_proxy_shared_context_sends_done_after_all_discards():
 
     proxy_1.ref_count_down()
     context.send_done.assert_called_once()
+
+
+def test_pd_transfer_context_sends_done_after_last_request_lease():
+    """PD delay-pull Done is gated by request leases, not proxy refcounts."""
+    # First Party
+    from lmcache_ascend.v1.transfer_context import PDTransferContext
+
+    done_callback = MagicMock()
+    context = PDTransferContext(
+        sender_id="sender-1",
+        done_callback=done_callback,
+        num_proxies=2,
+        memory_allocator=MagicMock(),
+        shapes=[DEFAULT_SHAPE],
+        dtypes=[DEFAULT_DTYPE],
+        fmt=MemoryFormat.KV_2LTD,
+    )
+
+    context.acquire_request("req-1")
+    context.acquire_request("req-2")
+
+    context.decref()
+    context.send_done_now()
+    done_callback.assert_not_called()
+
+    context.release_request("req-1")
+    done_callback.assert_not_called()
+
+    context.release_request("req-2")
+    done_callback.assert_called_once()
+
+    context.release_request("req-2")
+    context.send_done_now()
+    done_callback.assert_called_once()

--- a/tests/v1/storage_backend/test_storage_backend_init.py
+++ b/tests/v1/storage_backend/test_storage_backend_init.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+
+def _mixed_sender_config(max_local_cpu_size: int = 16):
+    return SimpleNamespace(
+        enable_pd=True,
+        enable_p2p=True,
+        pd_role="sender",
+        enable_async_loading=False,
+        local_cpu=False,
+        local_disk=False,
+        max_local_cpu_size=max_local_cpu_size,
+        max_local_disk_size=0,
+        enable_controller=True,
+        controller_pull_url="localhost:9800",
+        controller_reply_url="localhost:9900",
+        lmcache_worker_ports=[9950],
+        p2p_host="localhost",
+        p2p_init_ports=[9960],
+        p2p_lookup_ports=[9962],
+        transfer_channel="hccl",
+        remote_storage_plugins=None,
+        remote_url=None,
+        use_layerwise=False,
+        extra_config=None,
+    )
+
+
+def _worker_metadata():
+    return SimpleNamespace(role="worker", worker_id=0)
+
+
+def _patch_backend_constructors(monkeypatch):
+    # First Party
+    import lmcache_ascend.v1.storage_backend as storage_backend_module
+    import lmcache_ascend.v1.storage_backend.pd as pd_module
+
+    class _FakeLocalCPUBackend:
+        def __init__(self, config, metadata, dst_device, lmcache_worker):
+            self.config = config
+            self.metadata = metadata
+            self.dst_device = dst_device
+            self.lmcache_worker = lmcache_worker
+
+        def __str__(self):
+            return "LocalCPUBackend"
+
+    class _FakePDBackend:
+        def __init__(self, config, metadata):
+            self.config = config
+            self.metadata = metadata
+
+    class _FakeP2PBackend:
+        def __init__(self, config, metadata, loop, local_cpu_backend, lmcache_worker):
+            self.config = config
+            self.metadata = metadata
+            self.loop = loop
+            self.local_cpu_backend = local_cpu_backend
+            self.lmcache_worker = lmcache_worker
+
+        def __str__(self):
+            return "P2PBackend"
+
+    monkeypatch.setattr(storage_backend_module, "is_npu_worker", lambda metadata: False)
+    monkeypatch.setattr(storage_backend_module, "LocalCPUBackend", _FakeLocalCPUBackend)
+    monkeypatch.setattr(storage_backend_module, "AscendP2PBackend", _FakeP2PBackend)
+    monkeypatch.setattr(pd_module, "AscendPDBackend", _FakePDBackend)
+    monkeypatch.setattr(storage_backend_module, "storage_plugin_launcher", MagicMock())
+
+    return storage_backend_module
+
+
+def test_mixed_pd_p2p_sender_provisions_local_cpu_backend(monkeypatch):
+    """P2P construction gets a LocalCPUBackend even when local_cpu is disabled."""
+    storage_backend_module = _patch_backend_constructors(monkeypatch)
+    config = _mixed_sender_config(max_local_cpu_size=16)
+
+    backends = storage_backend_module.CreateStorageBackends(
+        config,
+        _worker_metadata(),
+        MagicMock(),
+        lmcache_worker=MagicMock(),
+    )
+
+    assert list(backends.keys()) == ["PDBackend", "LocalCPUBackend", "P2PBackend"]
+    assert backends["P2PBackend"].local_cpu_backend is backends["LocalCPUBackend"]
+
+
+def test_mixed_pd_p2p_sender_requires_local_cpu_capacity(monkeypatch):
+    """P2P construction reports missing LocalCPUBackend capacity explicitly."""
+    storage_backend_module = _patch_backend_constructors(monkeypatch)
+    config = _mixed_sender_config(max_local_cpu_size=0)
+
+    with pytest.raises(ValueError, match="max_local_cpu_size"):
+        storage_backend_module.CreateStorageBackends(
+            config,
+            _worker_metadata(),
+            MagicMock(),
+            lmcache_worker=MagicMock(),
+        )

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -62,3 +62,26 @@ def test_allocate_and_copy_objects_preserves_key_alignment_after_existing_key():
         src_objs[2].tensor,
         non_blocking=True,
     )
+
+
+def test_batched_contains_uses_pd_request_lease_when_context_set():
+    """Pinned PD receiver lookup should create a request-scoped lease."""
+    # First Party
+    from lmcache_ascend.v1.storage_backend import storage_manager as sm
+
+    keys = ["k0", "k1"]
+    pd_backend = MagicMock()
+    pd_backend.batched_contains_and_lease.return_value = len(keys)
+    manager = MagicMock()
+    manager.get_active_storage_backends.return_value = [("PDBackend", pd_backend)]
+
+    token = sm.set_current_pd_lookup_id("req-1")
+    try:
+        hit_chunks, block_mapping = sm.batched_contains(manager, keys, pin=True)
+    finally:
+        sm.reset_current_pd_lookup_id(token)
+
+    assert hit_chunks == len(keys)
+    assert block_mapping == {"PDBackend": keys}
+    pd_backend.batched_contains_and_lease.assert_called_once_with(keys, "req-1")
+    pd_backend.batched_contains.assert_not_called()

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # ruff: noqa: F401
+# Standard
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
 # Third Party
 from lmcache_tests.v1.storage_backend.test_storage_manager import (
     TestStorageManagerPrefetchCallback,
@@ -8,3 +12,53 @@ from lmcache_tests.v1.storage_backend.test_storage_manager import (
     storage_manager_config,
     storage_manager_metadata,
 )
+
+
+def _make_copy_source():
+    src = MagicMock()
+    src.tensor = MagicMock()
+    src.meta.fmt = "fmt"
+    src.group_prefix_sum = [0, 1]
+    src.get_shape.return_value = "shape"
+    src.get_dtype.return_value = "dtype"
+    return src
+
+
+def _make_copy_target():
+    dst = MagicMock()
+    dst.tensor = MagicMock()
+    return dst
+
+
+def test_allocate_and_copy_objects_preserves_key_alignment_after_existing_key():
+    """Skipped existing keys must not shift copied objects onto wrong keys."""
+    # First Party
+    from lmcache_ascend.v1.storage_backend import storage_manager as sm
+
+    keys = ["k0", "k1", "k2"]
+    src_objs = [_make_copy_source(), _make_copy_source(), _make_copy_source()]
+    dst_objs = [_make_copy_target(), _make_copy_target()]
+
+    allocator = MagicMock()
+    allocator.contains.side_effect = lambda key: key == "k0"
+    allocator.allocate.side_effect = dst_objs
+
+    with patch.object(sm.torch_dev, "stream", return_value=nullcontext()):
+        allocated_keys, allocated_objs = sm.allocate_and_copy_objects(
+            allocator,
+            keys,
+            src_objs,
+            stream=None,
+        )
+
+    assert allocated_keys == ["k1", "k2"]
+    assert allocated_objs == dst_objs
+    assert allocator.allocate.call_count == 2
+    dst_objs[0].tensor.copy_.assert_called_once_with(
+        src_objs[1].tensor,
+        non_blocking=True,
+    )
+    dst_objs[1].tensor.copy_.assert_called_once_with(
+        src_objs[2].tensor,
+        non_blocking=True,
+    )

--- a/tests/v1/test_disagg_proxy_request.py
+++ b/tests/v1/test_disagg_proxy_request.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+# Third Party
+import pytest
+
+EXAMPLE_DIR = Path(__file__).parents[2] / "examples" / "disagg_prefill"
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+# Third Party
+import disagg_proxy_request as request_helpers  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "request_data",
+    [
+        {"tools": []},
+        {"tools": [], "tool_choice": None},
+        {"tools": [], "tool_choice": "none"},
+    ],
+)
+def test_normalize_chat_request_removes_semantically_empty_tools(request_data):
+    request_data.update(
+        {
+            "model": "MiniMax-M2.7",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+    )
+    original = deepcopy(request_data)
+
+    normalized = request_helpers.normalize_chat_request(request_data)
+
+    assert "tools" not in normalized
+    assert request_data == original
+
+
+@pytest.mark.parametrize("tool_choice", ["auto", "required", {"type": "function"}])
+def test_normalize_chat_request_preserves_invalid_tool_choice_for_validation(
+    tool_choice,
+):
+    request_data = {"tools": [], "tool_choice": tool_choice}
+
+    normalized = request_helpers.normalize_chat_request(request_data)
+
+    assert normalized == request_data
+    assert normalized is not request_data
+
+
+def test_chat_decode_preserves_native_request_and_full_output_budget():
+    request_data = {
+        "model": "MiniMax-M2.7",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+        "max_completion_tokens": 150,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 0.7,
+    }
+    original = deepcopy(request_data)
+
+    prefill_request, decode_request = request_helpers.build_chat_phase_requests(
+        request_data,
+        [10, 20, 30],
+    )
+
+    assert request_data == original
+    assert "max_completion_tokens" not in prefill_request
+    assert "stream_options" not in prefill_request
+    assert prefill_request["prompt"] == [10, 20, 30]
+    assert prefill_request["max_tokens"] == 1
+    assert prefill_request["stream"] is False
+    assert decode_request == original
+    assert decode_request is not request_data
+    assert "prompt" not in decode_request
+    assert "kv_transfer_params" not in decode_request
+
+
+def test_chat_decode_leaves_omitted_output_limit_for_vllm_to_resolve():
+    request_data = {
+        "model": "MiniMax-M2.7",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": False,
+    }
+
+    prefill_request, decode_request = request_helpers.build_chat_phase_requests(
+        request_data,
+        [10, 20],
+    )
+
+    assert prefill_request["max_tokens"] == 1
+    assert "max_completion_tokens" not in decode_request
+    assert "max_tokens" not in decode_request
+    assert decode_request["stream"] is False
+    assert "kv_transfer_params" not in decode_request
+
+
+def test_parse_chat_render_output_returns_tokens_and_effective_budget():
+    prompt_token_ids, resolved_max_tokens = request_helpers.parse_chat_render_output(
+        {
+            "token_ids": [10, 20, 30],
+            "sampling_params": {"max_tokens": 196569, "temperature": 1.0},
+        }
+    )
+
+    assert prompt_token_ids == [10, 20, 30]
+    assert resolved_max_tokens == 196569
+
+
+def test_upstream_service_error_preserves_response_details():
+    response = SimpleNamespace(
+        status_code=400,
+        request=SimpleNamespace(
+            url="http://7.150.2.142:7100/v1/chat/completions/render"
+        ),
+        content=b'{"error":{"message":"Input length exceeds model limit"}}',
+        headers={"content-type": "application/json"},
+    )
+
+    error = request_helpers.upstream_service_error_from_response(response)
+
+    assert error.status_code == 400
+    assert error.url == "http://7.150.2.142:7100/v1/chat/completions/render"
+    assert error.body == response.content
+    assert error.content_type == "application/json"
+    assert "Input length exceeds model limit" in str(error)
+
+
+def test_completion_without_max_tokens_uses_vllm_default():
+    request_data = {
+        "model": "MiniMax-M2.7",
+        "prompt": "hello",
+        "stream_options": {"include_usage": True},
+        "ignore_eos": True,
+    }
+    original = deepcopy(request_data)
+
+    prefill_request, decode_request = request_helpers.build_phase_requests(
+        request_data,
+        [10, 20],
+        is_chat=False,
+    )
+
+    assert request_data == original
+    assert prefill_request == {
+        "model": "MiniMax-M2.7",
+        "prompt": [10, 20],
+        "ignore_eos": True,
+        "max_tokens": 1,
+        "stream": False,
+    }
+    assert decode_request == {
+        "model": "MiniMax-M2.7",
+        "prompt": [10, 20],
+        "ignore_eos": True,
+        "max_tokens": 15,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+
+def test_completion_single_token_builds_zero_token_decode_budget():
+    request_data = {
+        "model": "MiniMax-M2.7",
+        "prompt": "hello",
+        "max_tokens": 1,
+        "stream_options": {"include_usage": True},
+    }
+
+    prefill_request, decode_request = request_helpers.build_phase_requests(
+        request_data,
+        [10, 20],
+        is_chat=False,
+    )
+
+    assert prefill_request["max_tokens"] == 1
+    assert prefill_request["stream"] is False
+    assert "stream_options" not in prefill_request
+    assert decode_request["max_tokens"] == 0
+    assert decode_request["stream"] is True
+    assert decode_request["stream_options"] == {"include_usage": True}

--- a/tests/v1/test_disagg_proxy_routing.py
+++ b/tests/v1/test_disagg_proxy_routing.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from types import SimpleNamespace
+import asyncio
+
+# Third Party
+import pytest
+
+# First Party
+from tests.v1.disagg_proxy_test_utils import load_proxy_server
+
+proxy = load_proxy_server()
+
+
+def _client_info(name: str):
+    return proxy.ClientInfo(
+        client=object(),
+        host="127.0.0.1",
+        init_port=[7100],
+        alloc_port=[7200],
+        name=name,
+        base_url=f"http://{name}",
+    )
+
+
+def test_weighted_semaphore_blocks_until_slots_are_released():
+    async def scenario():
+        semaphore = proxy.WeightedSemaphore(3)
+        await semaphore.acquire(2)
+
+        waiter = asyncio.create_task(semaphore.acquire(2))
+        await asyncio.sleep(0)
+
+        assert semaphore.available == 1
+        assert not waiter.done()
+
+        await semaphore.release(2)
+        await asyncio.wait_for(waiter, timeout=1)
+
+        assert semaphore.available == 1
+        await semaphore.release(2)
+        assert semaphore.available == semaphore.capacity == 3
+
+    asyncio.run(scenario())
+
+
+def test_select_and_release_prefiller_updates_load_and_metrics():
+    async def scenario():
+        busier = proxy.PrefillerState(
+            client_info=_client_info("prefiller-0"),
+            name="prefiller-0",
+            host="127.0.0.1",
+            port=8000,
+            active_prefill_requests=1,
+        )
+        selected_state = proxy.PrefillerState(
+            client_info=_client_info("prefiller-1"),
+            name="prefiller-1",
+            host="127.0.0.1",
+            port=8001,
+            active_prefill_tokens=10,
+        )
+        proxy.app.state.prefiller_states = [busier, selected_state]
+        proxy.app.state.prefiller_lock = asyncio.Lock()
+        proxy.app.state.prefiller_select_seq = 0
+
+        selected, route_info = await proxy.select_prefiller(64)
+
+        assert selected is selected_state
+        assert selected.active_prefill_tokens == 74
+        assert selected.active_prefill_requests == 1
+        assert selected.total_prefill_tokens == 64
+        assert selected.total_prefill_requests == 1
+        assert route_info["selected_prefiller"] == "prefiller-1"
+        assert len(route_info["candidate_prefiller_loads"]) == 2
+
+        snapshot = await proxy.release_prefiller(
+            selected,
+            64,
+            success=True,
+            prefill_ms=20.0,
+        )
+
+        assert snapshot["active_prefill_tokens"] == 10
+        assert snapshot["active_prefill_requests"] == 0
+        assert snapshot["last_prefill_ms"] == 20.0
+        assert snapshot["prefill_ms_ewma"] == 20.0
+        assert snapshot["failed_prefill_requests"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_select_and_release_decoder_updates_load_and_metrics():
+    async def scenario():
+        busier = proxy.DecoderState(
+            client_info=_client_info("decoder-0"),
+            name="decoder-0",
+            host="127.0.0.1",
+            port=8100,
+            init_port=[7100],
+            alloc_port=[7200],
+            active_decode_tokens=100,
+        )
+        selected_state = proxy.DecoderState(
+            client_info=_client_info("decoder-1"),
+            name="decoder-1",
+            host="127.0.0.1",
+            port=8101,
+            init_port=[7101],
+            alloc_port=[7201],
+            active_decode_tokens=10,
+        )
+        proxy.app.state.decoder_states = [busier, selected_state]
+        proxy.app.state.decoder_lock = asyncio.Lock()
+        proxy.app.state.decoder_select_seq = 0
+
+        selected, route_info = await proxy.select_decoder(32)
+
+        assert selected is selected_state
+        assert selected.active_decode_tokens == 42
+        assert selected.active_decode_requests == 1
+        assert selected.total_decode_tokens == 32
+        assert selected.total_decode_requests == 1
+        assert route_info["selected_decoder"] == "decoder-1"
+        assert len(route_info["candidate_decoder_loads"]) == 2
+
+        snapshot = await proxy.release_decoder(
+            selected,
+            32,
+            success=False,
+            error="decode failed",
+        )
+
+        assert snapshot["active_decode_tokens"] == 10
+        assert snapshot["active_decode_requests"] == 0
+        assert snapshot["failed_decode_requests"] == 1
+        assert snapshot["last_error"] == "decode failed"
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("transfer_mode", "admission_enabled"),
+    [
+        (proxy.PD_TRANSFER_MODE_PUSH, True),
+        (proxy.PD_TRANSFER_MODE_EAGER_PULL, True),
+        (proxy.PD_TRANSFER_MODE_DELAY_PULL, False),
+    ],
+)
+def test_pd_buffer_admission_matches_transfer_mode(
+    transfer_mode,
+    admission_enabled,
+):
+    async def scenario():
+        semaphore = proxy.WeightedSemaphore(4) if admission_enabled else None
+        decoder = proxy.DecoderState(
+            client_info=_client_info("decoder-0"),
+            name="decoder-0",
+            host="127.0.0.1",
+            port=8100,
+            init_port=[7100],
+            alloc_port=[7200],
+            pd_buffer_semaphore=semaphore,
+            pd_transfer_mode=transfer_mode,
+        )
+        proxy.global_args = SimpleNamespace(chunk_size=16)
+
+        slots, wait_ms, acquired = await proxy.acquire_pd_buffer_slots(decoder, 17)
+
+        if admission_enabled:
+            assert (slots, acquired) == (2, True)
+            assert wait_ms >= 0
+            assert semaphore.available == 2
+            await proxy.release_pd_buffer_slots(decoder, slots)
+            assert semaphore.available == semaphore.capacity == 4
+        else:
+            assert (slots, wait_ms, acquired) == (0, 0.0, False)
+
+    asyncio.run(scenario())

--- a/tests/v1/test_disagg_proxy_server.py
+++ b/tests/v1/test_disagg_proxy_server.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+import asyncio
+import json
+
+# Third Party
+import pytest
+
+# First Party
+from tests.v1.disagg_proxy_test_utils import (
+    FakeRequest,
+    FakeResponse,
+    collect_streaming_response,
+    load_proxy_server,
+)
+
+proxy = load_proxy_server()
+
+
+def _client_info(name: str, *, init_port: list[int] | None = None):
+    return proxy.ClientInfo(
+        client=name,
+        host="127.0.0.1",
+        init_port=init_port or [7100],
+        alloc_port=[7200],
+        name=name,
+        base_url=f"http://{name}",
+    )
+
+
+def _prefiller_state():
+    return proxy.PrefillerState(
+        client_info=_client_info("prefiller"),
+        name="prefiller",
+        host="127.0.0.1",
+        port=8000,
+    )
+
+
+def _decoder_state():
+    return proxy.DecoderState(
+        client_info=_client_info("decoder", init_port=[7100]),
+        name="decoder",
+        host="127.0.0.1",
+        port=8100,
+        init_port=[7100],
+        alloc_port=[7200],
+    )
+
+
+def _prefill_response():
+    return {
+        "id": "cmpl-prefill",
+        "object": "text_completion",
+        "created": 1,
+        "model": "MiniMax-M2.7",
+        "choices": [
+            {
+                "index": 0,
+                "text": "A",
+                "logprobs": None,
+                "finish_reason": "length",
+                "stop_reason": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 2,
+            "completion_tokens": 1,
+            "total_tokens": 3,
+        },
+        "kv_transfer_params": {"first_tok": 30},
+    }
+
+
+@pytest.mark.parametrize("max_tokens", [1, 4])
+def test_completion_endpoint_handles_prefill_only_and_decode_paths(
+    monkeypatch,
+    max_tokens,
+):
+    async def scenario():
+        tokenization_client = _client_info("tokenizer")
+        prefiller = _prefiller_state()
+        decoder = _decoder_state()
+        service_calls = []
+        decode_requests = []
+
+        async def send_request(client, endpoint, req_data):
+            service_calls.append((client, endpoint, deepcopy(req_data)))
+            if endpoint == "/tokenize":
+                return FakeResponse({"tokens": [10, 20]})
+            assert client == "prefiller"
+            assert endpoint == "/v1/completions"
+            return FakeResponse(_prefill_response())
+
+        async def stream_response(client, endpoint, req_data):
+            assert client == "decoder"
+            assert endpoint == "/v1/completions"
+            decode_requests.append(deepcopy(req_data))
+            yield b"data: [DONE]\n\n"
+
+        release_prefiller = AsyncMock(return_value={})
+        release_decoder = AsyncMock(return_value={})
+        select_decoder = AsyncMock(return_value=(decoder, {}))
+        monkeypatch.setattr(proxy, "counter", 0)
+        monkeypatch.setattr(proxy, "stats_calculator", SimpleNamespace(add=Mock()))
+        monkeypatch.setattr(
+            proxy,
+            "pick_up_tokenization_client",
+            lambda _request: tokenization_client,
+        )
+        monkeypatch.setattr(proxy, "send_request_to_service", send_request)
+        monkeypatch.setattr(proxy, "stream_service_response", stream_response)
+        monkeypatch.setattr(
+            proxy,
+            "select_prefiller",
+            AsyncMock(return_value=(prefiller, {})),
+        )
+        monkeypatch.setattr(proxy, "release_prefiller", release_prefiller)
+        monkeypatch.setattr(proxy, "select_decoder", select_decoder)
+        monkeypatch.setattr(proxy, "release_decoder", release_decoder)
+        monkeypatch.setattr(
+            proxy,
+            "acquire_pd_buffer_slots",
+            AsyncMock(return_value=(0, 0.0, False)),
+        )
+        monkeypatch.setattr(proxy, "wait_decode_kv_ready", AsyncMock())
+        monkeypatch.setattr(proxy, "log_route_event", Mock())
+
+        request = FakeRequest(
+            {
+                "model": "MiniMax-M2.7",
+                "prompt": "hello",
+                "max_tokens": max_tokens,
+                "stream_options": {"include_usage": True},
+            }
+        )
+        response = await proxy.handle_completions(request)
+        body = await collect_streaming_response(response)
+
+        assert service_calls[0] == (
+            "tokenizer",
+            "/tokenize",
+            {"prompt": "hello"},
+        )
+        release_prefiller.assert_awaited_once()
+
+        if max_tokens == 1:
+            select_decoder.assert_not_awaited()
+            release_decoder.assert_not_awaited()
+            assert not decode_requests
+            assert b'"text":"A"' in body
+            assert b'"finish_reason":"length"' in body
+            assert b'"completion_tokens":1' in body
+        else:
+            select_decoder.assert_awaited_once_with(2)
+            release_decoder.assert_awaited_once()
+            assert decode_requests == [
+                {
+                    "model": "MiniMax-M2.7",
+                    "prompt": [10, 20, 30],
+                    "max_tokens": 3,
+                    "stream": True,
+                    "stream_options": {"include_usage": True},
+                }
+            ]
+            assert b'"text":"A"' in body
+
+        assert body.endswith(b"data: [DONE]\n\n")
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_chat_endpoint_preserves_native_stream_and_nonstream_responses(
+    monkeypatch,
+    stream,
+):
+    async def scenario():
+        render_client = _client_info("renderer")
+        prefiller = _prefiller_state()
+        decoder = _decoder_state()
+        prefill_requests = []
+        decode_requests = []
+        tool_call_chunk = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": "{}"},
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+        nonstream_body = json.dumps(
+            {
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "choices": [{"message": {"tool_calls": [{"id": "call-1"}]}}],
+            }
+        ).encode()
+
+        async def send_request(client, endpoint, req_data):
+            if endpoint == "/v1/chat/completions/render":
+                assert client == "renderer"
+                return FakeResponse(
+                    {
+                        "token_ids": [10, 20],
+                        "sampling_params": {"max_tokens": 32},
+                    }
+                )
+            if client == "prefiller":
+                assert endpoint == "/v1/completions"
+                prefill_requests.append(deepcopy(req_data))
+                return FakeResponse({"choices": [{"text": "discarded"}]})
+            assert client == "decoder"
+            assert endpoint == "/v1/chat/completions"
+            decode_requests.append(deepcopy(req_data))
+            return FakeResponse(content=nonstream_body)
+
+        async def stream_response(client, endpoint, req_data):
+            assert client == "decoder"
+            assert endpoint == "/v1/chat/completions"
+            decode_requests.append(deepcopy(req_data))
+            yield proxy.encode_sse_data(tool_call_chunk)
+            yield b"data: [DONE]\n\n"
+
+        release_decoder = AsyncMock(return_value={})
+        monkeypatch.setattr(proxy, "counter", 0)
+        monkeypatch.setattr(proxy, "stats_calculator", SimpleNamespace(add=Mock()))
+        monkeypatch.setattr(proxy.app.state, "prefill_clients", [render_client])
+        monkeypatch.setattr(proxy, "send_request_to_service", send_request)
+        monkeypatch.setattr(proxy, "stream_service_response", stream_response)
+        monkeypatch.setattr(
+            proxy,
+            "select_prefiller",
+            AsyncMock(return_value=(prefiller, {})),
+        )
+        monkeypatch.setattr(proxy, "release_prefiller", AsyncMock(return_value={}))
+        monkeypatch.setattr(
+            proxy,
+            "select_decoder",
+            AsyncMock(return_value=(decoder, {})),
+        )
+        monkeypatch.setattr(proxy, "release_decoder", release_decoder)
+        monkeypatch.setattr(
+            proxy,
+            "acquire_pd_buffer_slots",
+            AsyncMock(return_value=(0, 0.0, False)),
+        )
+        monkeypatch.setattr(proxy, "wait_decode_kv_ready", AsyncMock())
+        monkeypatch.setattr(proxy, "log_route_event", Mock())
+
+        request_data = {
+            "model": "MiniMax-M2.7",
+            "messages": [{"role": "user", "content": "weather"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+            "stream": stream,
+        }
+        response = await proxy.handle_chat_completions(FakeRequest(request_data))
+
+        if stream:
+            body = await collect_streaming_response(response)
+            assert b'"tool_calls"' in body
+            assert body.endswith(b"data: [DONE]\n\n")
+        else:
+            assert response.body == nonstream_body
+            assert response.status_code == 200
+
+        assert len(prefill_requests) == 1
+        assert prefill_requests[0]["prompt"] == [10, 20]
+        assert prefill_requests[0]["max_tokens"] == 1
+        assert prefill_requests[0]["stream"] is False
+        assert "disagg_spec" in prefill_requests[0]["kv_transfer_params"]
+        assert decode_requests == [request_data]
+        assert "kv_transfer_params" not in decode_requests[0]
+        release_decoder.assert_awaited_once()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("failure_stage", ["prefill", "stream"])
+def test_request_failure_and_cancellation_release_resources_once(
+    monkeypatch,
+    failure_stage,
+):
+    async def scenario():
+        tokenization_client = _client_info("tokenizer")
+        prefiller = _prefiller_state()
+        decoder = _decoder_state()
+
+        async def send_request(client, endpoint, req_data):
+            if endpoint == "/tokenize":
+                return FakeResponse({"tokens": [10, 20]})
+            if failure_stage == "prefill":
+                raise RuntimeError("prefill failed")
+            return FakeResponse(_prefill_response())
+
+        async def cancelled_stream(_client, _endpoint, _req_data):
+            raise asyncio.CancelledError
+            yield b""  # pragma: no cover
+
+        release_prefiller = AsyncMock(return_value={})
+        release_decoder = AsyncMock(return_value={})
+        release_slots = AsyncMock()
+        monkeypatch.setattr(proxy, "counter", 0)
+        monkeypatch.setattr(proxy, "stats_calculator", SimpleNamespace(add=Mock()))
+        monkeypatch.setattr(
+            proxy,
+            "pick_up_tokenization_client",
+            lambda _request: tokenization_client,
+        )
+        monkeypatch.setattr(proxy, "send_request_to_service", send_request)
+        monkeypatch.setattr(proxy, "stream_service_response", cancelled_stream)
+        monkeypatch.setattr(
+            proxy,
+            "select_prefiller",
+            AsyncMock(return_value=(prefiller, {})),
+        )
+        monkeypatch.setattr(proxy, "release_prefiller", release_prefiller)
+        monkeypatch.setattr(
+            proxy,
+            "select_decoder",
+            AsyncMock(return_value=(decoder, {})),
+        )
+        monkeypatch.setattr(proxy, "release_decoder", release_decoder)
+        monkeypatch.setattr(
+            proxy,
+            "acquire_pd_buffer_slots",
+            AsyncMock(return_value=(2, 0.0, True)),
+        )
+        monkeypatch.setattr(proxy, "release_pd_buffer_slots", release_slots)
+        monkeypatch.setattr(proxy, "wait_decode_kv_ready", AsyncMock())
+        monkeypatch.setattr(proxy, "log_route_event", Mock())
+
+        request = FakeRequest(
+            {
+                "model": "MiniMax-M2.7",
+                "prompt": "hello",
+                "max_tokens": 4,
+            }
+        )
+
+        if failure_stage == "prefill":
+            with pytest.raises(RuntimeError, match="prefill failed"):
+                await proxy.handle_completions(request)
+        else:
+            response = await proxy.handle_completions(request)
+            with pytest.raises(asyncio.CancelledError):
+                await collect_streaming_response(response)
+
+        release_prefiller.assert_awaited_once()
+        release_decoder.assert_awaited_once()
+        release_slots.assert_awaited_once_with(decoder, 2)
+        assert release_prefiller.await_args.kwargs["success"] is (
+            failure_stage == "stream"
+        )
+        assert release_decoder.await_args.kwargs["success"] is False
+
+    asyncio.run(scenario())

--- a/tests/v1/test_disagg_proxy_server.py
+++ b/tests/v1/test_disagg_proxy_server.py
@@ -280,6 +280,7 @@ def test_chat_endpoint_preserves_native_stream_and_nonstream_responses(
         response = await proxy.handle_chat_completions(FakeRequest(request_data))
 
         if stream:
+            release_decoder.assert_not_awaited()
             body = await collect_streaming_response(response)
             assert b'"tool_calls"' in body
             assert body.endswith(b"data: [DONE]\n\n")
@@ -299,7 +300,7 @@ def test_chat_endpoint_preserves_native_stream_and_nonstream_responses(
     asyncio.run(scenario())
 
 
-@pytest.mark.parametrize("failure_stage", ["prefill", "stream"])
+@pytest.mark.parametrize("failure_stage", ["prefill", "cancelled_prefill", "stream"])
 def test_request_failure_and_cancellation_release_resources_once(
     monkeypatch,
     failure_stage,
@@ -314,6 +315,8 @@ def test_request_failure_and_cancellation_release_resources_once(
                 return FakeResponse({"tokens": [10, 20]})
             if failure_stage == "prefill":
                 raise RuntimeError("prefill failed")
+            if failure_stage == "cancelled_prefill":
+                raise asyncio.CancelledError
             return FakeResponse(_prefill_response())
 
         async def cancelled_stream(_client, _endpoint, _req_data):
@@ -364,6 +367,9 @@ def test_request_failure_and_cancellation_release_resources_once(
         if failure_stage == "prefill":
             with pytest.raises(RuntimeError, match="prefill failed"):
                 await proxy.handle_completions(request)
+        elif failure_stage == "cancelled_prefill":
+            with pytest.raises(asyncio.CancelledError):
+                await proxy.handle_completions(request)
         else:
             response = await proxy.handle_completions(request)
             with pytest.raises(asyncio.CancelledError):
@@ -376,5 +382,175 @@ def test_request_failure_and_cancellation_release_resources_once(
             failure_stage == "stream"
         )
         assert release_decoder.await_args.kwargs["success"] is False
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("exit_error", [False, True])
+def test_lifespan_closes_idle_zmq_socket_and_can_restart(monkeypatch, exit_error):
+    async def scenario():
+        sockets = []
+        clients = []
+        receiving = asyncio.Event()
+
+        async def recv():
+            receiving.set()
+            await asyncio.Event().wait()
+
+        def make_socket(_socket_type):
+            socket = SimpleNamespace(bind=Mock(), recv=recv, close=Mock())
+            sockets.append(socket)
+            return socket
+
+        def make_client(**_kwargs):
+            client = SimpleNamespace(aclose=AsyncMock())
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr(proxy.app, "state", SimpleNamespace())
+        monkeypatch.setattr(proxy, "run_proxy", True)
+        monkeypatch.setattr(proxy, "zmq_ctx", SimpleNamespace(socket=make_socket))
+        monkeypatch.setattr(proxy.httpx, "AsyncClient", make_client)
+        monkeypatch.setattr(
+            proxy,
+            "global_args",
+            SimpleNamespace(
+                prefiller_host=["localhost"],
+                prefiller_port=[8000],
+                num_prefillers=1,
+                decoder_host=["localhost"],
+                decoder_port=[8100],
+                num_decoders=1,
+                decoder_init_port=[7100],
+                decoder_alloc_port=[7200],
+                pd_transfer_mode="delay_pull",
+                pd_buffer_size=1024,
+                proxy_host="localhost",
+                proxy_port=9999,
+            ),
+            raising=False,
+        )
+
+        async def enter_and_exit():
+            async with proxy.lifespan(proxy.app):
+                await receiving.wait()
+                if exit_error:
+                    raise RuntimeError("lifespan body failed")
+
+        for _ in range(2):
+            receiving.clear()
+            if exit_error:
+                with pytest.raises(RuntimeError, match="lifespan body failed"):
+                    await asyncio.wait_for(enter_and_exit(), timeout=1)
+            else:
+                await asyncio.wait_for(enter_and_exit(), timeout=1)
+            assert proxy.app.state.zmq_task.done()
+            assert not proxy.run_proxy
+            sockets[-1].close.assert_called_once()
+
+        assert len(sockets) == 2
+        assert len(clients) == 4
+        for client in clients:
+            client.aclose.assert_awaited_once()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("transfer_mode", "stream", "cancel_stage"),
+    [
+        ("eager_pull", False, "kv_ready"),
+        ("eager_pull", False, "decode"),
+        ("eager_pull", True, "prefill"),
+        ("delay_pull", False, "kv_ready"),
+    ],
+)
+def test_chat_cancellation_releases_accounting_and_permits(
+    monkeypatch, transfer_mode, stream, cancel_stage
+):
+    async def scenario():
+        prefiller = _prefiller_state()
+        decoder = _decoder_state()
+        decoder.pd_transfer_mode = transfer_mode
+        if transfer_mode == "eager_pull":
+            decoder.pd_buffer_semaphore = proxy.WeightedSemaphore(2)
+        reached = asyncio.Event()
+
+        async def block_until_cancelled():
+            reached.set()
+            await asyncio.Event().wait()
+
+        async def send_request(_client, endpoint, _data):
+            if endpoint.endswith("/render"):
+                return FakeResponse(
+                    {"token_ids": [10, 20], "sampling_params": {"max_tokens": 32}}
+                )
+            if endpoint == "/v1/completions":
+                if cancel_stage == "prefill":
+                    await block_until_cancelled()
+                return FakeResponse({"choices": [{"text": "discarded"}]})
+            assert endpoint == "/v1/chat/completions"
+            await block_until_cancelled()
+
+        async def wait_ready(*_args):
+            if cancel_stage == "kv_ready":
+                await block_until_cancelled()
+
+        release_prefiller = AsyncMock(wraps=proxy.release_prefiller)
+        release_decoder = AsyncMock(wraps=proxy.release_decoder)
+        release_slots = AsyncMock(wraps=proxy.release_pd_buffer_slots)
+        monkeypatch.setattr(
+            proxy.app,
+            "state",
+            SimpleNamespace(
+                prefill_clients=[prefiller.client_info],
+                prefiller_states=[prefiller],
+                decoder_states=[decoder],
+                prefiller_lock=asyncio.Lock(),
+                decoder_lock=asyncio.Lock(),
+                prefiller_select_seq=0,
+                decoder_select_seq=0,
+            ),
+        )
+        monkeypatch.setattr(
+            proxy, "global_args", SimpleNamespace(chunk_size=1), raising=False
+        )
+        monkeypatch.setattr(proxy, "stats_calculator", SimpleNamespace(add=Mock()))
+        monkeypatch.setattr(proxy, "send_request_to_service", send_request)
+        monkeypatch.setattr(proxy, "wait_decode_kv_ready", wait_ready)
+        monkeypatch.setattr(proxy, "release_prefiller", release_prefiller)
+        monkeypatch.setattr(proxy, "release_decoder", release_decoder)
+        monkeypatch.setattr(proxy, "release_pd_buffer_slots", release_slots)
+        monkeypatch.setattr(proxy, "log_route_event", Mock())
+        request = FakeRequest(
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": stream,
+            }
+        )
+        task = asyncio.create_task(proxy.handle_chat_completions(request))
+        try:
+            await asyncio.wait_for(reached.wait(), timeout=1)
+            assert decoder.active_decode_requests == 1
+            assert decoder.active_decode_tokens == 2
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert decoder.active_decode_requests == decoder.active_decode_tokens == 0
+        assert prefiller.active_prefill_requests == prefiller.active_prefill_tokens == 0
+        release_decoder.assert_awaited_once()
+        assert release_decoder.await_args.kwargs["success"] is False
+        release_prefiller.assert_awaited_once()
+        assert release_prefiller.await_args.kwargs["success"] is (
+            cancel_stage != "prefill"
+        )
+        if transfer_mode == "eager_pull":
+            release_slots.assert_awaited_once_with(decoder, 2)
+            assert decoder.pd_buffer_semaphore.available == 2
+        else:
+            release_slots.assert_not_awaited()
 
     asyncio.run(scenario())

--- a/tests/v1/test_pd_p2p_config.py
+++ b/tests/v1/test_pd_p2p_config.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+from lmcache.v1.config import LMCacheEngineConfig
+import pytest
+
+
+def _mixed_sender_config():
+    config = LMCacheEngineConfig.from_defaults(
+        **{
+            "enable_pd": True,
+            "enable_p2p": True,
+            "pd_role": "sender",
+            "pd_buffer_size": 1024,
+            "pd_buffer_device": "cpu",
+            "enable_controller": True,
+            "lmcache_instance_id": "mixed-sender",
+            "controller_pull_url": "localhost:9800",
+            "controller_reply_url": "localhost:9900",
+            "lmcache_worker_ports": [9950],
+            "p2p_host": "localhost",
+            "p2p_init_ports": [9960],
+            "p2p_lookup_ports": [9962],
+            "transfer_channel": "hccl",
+            "enable_async_loading": False,
+        }
+    )
+    return config
+
+
+def test_mixed_sender_keeps_upstream_pd_validation():
+    config = _mixed_sender_config()
+    config.save_unfull_chunk = False
+    assert config.validate() is config
+    assert config.enable_p2p is True
+    assert config.save_unfull_chunk is True
+    assert config.ascend_flatten_multi_spec is True
+    assert config.ascend_bundle_multi_spec is True
+    assert config.ascend_skip_state_groups is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("pd_role", "receiver"),
+        ("enable_async_loading", True),
+        ("enable_controller", False),
+        ("controller_pull_url", None),
+        ("controller_reply_url", None),
+        ("lmcache_worker_ports", []),
+        ("p2p_host", None),
+        ("p2p_init_ports", None),
+        ("p2p_lookup_ports", None),
+        ("transfer_channel", None),
+    ],
+)
+def test_mixed_sender_rejects_invalid_p2p_config(field, value):
+    config = _mixed_sender_config()
+    setattr(config, field, value)
+    with pytest.raises(ValueError, match=field):
+        config.validate()
+    assert config.enable_p2p is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("pd_backend_mode", "invalid", ValueError),
+        ("pd_buffer_size", None, AssertionError),
+        ("lmcache_instance_id", None, ValueError),
+    ],
+)
+def test_mixed_sender_restores_p2p_after_upstream_validation_error(field, value, error):
+    config = _mixed_sender_config()
+    setattr(config, field, value)
+    with pytest.raises(error):
+        config.validate()
+    assert config.enable_p2p is True


### PR DESCRIPTION
## Overview

This PR enables PD and P2P to work together on the Ascend sender path and adds a token-aware proxy for disaggregated prefill/decode serving.

It combines the lifecycle improvements from #273 with proxy routing and request handling, targeting `dsv4_support_045` while preserving its existing multi-group KV support. The changes are not specific to a single model.

## Impact

The backend changes address mixed PD/P2P initialization, incorrect key/object pairing after skipped allocations, shared receiver entry ownership, and preemption metadata propagation(for vllm 0.23.0).

The proxy adds token-aware load distribution across prefill and decode instances, transfer-mode-aware admission control, and separate handling for Completion and native Chat requests.

## What changed

### Configuration and sender-side correctness
- Allow `enable_pd=true` and `enable_p2p=true` for `pd_role="sender"`, with explicit validation and upstream LMCache 0.4.5 checks preserved.
- Provision LocalCPUBackend for mixed senders even when local CPU caching is disabled, and report missing capacity explicitly.
- Track allocated keys alongside copied objects, preserving key/object alignment when existing keys are skipped.
- Retain multi-group shape/dtype allocation and device-independent stream handling.
- Clamp producer store skip to tokens already transferred to the decoder.

### Receiver lifecycle and preemption
- Track receiver entries and request ownership through lookup/retrieve contexts.
- Use request-local delay-pull proxy clones so consuming one request's proxy does not invalidate another request's hit.
- Release request leases during lookup unpin and retrieve cleanup; defer PD Done signaling until the final active request lease is released.
- Remove both receiver indexes during partial push allocation rollback without double-releasing objects.
- Carry scheduler preemption IDs alongside multi-group connector metadata, retaining legacy set payload compatibility and existing cleanup/drain behavior.
- Include #274 as a prerequisite and preserve its proxy refcount/pin handling.

### Token-aware disaggregated proxy
- Introduce the upstream-derived proxy and extend it with prompt-token-aware prefill/decode routing.
- Track per-instance request/token load and expose routing decisions and service timing metrics.
- Apply best-effort weighted buffer admission in push and eager-pull modes; disable buffer-size admission for delay-pull.
- For Completion requests, reuse the prefiller's first output token, adjust the remaining decode budget, and handle single-token requests without invoking the decoder.
- For Chat requests, render prompt tokens through vLLM, use an internal prefill request, and retain native Chat decoding with the full client-visible output budget.
- Preserve upstream HTTP error details and release proxy accounting resources on tested failure and cancellation paths.

## Tests

Added and adjusted regression coverage for:
- Mixed sender configuration, upstream validation, and LocalCPUBackend initialization.
- Key/object alignment, multi-group byte copying, and producer skip clamping.
- Shared receiver leases, request-local proxy isolation, final-lease Done signaling, and allocation rollback.
- Multi-group metadata preservation, preemption payload compatibility, and retrieve context cleanup.
- Proxy request construction, routing/accounting, transfer-mode admission, native Chat responses, and failure/cancellation cleanup.

## Scope note

This PR retains the existing multi-group implementation rather than introducing a new model-specific KV layout.

Delay-pull is the primary deployment mode, with identically configured prefill instances and a validated homogeneous P/D topology. Generalized multi-group buffer capacity estimation and heterogeneous topology support are deferred; proxy admission remains best-effort.

Additional handoff-ID propagation and protection for the interval before decoder request leases are established remain follow-up work.
Validation:
- Pre-commit checks passed for the migrated changes.
- Proxy tests passed: 24 cases, run independently of the NPU test bootstrap.
- The original implementation was end-to-end tested before migration. Full backend/NPU and end-to-end validation on this target branch remains pending.

## Scope note

This PR retains the existing multi-group implementation rather than introducing a new model-specific KV layout.

Delay-pull is the primary pd deployment mode, with identically configured prefill instances and a validated homogeneous P/D topology. Generalized multi-group buffer capacity estimation(in proxy) and heterogeneous topology support are deferred; proxy admission remains best-effort.

Additional handoff-ID propagation and protection for the interval before decoder request leases are established remain follow-up work.