### PR TITLE
 fix: handle_preemptions crashes on vLLM v0.25.1rc (KVConnectorMetadata API change)

### DIFF
--- a/lmcache_ascend/integration/vllm/multi_group_vllm_adapter.py
+++ b/lmcache_ascend/integration/vllm/multi_group_vllm_adapter.py
@@ -628,6 +628,11 @@ class LMCacheConnectorV1ImplMultiGroup(LMCacheConnectorV1Impl):
 
         meta = LMCacheConnectorMetadata()
 
+        # vLLM v1's handle_preemptions() receives only the connector metadata,
+        # not the preempted req-id set. Stash it here so the worker-side
+        # handle_preemptions() can recover it (see vllm_v1_adapter.py).
+        meta.preempted_req_ids = set(scheduler_output.preempted_req_ids or ())
+
         for finished_req_id in scheduler_output.finished_req_ids:
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -689,11 +689,21 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
         # build_connector_meta() stashed the preempted ids on the metadata;
         # fall back to the legacy set[str] argument for older vLLM.
         if hasattr(kv_connector_metadata, "preempted_req_ids"):
+            # vLLM v0.25.1rc+: metadata carries the stashed id set.
             preempted_req_ids = set(kv_connector_metadata.preempted_req_ids or ())
         elif isinstance(kv_connector_metadata, (set, list, tuple)):
+            # Legacy vLLM passed the id set directly.
             preempted_req_ids = set(kv_connector_metadata)
         else:
-            preempted_req_ids = set()
+            # Unknown shape: fail fast instead of silently no-op'ing, so a
+            # future vLLM API change surfaces immediately rather than
+            # silently skipping preemption cleanup (lookup_unpin / async
+            # store drain), which is the exact failure mode this fix targets.
+            raise TypeError(
+                "handle_preemptions expects a KVConnectorMetadata with "
+                "'preempted_req_ids' or a set/list/tuple of req ids, got "
+                f"{type(kv_connector_metadata).__name__}"
+            )
 
         logger.debug(
             "LMCache-Ascend handling preemptions: req_ids=%s",

--- a/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache_ascend/integration/vllm/vllm_v1_adapter.py
@@ -680,9 +680,20 @@ class LMCacheAscendConnectorV1Impl(LMCacheConnectorV1ImplMultiGroup):
             None,
         )
 
-    def handle_preemptions(self, preempted_req_ids: set[str]) -> None:
+    def handle_preemptions(self, kv_connector_metadata) -> None:
         if self.lmcache_engine is None:
             return
+
+        # vLLM v0.25.1rc changed handle_preemptions() to pass the
+        # KVConnectorMetadata object instead of a set[str] of req ids.
+        # build_connector_meta() stashed the preempted ids on the metadata;
+        # fall back to the legacy set[str] argument for older vLLM.
+        if hasattr(kv_connector_metadata, "preempted_req_ids"):
+            preempted_req_ids = set(kv_connector_metadata.preempted_req_ids or ())
+        elif isinstance(kv_connector_metadata, (set, list, tuple)):
+            preempted_req_ids = set(kv_connector_metadata)
+        else:
+            preempted_req_ids = set()
 
         logger.debug(
             "LMCache-Ascend handling preemptions: req_ids=%s",

--- a/tests/integration/vllm/test_handle_preemptions.py
+++ b/tests/integration/vllm/test_handle_preemptions.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import pickle
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -102,3 +103,87 @@ def test_ascend_adapter_skips_preemption_drain_when_not_required(
 
     if has_engine:
         lmcache_engine.wait_for_pending_stores.assert_not_called()
+
+
+def _import_metadata():
+    """Import LMCacheConnectorMetadata for constructing v0.25.1rc-style args."""
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    # First Party
+    from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorMetadata
+
+    return LMCacheConnectorMetadata
+
+
+def test_ascend_adapter_handles_v0251rc_metadata_path():
+    """v0.25.1rc passes a KVConnectorMetadata with stashed preempted_req_ids.
+
+    This is the primary fix path: ``build_connector_meta`` stashes the id set
+    on the metadata, and ``handle_preemptions`` recovers it via ``hasattr``.
+    """
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+    LMCacheConnectorMetadata = _import_metadata()
+
+    lmcache_engine = MagicMock()
+    lmcache_engine.wait_for_pending_stores.return_value = set()
+    adapter = _make_adapter(
+        adapter_mod,
+        store_async=True,
+        kv_role="kv_both",
+        lmcache_engine=lmcache_engine,
+    )
+
+    meta = LMCacheConnectorMetadata()
+    meta.preempted_req_ids = {"req-1", "req-2"}
+
+    adapter.handle_preemptions(meta)
+
+    # lookup_unpin is called once per preempted id (request-scoped pins).
+    assert lmcache_engine.lookup_unpin.call_count == 2
+    unpinned = {call.args[0] for call in lmcache_engine.lookup_unpin.call_args_list}
+    assert unpinned == {"req-1", "req-2"}
+    # The recovered set reaches wait_for_pending_stores, not the metadata object.
+    lmcache_engine.wait_for_pending_stores.assert_called_once_with({"req-1", "req-2"})
+
+
+def test_ascend_adapter_preemption_ids_survive_pickle_round_trip():
+    """Stashed preempted_req_ids must survive scheduler->worker pickle IPC.
+
+    ``build_connector_meta`` runs scheduler-side; ``handle_preemptions``
+    runs worker-side and receives the unpickled metadata. A plain @dataclass
+    without ``slots=True`` carries dynamically attached attributes through the
+    default ``__dict__`` pickle path — this test locks that contract so a
+    future ``slots=True`` addition does not silently drop the attribute.
+    """
+    LMCacheConnectorMetadata = _import_metadata()
+
+    meta = LMCacheConnectorMetadata()
+    meta.preempted_req_ids = {"req-1", "req-2", "req-3"}
+
+    restored = pickle.loads(pickle.dumps(meta))
+    assert hasattr(restored, "preempted_req_ids")
+    assert restored.preempted_req_ids == {"req-1", "req-2", "req-3"}
+
+
+def test_ascend_adapter_handle_preemptions_fails_fast_on_unknown_arg():
+    """An unknown argument type must raise, not silently no-op.
+
+    Silent ``set()`` would skip ``lookup_unpin`` and async store drain with no
+    signal — the exact failure mode this fix targets. Fail fast so future vLLM
+    API drift surfaces immediately.
+    """
+    pytest.importorskip("lmcache")
+    pytest.importorskip("vllm")
+    adapter_mod = pytest.importorskip("lmcache_ascend.integration.vllm.vllm_v1_adapter")
+
+    adapter = _make_adapter(
+        adapter_mod,
+        store_async=False,
+        kv_role="kv_both",
+        lmcache_engine=MagicMock(),
+    )
+
+    with pytest.raises(TypeError, match="handle_preemptions expects"):
+        adapter.handle_preemptions(object())


### PR DESCRIPTION
### Summary

LMCacheAscendConnectorV1Impl.handle_preemptions crashes on vLLM v0.25.1rc, causing the vLLM + Ascend + LMCache
shared L2 cache setup to raise an exception on every step that triggers a preemption.

### Root cause

vLLM v0.25.1rc changed the signature of KVConnectorBase_V1.handle_preemptions() from

def handle_preemptions(self, preempted_req_ids: set[str]) -> None:

to

def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata) -> None:

vllm-ascend's model_runner_v1.py invokes this hook every step. The dsv4_support_045 branch still forwarded the
argument as a plain set[str], so sorted(preempted_req_ids) raised:

TypeError: 'KVConnectorMetadata' object is not iterable

### Environment

┌────────────────┬───────────────────────────────────────────────┐
│   Component                    │                    Version                                                                                          │
├────────────────┼───────────────────────────────────────────────┤
│ Model                               │ DeepSeek-V4-Flash-0731-w8a8                                                                      │
├────────────────┼───────────────────────────────────────────────┤
│ vllm-ascend                      │ v0.25.1rc                                                                                                          │
├────────────────┼───────────────────────────────────────────────┤
│ LMCache                          │ v0.4.5                                                                                                                │
├────────────────┼───────────────────────────────────────────────┤
│ LMCache-Ascend             │ dsv4_support_045                                                                                            │
├────────────────┼───────────────────────────────────────────────┤
│ Setup                                │ vLLM + Ascend + LMCache shared L2 cache, TP=8                                        │
└────────────────┴───────────────────────────────────────────────┘

### Fix

Two minimal changes:

1. multi_group_vllm_adapter.py — in build_connector_meta(), while scheduler_output is still in scope, stash preempted_req_ids onto the metadata:
  meta.preempted_req_ids = set(scheduler_output.preempted_req_ids or ())
2. vllm_v1_adapter.py — handle_preemptions() now accepts kv_connector_metadata and recovers preempted_req_ids from it, with a fallback to the legacy set[str]/list/tuple argument shape for older vLLM:
def handle_preemptions(self, kv_connector_metadata) -> None:
  if self.lmcache_engine is None:
      return
  if hasattr(kv_connector_metadata, "preempted_req_ids"):
      preempted_req_ids = set(kv_connector_metadata.preempted_req_ids or ())
  elif isinstance(kv_connector_metadata, (set, list, tuple)):
      preempted_req_ids = set(kv_connector_metadata)
  else:
      preempted_req_ids = set()

### Why stash on metadata (and why it's pickle-safe)

build_connector_meta runs on the scheduler side; handle_preemptions runs on the worker side. The metadata crosses the process boundary via pickle. Attaching preempted_req_ids dynamically is safe — verified:
- LMCacheConnectorMetadata is a plain @dataclass (no slots=True);
- its base KVConnectorMetadata is a bare ABC (pass only, no __slots__);
- nothing in the MRO defines __getstate__/__setstate__/__reduce__;

so the default __dict__-based pickle carries the attribute through unchanged, and the worker-side hasattr(...)
branch recovers it.

▎ Caveat: if a future vLLM adds __slots__ or slots=True to KVConnectorMetadata, this must switch to declaring
▎ preempted_req_ids: set[str] = field(default_factory=set) on LMCacheConnectorMetadata explicitly.

### Backward compatibility
The set/list/tuple fallback preserves behavior on older vLLM versions that still pass set[str].

### Changes
- lmcache_ascend/integration/vllm/multi_group_vllm_adapter.py (+5)
- lmcache_ascend/integration/vllm/vllm_v1_adapter.py (+12, -1)

### Testing

Verified on DeepSeek-V4-Flash-0731-w8a8 + vllm-ascend v0.25.1rc + lmcache v0.4.5 + lmcache-ascend dsv4_support_045,
TP=8, shared L2 cache. Before the fix, the preemption path raised TypeError: 'KVConnectorMetadata' object is not
iterable every step; after the fix, preemption recovery proceeds normally with no error.
```
### lmcache-p2p-a.yaml  ###
chunk_size: 1024
local_cpu: true
max_local_cpu_size: 1
enable_async_loading: true
use_layerwise: false
numa_mode: "auto"
save_unfull_chunk: false

# Cross-node P2P KV sharing
enable_p2p: true
p2p_host: "10.0.130.70"
p2p_init_ports: [8200, 8201, 8202, 8203, 8204, 8205, 8206, 8207]
p2p_lookup_ports: [8210, 8211, 8212, 8213, 8214, 8215, 8216, 8217]
transfer_channel: "hccl"
p2p_use_npu: false
p2p_pull_mode: true
p2p_delay_pull: false
p2p_npu_buffer_size: 134217728


enable_controller: true
lmcache_instance_id: "lmcache_colocated_a"
controller_pull_url: "10.0.130.70:9800"
controller_reply_url: "10.0.130.70:9900"
lmcache_worker_ports: [8500, 8501, 8502, 8503, 8504, 8505, 8506, 8507]

extra_config:
  save_only_first_rank: true
  use_host_staging: true
  os_staging_bytes: 8589934592
  lookup_backoff_time: 0.001
  first_rank_max_local_cpu_size: 150

### lmcache-p2p-b.yaml ###
chunk_size: 1024
local_cpu: true
max_local_cpu_size: 1
enable_async_loading: true
use_layerwise: false
numa_mode: "auto"
save_unfull_chunk: false

# Cross-node P2P KV sharing
enable_p2p: true
p2p_host: "10.0.130.70"
p2p_init_ports: [8300, 8301, 8302, 8303, 8304, 8305, 8306, 8307]
p2p_lookup_ports: [8310, 8311, 8312, 8313, 8314, 8315, 8316, 8317]
transfer_channel: "hccl"
p2p_use_npu: false
p2p_pull_mode: true
p2p_delay_pull: false
p2p_npu_buffer_size: 134217728

enable_controller: true
lmcache_instance_id: "lmcache_colocated_b"
controller_pull_url: "10.0.130.70:9800"
controller_reply_url: "10.0.130.70:9900"
lmcache_worker_ports: [8600, 8601, 8602, 8603, 8604, 8605, 8606, 8607]

extra_config:
  save_only_first_rank: true
  use_host_staging: true
  os_staging_bytes: 8589934592
  lookup_backoff_time: 0.001
  first_rank_max_local_cpu_size: 150

### vllm-lmcache-1.sh ###
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0

NODE_IP="10.0.130.70"          # this node's internal IP
NIC_NAME="eth0"
MODEL_PATH="/data/models/DeepSeek-V4-Flash-0731-w8a8"
WORK_DIR="/data/yangfan/dsv4-lmcache"

export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD
export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
export HCCL_BUFFSIZE=1024
export HCCL_OP_EXPANSION_MODE=AIV
export TASK_QUEUE_ENABLE=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
export VLLM_ENABLE_V1_MULTIPROCESSING=1
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTHONHASHSEED=0
export LMCACHE_TRACK_USAGE=false
export GLOO_SOCKET_IFNAME=$NIC_NAME
export TP_SOCKET_IFNAME=$NIC_NAME
export HCCL_SOCKET_IFNAME=$NIC_NAME
export HCCL_IF_IP=$NODE_IP
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export LMCACHE_CONFIG_FILE="${WORK_DIR}/lmcache-p2p-a.yaml"


mkdir -p "${WORK_DIR}/logs"

export VLLM_RPC_TIMEOUT=3600000
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000

# LMCache controller (Node A only)
nohup lmcache_controller \
    --host 0.0.0.0 \
    --port 9000 \
    --monitor-ports '{"pull": 9800, "reply": 9900}' \
    > "${WORK_DIR}/logs/controller.log" 2>&1 &
sleep 2

nohup vllm serve "$MODEL_PATH" \
    --host 0.0.0.0 \
    --port 8010 \
    --served-model-name dsv4 \
    --max-model-len 262144 \
    --max-num-batched-tokens 8192 \
    --max-num-seqs 60 \
    --data-parallel-size 1 \
    --tensor-parallel-size 8 \
    --enable-expert-parallel \
    --enable-prefix-caching \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 128}' \
    --quantization ascend \
    --speculative-config '{"num_speculative_tokens": 3, "method": "dspark"}' \
    --gpu-memory-utilization 0.85 \
    --block-size 128 \
    --no-disable-hybrid-kv-cache-manager \
    --enable-auto-tool-choice \
    --async-scheduling \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
    --additional-config '{"enable_cpu_binding":true,"multistream_overlap_shared_expert":false}' \
    --kv-transfer-config '{"kv_connector":"LMCacheAscendConnector","kv_role":"kv_both","kv_connector_module_path":"lmcache_ascend.integration.vllm.lmcache_ascend_connector","kv_connector_extra_config":{"discard_partial_chunks":true}}' \
    > "${WORK_DIR}/logs/instance_a.log" 2>&1 &

### vllm-lmcache-2.sh ###
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0

NODE_IP="10.0.130.70"          # this node's internal IP
NIC_NAME="eth0"
MODEL_PATH="/data/models/DeepSeek-V4-Flash-0731-w8a8"
WORK_DIR="/data/yangfan/dsv4-lmcache"

export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD
export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
export HCCL_BUFFSIZE=1024
export HCCL_OP_EXPANSION_MODE=AIV
export TASK_QUEUE_ENABLE=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
export VLLM_ENABLE_V1_MULTIPROCESSING=1
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTHONHASHSEED=0
export LMCACHE_TRACK_USAGE=false
export GLOO_SOCKET_IFNAME=$NIC_NAME
export TP_SOCKET_IFNAME=$NIC_NAME
export HCCL_SOCKET_IFNAME=$NIC_NAME
export HCCL_IF_IP=$NODE_IP
export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
export LMCACHE_CONFIG_FILE="${WORK_DIR}/lmcache-p2p-b.yaml"

mkdir -p "${WORK_DIR}/logs"

export VLLM_RPC_TIMEOUT=3600000
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000

nohup vllm serve "$MODEL_PATH" \
    --host 0.0.0.0 \
    --port 8011 \
    --served-model-name dsv4 \
    --max-model-len 262144 \
    --max-num-batched-tokens 8192 \
    --max-num-seqs 60 \
    --seed 1024 \
    --data-parallel-size 1 \
    --tensor-parallel-size 8 \
    --enable-expert-parallel \
    --enable-prefix-caching \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --enable-auto-tool-choice \
    --reasoning-parser deepseek_v4 \
    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 128}' \
    --quantization ascend \
    --speculative-config '{"num_speculative_tokens": 3, "method": "dspark"}' \
    --gpu-memory-utilization 0.85 \
    --block-size 128 \
    --no-disable-hybrid-kv-cache-manager \
    --enable-auto-tool-choice \
    --async-scheduling \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
    --additional-config '{"enable_cpu_binding":true,"multistream_overlap_shared_expert":false}' \
    --kv-transfer-config '{"kv_connector":"LMCacheAscendConnector","kv_role":"kv_both","kv_connector_module_path":"lmcache_ascend.integration.vllm.lmcache_ascend_connector","kv_connector_extra_config":{"discard_partial_chunks":true}}' \
    > "${WORK_DIR}/logs/instance_b.log" 2>&1 &
```