### PR TITLE
[Feature] Add HCCS disaggregated prefill example with 2MB-aligned PD NPU buffer

### DIFF
--- a/examples/disagg_prefill/hccs/README.md
+++ b/examples/disagg_prefill/hccs/README.md
@@ -1,0 +1,147 @@
+## Example of Disaggregated Prefill over HCCS (No RoCE)
+
+This example demonstrates how to run LMCache with disaggregated prefill on a single node **without RoCE**, using the on-chip **HCCS** interconnect instead. It is a TP=1 variant of the [`1p1d`](../1p1d) example.
+
+> Note: for multi-nodes setting, replace the localhost with ip addresses accordingly.
+
+### Differences from the `1p1d` example
+
+| Item | `1p1d` | This example (HCCS) |
+| :--- | :--- | :--- |
+| Transfer channel | `hcomm_onesided` (default) | `hixl` |
+| Network | RoCE (required) | HCCS only — no RoCE NIC needed |
+| Key environment variables | — | `HCCL_INTRA_ROCE_ENABLE=0`, `HCCL_INTRA_PCIE_ENABLE=0` |
+| TP size | 2 | 1 |
+| Peer ports | `[7300, 7301]` / `[7400, 7401]` | `[7300]` / `[7400]` |
+
+### Prerequisites
+
+- CANN 8.5+ (for the `hixl` channel)
+- Ascend HDK 25.5.0+ drivers and firmware
+- At least 2 NPUs connected over HCCS
+- The following patches from `docker/` must be applied before use:
+  - `docker/vllm-utils.diff` to vLLM
+  - `docker/vllm-sched.diff` to vLLM-Ascend
+
+> After applying patches, reinstall the affected packages (vLLM, vLLM-Ascend, LMCache, LMCache-Ascend) for the changes to take effect.
+
+### HCCS Environment Variables
+
+HCCL must be told to use the on-chip HCCS fabric instead of RoCE/PCIe. Export these in **both** the prefill and decode processes:
+
+```bash
+export HCCL_INTRA_ROCE_ENABLE=0
+export HCCL_INTRA_PCIE_ENABLE=0
+```
+
+> **Important:** `HCCL_INTRA_PCIE_ENABLE` must be set explicitly. Setting only `HCCL_INTRA_ROCE_ENABLE=0` (or leaving the PCIe variable empty) raises HCCL error 103900 during connection setup.
+
+### Transfer Channel Configuration
+
+Use the `hixl` transfer channel in both `configs/lmcache-prefiller-config.yaml` and `configs/lmcache-decoder-config.yaml`:
+
+```yaml
+transfer_channel: "hixl"
+```
+
+### Buffer Size
+
+The `pd_buffer_size` field must be:
+
+1. **Identical on the sender and the decoder** (the decoder reads into a buffer of this size that the sender also allocates).
+2. A **multiple of the KV page size** — the paged allocator requires `buffer_size % align_bytes == 0`.
+
+The provided configs use `pd_buffer_size: 2415919104` (= 64 pages x 36 MB), aligned with the KV page shape `[2, 36, 256, 1024]` in fp16 for a Qwen3-8B class model with `--block-size 128`. Adjust it proportionally for other model/token budgets.
+
+> **Note:** HCCS transport also requires the KV transfer buffer VA to be 2 MB aligned. This is guaranteed by the PD backend's aligned NPU buffer allocation (see `lmcache_ascend/v1/storage_backend/pd/backend.py`), which is included in the same change set as this example. Without it, HCCL fails to register the buffer (errors 503900 / 507899 / error 15).
+
+### Usage
+
+All values are configurable via environment variables. Equivalent inline commands are shown below.
+
+Launch prefill (sender):
+
+```bash
+export MODEL=/path/to/model
+export LMCACHE_CONFIG_FILE=/workspace/LMCache-Ascend/examples/disagg_prefill/hccs/configs/lmcache-prefiller-config.yaml
+export ASCEND_RT_VISIBLE_DEVICES=2
+export ASCEND_VISIBLE_DEVICES=2
+export VLLM_ENABLE_V1_MULTIPROCESSING=1
+export VLLM_WORKER_MULTIPROC_METHOD=fork
+export PYTHONHASHSEED=0
+export HCCL_INTRA_ROCE_ENABLE=0
+export HCCL_INTRA_PCIE_ENABLE=0
+python \
+    -m vllm.entrypoints.openai.api_server \
+    --port 8001 \
+    --model $MODEL \
+    --enforce-eager \
+    --no-enable-prefix-caching \
+    --tensor-parallel-size 1 \
+    --trust-remote-code \
+    --block-size 128 \
+    --max-model-len 32768 \
+    --kv-transfer-config '{"kv_connector":"LMCacheAscendConnector","kv_role":"kv_producer", "kv_connector_module_path":"lmcache_ascend.integration.vllm.lmcache_ascend_connector_v1","kv_connector_extra_config": {"discard_partial_chunks": false, "lmcache_rpc_port": "producer1"}}' > prefill.txt 2>&1
+```
+
+Launch decode (receiver):
+
+```bash
+export MODEL=/path/to/model
+export LMCACHE_CONFIG_FILE=/workspace/LMCache-Ascend/examples/disagg_prefill/hccs/configs/lmcache-decoder-config.yaml
+export ASCEND_RT_VISIBLE_DEVICES=3
+export ASCEND_VISIBLE_DEVICES=3
+export VLLM_ENABLE_V1_MULTIPROCESSING=1
+export VLLM_WORKER_MULTIPROC_METHOD=fork
+export PYTHONHASHSEED=0
+export HCCL_INTRA_ROCE_ENABLE=0
+export HCCL_INTRA_PCIE_ENABLE=0
+python \
+    -m vllm.entrypoints.openai.api_server \
+    --port 8002 \
+    --model $MODEL \
+    --enforce-eager \
+    --no-enable-prefix-caching \
+    --tensor-parallel-size 1 \
+    --trust-remote-code \
+    --block-size 128 \
+    --max-model-len 32768 \
+    --kv-transfer-config '{"kv_connector":"LMCacheAscendConnector","kv_role":"kv_consumer", "kv_connector_module_path":"lmcache_ascend.integration.vllm.lmcache_ascend_connector_v1","kv_connector_extra_config": {"discard_partial_chunks": false, "lmcache_rpc_port": "consumer1", "skip_last_n_tokens": 1}}' > decode.txt 2>&1
+```
+
+Launch the proxy server to coordinate prefill and decode:
+
+```bash
+python3 /workspace/LMCache/examples/disagg_prefill/disagg_proxy_server.py \
+  --host localhost \
+  --port 9100 \
+  --prefiller-host localhost \
+  --prefiller-port 8001 \
+  --num-prefillers 1 \
+  --decoder-host localhost \
+  --decoder-port 8002 \
+  --decoder-init-port "7300" \
+  --decoder-alloc-port "7400" \
+  --proxy-host localhost \
+  --proxy-port 7500 \
+  --num-decoders 1 \
+  --model $MODEL
+```
+
+Send a request through the proxy:
+
+```bash
+curl -X POST http://localhost:9100/v1/completions \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"/path/to/model\",
+    \"prompt\": \"$(printf 'Explain the significance of KV cache in language models in English.%.0s' {1..100})\",
+    \"max_tokens\": 100
+  }"
+```
+
+### Notes
+
+1. **Single peer ports for TP=1.** The proxy derives the expected number of TP ranks from the port list length (`num_tp_rank = len(init_port)`). With TP=1 the ports must be single-element lists (`"7300"` / `"7400"`); using two ports makes the proxy wait for responses that never arrive.
+2. **Restart all three processes after changing any port.** The HIXL peer ids / handshake state are derived from the ports; a partial restart leaves stale peer registrations.
+3. Official prerequisites (CANN 8.5+, HDK 25.5.0+, docker patches) still apply.

--- a/examples/disagg_prefill/hccs/configs/lmcache-decoder-config.yaml
+++ b/examples/disagg_prefill/hccs/configs/lmcache-decoder-config.yaml
@@ -1,0 +1,16 @@
+local_cpu: False # Enable local CPU RAM cache for fast access
+
+enable_pd: True
+transfer_channel: "hixl"
+pd_role: "receiver"
+pd_peer_host: "localhost" # replace with the host ip
+pd_pull_mode: False
+pd_delay_pull: False # Enable delayed pulling of data from the peer
+pd_peer_init_port: [7300] # Need to have 1 for each TP instance (TP=1 here)
+pd_peer_alloc_port: [7400] # Need to have 1 for each TP instance (TP=1 here)
+pd_buffer_size: 2415919104 # Transfer buffer size in bytes — must match sender.
+                           # = 64 pages x 36 MB, aligned with the KV page
+                           # [2, 36, 256, 1024] fp16. HCCS requires the VA to be
+                           # 2 MB aligned, and pd_buffer_size must be a multiple
+                           # of the KV page size.
+pd_buffer_device: "npu" # Use npu memory for buffering

--- a/examples/disagg_prefill/hccs/configs/lmcache-prefiller-config.yaml
+++ b/examples/disagg_prefill/hccs/configs/lmcache-prefiller-config.yaml
@@ -1,0 +1,22 @@
+local_cpu: False # Enable local CPU RAM cache for fast access
+
+enable_pd: True
+transfer_channel: "hixl"
+pd_role: "sender"
+pd_pull_mode: False
+pd_delay_pull: False
+pd_pull_done_port: [7600] # per TP instance (TP=1 here; only used in pull mode)
+pd_use_cpu_offload: False
+pd_cpu_buffer_size: 21474836480 # 20GB — inert unless pd_use_cpu_offload=True
+pd_peer_host: "localhost" # replace with the host ip
+pd_proxy_host: "localhost" # replace with the proxy ip
+pd_proxy_port: 7500 # replace with the proxy port
+pd_buffer_size: 2415919104 # Transfer buffer size in bytes — must match decoder.
+                           # = 64 pages x 36 MB, aligned with the KV page
+                           # [2, 36, 256, 1024] fp16.
+pd_buffer_device: "npu" # Use NPU memory for buffer
+
+# For LMCache 0.3.12, we see that for small prompt
+# prefill would not send the unfull chunk to the decoder.
+# setting this to true will ensure the pd transfer occurs even for small prompts.
+save_unfull_chunk: True # Save unfull chunk to disk

--- a/lmcache_ascend/v1/storage_backend/pd/backend.py
+++ b/lmcache_ascend/v1/storage_backend/pd/backend.py
@@ -20,6 +20,7 @@ from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
     PagedCpuGpuMemoryAllocator,
+    PagedTensorMemoryAllocator,
 )
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc_utils import get_zmq_context
@@ -133,6 +134,9 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
         buffer_type = []
         align_bytes = []
         if self.pd_config.buffer_device.startswith("npu"):
+            # Note: torch.split() may return copies for non-contiguous tensors,
+            # causing allocated addresses to exceed the original buffer range.
+            # The actual buffer info comes from memory_allocator.gpu_allocator.
             buffer_ptr.append(self.memory_allocator.gpu_allocator.buffer_ptr)
             buffer_size.append(self.memory_allocator.gpu_allocator.buffer_size)
             buffer_type.append("npu")
@@ -197,12 +201,41 @@ class AscendPDBackend(AscendPDSenderMixin, AscendPDReceiverMixin, PDBackend):
             npu_aligned_byte = (
                 (config.pd_buffer_size + total_size - 1) // total_size * total_size
             )
-            paged_mem_allocator.init_gpu_memory_allocator(
-                npu_aligned_byte, sizes, dtypes, fmt, npu_corrected_device
+            npu_aligned_byte = int(npu_aligned_byte)
+            # Allocate extra 2MB to guarantee we can find a 2MB-aligned sub-buffer.
+            # torch.empty() may return a pointer that is not 2MB-aligned, which
+            # causes HCCL/HIXL registration to fail.
+            total_alloc_size = npu_aligned_byte + 2 * 1024 * 1024
+            raw_buf = torch.empty(
+                total_alloc_size,
+                dtype=torch.uint8,
+                device=npu_corrected_device,
             )
+            raw_addr = raw_buf.data_ptr()
+            # Round up to 2MB alignment boundary (0x200000)
+            aligned_addr = (raw_addr + (2 * 1024 * 1024) - 1) & ~((2 * 1024 * 1024) - 1)
+            offset = aligned_addr - raw_addr
+            # Use view (not clone) to avoid memory duplication
+            aligned_buf = raw_buf[offset : offset + npu_aligned_byte]
+            # NOTE: We deliberately do NOT call init_gpu_memory_allocator()
+            # here. That method internally creates its own (unaligned) tensor
+            # via torch.empty() and builds PagedTensorMemoryAllocator from it.
+            # Overriding buffer_ptr afterwards leaves free_blocks pointing at
+            # the unaligned internal buffer; worse, free_blocks.clear() fires
+            # TensorMemoryObj.__del__ on the stale objects, which re-appends
+            # them to the deque via parent_allocator.free(), polluting the pool
+            # with addresses outside the registered RDMA range. Construct the
+            # allocator directly from our 2MB-aligned buffer so that buffer,
+            # paged_buffers and free_blocks are all consistent.
+            paged_mem_allocator.gpu_allocator = PagedTensorMemoryAllocator(
+                aligned_buf, sizes, dtypes, fmt
+            )
+            # Keep raw_buf alive (may be needed for hugepage)
+            paged_mem_allocator._npu_raw_buf = raw_buf
             logger.info(
-                "Initialized NPU allocator: %.2f MB",
-                npu_aligned_byte / (1024 * 1024),
+                "Initialized NPU allocator: %.2f MB (aligned base: 0x%x)",
+                aligned_buf.numel() / (1024 * 1024),
+                aligned_addr,
             )
 
         if self.pd_config.buffer_device == "cpu" or self.use_cpu_offload:


### PR DESCRIPTION
## Summary

- Add `examples/disagg_prefill/hccs`, a TP=1 disaggregated-prefill example that transfers KV cache over HCCS without requiring RoCE.
- Use the `hixl` transfer channel with the required HCCS environment variables.
- Align the PD NPU transfer-buffer base address to a 2 MiB boundary.

## Motivation

HCCL/HIXL requires the registered NPU transfer-buffer virtual address to be 2 MiB aligned. A buffer returned directly by `torch.empty()` is not guaranteed to satisfy that requirement, which can cause HCCL/HIXL registration failures such as errors 503900 and 507899.

## Implementation

The PD backend now:

1. Rounds `pd_buffer_size` up to a whole number of KV pages.
2. Allocates an additional 2 MiB of NPU memory.
3. Selects a 2 MiB-aligned view from that allocation.
4. Constructs `PagedTensorMemoryAllocator` directly from the aligned view so that the registered buffer, paged buffers, and free-block addresses remain consistent.
5. Keeps the original allocation alive for the lifetime of the allocator.

The example configures both prefill and decode processes with:

```bash
export HCCL_INTRA_ROCE_ENABLE=0
export HCCL_INTRA_PCIE_ENABLE=0
```

and:

```yaml
transfer_channel: "hixl"
pd_buffer_device: "npu"
```

The sender and receiver use the same page-aligned `pd_buffer_size`.

## Files changed

- `examples/disagg_prefill/hccs/README.md`
- `examples/disagg_prefill/hccs/configs/lmcache-prefiller-config.yaml`
- `examples/disagg_prefill/hccs/configs/lmcache-decoder-config.yaml`
- `lmcache_ascend/v1/storage_backend/pd/backend.py`

## Validation

- The branch is rebased onto the latest `main`.
- Code Quality is triggered automatically for the updated commit.
- HCCS/910B/910C hardware validation can be run through the repository's self-hosted CI before merge.